### PR TITLE
Rename "GRASS GIS" to "GRASS" at top level, manual generation, Dockerfiles, scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ docker
 # Do not copy files from previous compilations
 dist.*
 
-# The following git files are needed by GRASS GIS to extract the revision
+# The following git files are needed by GRASS to extract the revision
 # during compilation. If you are not using one of the Dockerimages from this
 # repository, delete the .git folder in your Dockerfile after compilation.
 .git

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,10 +28,10 @@ assignees: ''
 ## System description
 <!--
 - Operating System: [e.g. Windows, Linux, ..., incl. version]
-- GRASS GIS version: [e.g. 4.0]
+- GRASS version: [e.g. 4.0]
 
 - details about further software components
-    - run `g.version -rge` in a GRASS GIS terminal session or check in
+    - run `g.version -rge` in a GRASS terminal session or check in
       the GUI menu "Help > About"
     - run `python3 -c "import sys, wx; print(sys.version); print(wx.version())"`
       to print the Python and wxPython version numbers

--- a/.github/workflows/build_osgeo4w.sh
+++ b/.github/workflows/build_osgeo4w.sh
@@ -4,7 +4,7 @@
 #
 # By default, the script will look for the source code in the current directory
 # and create bin.x86_64-w64-mingw32\grass$ver.bat (run this batch file to start
-# GRASS GIS) and dist.x86_64-w64-mingw32\etc\env.bat.
+# GRASS) and dist.x86_64-w64-mingw32\etc\env.bat.
 #
 # path	specify a path to the source code
 #

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -76,7 +76,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
-          name: GRASS GIS ${{ github.ref_name }}
+          name: GRASS ${{ github.ref_name }}
           body: |
             Overview of changes
             - First change

--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -119,7 +119,7 @@ jobs:
           echo cs_keychain_profile=\"${KEYCHAIN_PROFILE}\" >> ${{ env.Config }}
           echo cs_provisionprofile=\"${RUNNER_TEMP}/embedded.provisionprofile\" >> ${{ env.Config }}
 
-      - name: Build GRASS GIS app
+      - name: Build GRASS app
         run: |
           ./macos/build_grass_app.bash --with-liblas --notarize -o "${{ runner.temp }}"
 

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -101,7 +101,7 @@ jobs:
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
         shell: msys2 {0}
 
-      - name: Compile GRASS GIS
+      - name: Compile GRASS
         shell: msys2 {0}
         run: |
           .github/workflows/build_osgeo4w.sh

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
-GRASS GIS List of Authors
+GRASS List of Authors
 =========================
 
-Many people have contributed to GRASS GIS. Without any one of them the
+Many people have contributed to GRASS. Without any one of them the
 project would not exist in its current form.
 
 The authors of the individual programs are listed at the end of their

--- a/COPYING
+++ b/COPYING
@@ -26,7 +26,7 @@ along with this program; if not, write to the
   51 Franklin Street, Fifth Floor
   Boston, MA 02110-1301 USA
 
-Questions regarding GRASS GIS should be directed to the
+Questions regarding GRASS should be directed to the
 GRASS Development Team at the following address:
 
  GRASS Development Team

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,8 +269,8 @@ COPY . /src/grass_build/
 
 WORKDIR /src/grass_build
 
-# Set environmental variables for GRASS GIS compilation, without debug symbols
-# Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
+# Set environmental variables for GRASS compilation, without debug symbols
+# Set gcc/g++ environmental variables for GRASS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99"
 ENV MYLDFLAGS="-s"
 # CXX stuff:
@@ -279,7 +279,7 @@ ENV LDFLAGS="$MYLDFLAGS"
 ENV CFLAGS="$MYCFLAGS"
 ENV CXXFLAGS="$MYCXXFLAGS"
 
-# Configure compile and install GRASS GIS
+# Configure compile and install GRASS
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN ./configure $GRASS_CONFIG \
@@ -307,7 +307,7 @@ RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gd
 # Leave build stage
 FROM grass_gis AS grass_gis_final
 
-# GRASS GIS specific
+# GRASS specific
 # allow work with MAPSETs that are not owned by current user
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     SHELL="/bin/bash" \
@@ -318,27 +318,27 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH" \
     GDAL_DRIVER_PATH="/usr/lib/gdalplugins"
 
-# Copy GRASS GIS from build image
+# Copy GRASS from build image
 COPY --link --from=build /usr/local/bin/* /usr/local/bin/
 COPY --link --from=build /usr/local/grass85 /usr/local/grass85/
 COPY --link --from=build /src/site-packages /usr/lib/python3.10/
 COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 # COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
 
-# Create generic GRASS GIS lib name regardless of version number
+# Create generic GRASS lib name regardless of version number
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
-# show GRASS GIS, PROJ, GDAL etc versions
+# show GRASS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
 
 WORKDIR /scripts
 
-# enable GRASS GIS Python session support
+# enable GRASS Python session support
 ## grass --config python-path
 ENV PYTHONPATH="/usr/local/grass/etc/python:${PYTHONPATH}"
-# enable GRASS GIS ctypes imports
+# enable GRASS ctypes imports
 ## grass --config path
 ENV LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
@@ -346,7 +346,7 @@ WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## run GRASS GIS python session and scan the test LAZ file
+## run GRASS python session and scan the test LAZ file
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Install GRASS GIS from source code
+# Install GRASS from source code
 
 Please read _all_ text below.
 
@@ -16,7 +16,7 @@ Please read _all_ text below.
 - (I) CODE OPTIMIZATION
 - (J) DEBUGGING OPTIONS
 - (K) SUPPORT
-- (L) GRASS GIS PROGRAMMER'S MANUAL
+- (L) GRASS PROGRAMMER'S MANUAL
 - (M) CONTRIBUTING CODE AND PATCHES
 
 ## PREREQUISITES
@@ -31,7 +31,7 @@ Installation order:
 1. PROJ
 2. GDAL/OGR (compiled without GRASS support)
 3. optionally: databases such as PostgreSQL, MySQL, SQLite
-4. GRASS GIS
+4. GRASS
 5. optionally: GDAL-OGR-GRASS plugin
 
 ## (A) SOURCE CODE DISTRIBUTION
@@ -139,7 +139,7 @@ To successfully compile GRASS on 64bit platforms, the required
 FFTW library has to be compiled with `-fPIC` flag:
 
 ```bash
-#this applies to FFTW3, not to GRASS GIS:
+#this applies to FFTW3, not to GRASS:
 cd fftw-3.3.4/
 CFLAGS="-fPIC" ./configure
 make
@@ -177,13 +177,13 @@ grass
 
 See the `ReadMe.rtf` in the `./macosx/` folder and the Wiki page above.
 
-## (F) RUNNING GRASS GIS
+## (F) RUNNING GRASS
 
 Download a sample data package from the GRASS web site, see
 <https://grass.osgeo.org/download/sample-data/>
 
 Extract the data set and point the "Database" field in the
-GRASS GIS startup menu to the extracted directory.
+GRASS startup menu to the extracted directory.
 
 Enjoy.
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ FILES = AUTHORS CITING COPYING GPL.TXT INSTALL.md REQUIREMENTS.md contributors.c
 FILES_DST = $(patsubst %,$(ARCH_DISTDIR)/%,$(FILES))
 
 default:
-	@echo "GRASS GIS $(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR).$(GRASS_VERSION_RELEASE) $(GRASS_VERSION_GIT) compilation log" \
+	@echo "GRASS $(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR).$(GRASS_VERSION_RELEASE) $(GRASS_VERSION_GIT) compilation log" \
 		> $(ERRORLOG)
 	@echo "--------------------------------------------------" >> $(ERRORLOG)
 	@echo "Started compilation: `date`"                        >> $(ERRORLOG)

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-# Requirements to compile GRASS GIS 8
+# Requirements to compile GRASS 8
 
 A workstation running some flavor of UNIX including
 GNU/Linux, Solaris, IRIX, BSD, Mac OSX, Cygwin or MinGW (on Win32/Win64).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
-# GRASS GIS Security Policy
+# GRASS Security Policy
 
 ## Reporting a Vulnerability
 
-At GRASS GIS, we take security vulnerabilities seriously. We appreciate your
+At GRASS, we take security vulnerabilities seriously. We appreciate your
 efforts in responsibly disclosing any issues you may find. To report a security
 vulnerability, please follow these steps:
 
@@ -39,8 +39,8 @@ for details on which versions are currently supported.
 
 ## Vulnerability Scope
 
-Our security policy covers vulnerabilities in the GRASS GIS core codebase,
-official addons, and any official distributions provided by the GRASS GIS team.
+Our security policy covers vulnerabilities in the GRASS core codebase,
+official addons, and any official distributions provided by the GRASS team.
 
 While packages in Linux and other unix-like distributions are out of scope of
 this document, distribution maintainers traditionally do a great job in patching
@@ -55,4 +55,4 @@ in allowing us time to address any reported vulnerabilities before disclosing
 them publicly. We ask that you refrain from disclosing any details of the
 vulnerability until we have had adequate time to provide a fix.
 
-Thank you for helping to keep GRASS GIS secure!
+Thank you for helping to keep GRASS secure!

--- a/binaryInstall.src
+++ b/binaryInstall.src
@@ -40,7 +40,7 @@ fi
 if [ $# -lt 1 -o "$1" = "-h" -o "$1" = "-help" -o "$1" = "--help"  ] ; then
     echo "
 
-GRASS GIS $NAME_VER binary package installation tool
+GRASS $NAME_VER binary package installation tool
 
 Usage:	grass-$NAME_VER-install.sh grass-$NAME_VER.tar.gz [dest_dir] [bin_dir]
 
@@ -71,7 +71,7 @@ fi
 
 # Print out script identification message
 echo ""
-echo "GRASS GIS $NAME_VER binary package installation tool"
+echo "GRASS $NAME_VER binary package installation tool"
 echo ""
 
 # Check for correct package name:
@@ -338,11 +338,11 @@ cat ${DESTDIR}/include/Make/Platform.make.orig | \
 echo "Installation finished. Start GRASS $NAME_VER with"
 echo "    $BINDIR/grass-$NAME_VER"
 echo ""
-#echo "The graphical user interface can be started within GRASS GIS."
+#echo "The graphical user interface can be started within GRASS."
 #echo ""
 #echo "You can uninstall grass by typing"
 #echo "    sh $UNINSTALL"
 #echo "in the directory $BINDIR"
 echo ""
-echo "Welcome to GRASS GIS. Enjoy this open source GRASS GIS!"
+echo "Welcome to GRASS. Enjoy this open source GRASS GIS!"
 echo ""

--- a/configure
+++ b/configure
@@ -5010,8 +5010,8 @@ then :
 
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GRASS GIS headers commit date" >&5
-printf %s "checking for GRASS GIS headers commit date... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GRASS headers commit date" >&5
+printf %s "checking for GRASS headers commit date... " >&6; }
 if test "$GIT" != "no" ; then
    GRASS_VERSION_GIT=`$GIT rev-parse --short HEAD 2>/dev/null`
    if test -z "$GRASS_VERSION_GIT"; then

--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
 GRASS_HEADERS_GIT_DATE=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
 AC_PATH_PROG(GIT, git, no)
 AC_CHECK_FILE([$GRASS_VERSION_GIT_FILE])
-AC_MSG_CHECKING(for GRASS GIS headers commit date)
+AC_MSG_CHECKING(for GRASS headers commit date)
 if test "$GIT" != "no" ; then
    GRASS_VERSION_GIT=`$GIT rev-parse --short HEAD 2>/dev/null`
    if test -z "$GRASS_VERSION_GIT"; then

--- a/db/databaseintro.md
+++ b/db/databaseintro.md
@@ -1,9 +1,9 @@
 ---
-description: Database management in GRASS GIS
+description: Database management in GRASS
 index: database
 ---
 
-# Database management in GRASS GIS
+# Database management in GRASS
 
 ## Attribute management in general
 

--- a/doc/grass_database.html
+++ b/doc/grass_database.html
@@ -1,7 +1,7 @@
-<!-- meta page description: GRASS GIS Database -->
+<!-- meta page description: GRASS Database -->
 
-A GRASS GIS Database is simply a set of directories and files
-with certain structure which GRASS GIS works efficiently with.
+A GRASS Database is simply a set of directories and files
+with certain structure which GRASS works efficiently with.
 Project is a directory with data related to
 one geographic location or a project.
 All data within one project has the same coordinate reference system.
@@ -12,14 +12,14 @@ which can contain commonly used data within one GRASS project
 such as base maps.
 The PERMANENT mapset also contains metadata related to the project
 such as the coordinate reference system.
-When GRASS GIS is started it connects to a database, project and mapset
+When GRASS is started it connects to a database, project and mapset
 specified by the user.
 
 <p>
 <!-- original drawing: doc/grass_database.svg -->
 <center>
   <img src="grass_database.png" alt="example: nc_spm - highway - elevation"><br>
-  <i>Fig. 1: GRASS GIS Database structure as visible to the user</i>
+  <i>Fig. 1: GRASS Database structure as visible to the user</i>
 </center>
 
 <!--
@@ -32,9 +32,9 @@ In geospatial analysis often involves combining data from various sources
 multiple users
 -->
 
-<h3>GRASS GIS Database</h3>
+<h3>GRASS Database</h3>
 
-All data for GRASS GIS must be in GRASS GIS Database which is a directory
+All data for GRASS must be in GRASS Database which is a directory
 (visible on the disk) containing subdirectories which are GRASS projects.
 User can have one or more of Databases on the disk. Typically users have
 one directory called <code>grassdata</code> in their home directory.
@@ -45,13 +45,13 @@ in a shared network file system (e.g. NFS).
 <!-- TODO: above needs some fixes -->
 
 <p>
-GRASS GIS Databases can be safely copied or moved as any other directories.
-Don't be confused with (relational) databases which are used in GRASS GIS
-to hold attribute data and might be part of the GRASS GIS Database.
-From user point of view, GRASS GIS Database with all its data in it
+GRASS Databases can be safely copied or moved as any other directories.
+Don't be confused with (relational) databases which are used in GRASS
+to hold attribute data and might be part of the GRASS Database.
+From user point of view, GRASS Database with all its data in it
 is similar to, e.g. PostGIS, database, as it stores all information
 inside in a specific format and is accessible by specific tools.
-GRASS GIS Databases is in GRASS GIS often called GISDBASE or DATABASE.
+GRASS Databases is in GRASS often called GISDBASE or DATABASE.
 
 <h3>GRASS Projects</h3>
 
@@ -76,7 +76,7 @@ this name has not been completely removed from code and documentation yet.
 
 <p>
 Users and programmers familiar with relational databases such as PostgreSQL
-can view projects as individual databases inside a storage area (the GRASS GIS Database).
+can view projects as individual databases inside a storage area (the GRASS Database).
 Mapsets in a project are like namespaces or schemas inside a database.
 
 <!-- TODO: naming limitations and best practices -->
@@ -84,13 +84,13 @@ Mapsets in a project are like namespaces or schemas inside a database.
 <h3>GRASS Mapsets</h3>
 
 Mapsets contains the actual data, mostly geospatial data,
-referred to as maps in GRASS GIS.
+referred to as maps in GRASS.
 Mapsets are a tool for organizing maps in a transparent way
 as well as a tool for isolating different tasks to prevent data loss.
 
 <p>
-GRASS GIS is always connected to one particular mapset.
-GRASS GIS modules can create, modify, change, or delete a data only in
+GRASS is always connected to one particular mapset.
+GRASS modules can create, modify, change, or delete a data only in
 the current mapset.
 By default, only the data from the current mapset and PERMANENT mapset
 are visible. Using
@@ -131,11 +131,11 @@ match. In case of data coming with different coordinate reference systems,
 it is recommended to use <a href="r.proj.html"><em>r.proj</em></a>
 or <a href="v.proj.html"><em>v.proj</em></a> to reproject the data.
 The files and directories should not be moved or modified directly,
-but only using GRASS GIS tools.
+but only using GRASS tools.
 
 <h3>The role of the PERMANENT Mapset</h3>
 
-When creating a new project, GRASS GIS automatically creates a special
+When creating a new project, GRASS automatically creates a special
 mapset called PERMANENT where the core data for the project are stored.
 
 <p>
@@ -161,7 +161,7 @@ Users have the option of switching back to the default region at any time.
 
 <h3>Importing, exporting and linking data</h3>
 
-GRASS GIS works only with data which are imported into a GRASS Database,
+GRASS works only with data which are imported into a GRASS Database,
 so all data needs to be imported, e.g. by
 <a href="r.in.gdal.html"><em>r.in.gdal</em></a> or
 highly convenient <a href="r.import.html"><em>r.import</em></a>,
@@ -185,18 +185,18 @@ as standard raster maps. Similarly for newly created maps,
 setups a format and directory where the actual data will be stored,
 however in GRASS Database the data will be created as standard maps.
 
-<h3>Starting GRASS GIS</h3>
+<h3>Starting GRASS</h3>
 
-After launching GRASS GIS for the first time,
+After launching GRASS for the first time,
 the GUI opens in a default project <code>world_latlong_wgs84</code>.
 From there a new project can be created.
 
 <p>
 <center>
-  <img src="grass_start.png" alt="GRASS GIS GUI after first start"><br>
+  <img src="grass_start.png" alt="GRASS GUI after first start"><br>
 </center>
 
-GRASS GIS can be also started with a given database, project and mapset
+GRASS can be also started with a given database, project and mapset
 from the command line. For example, the following will start
 in a given mapset with only command line interface:
 
@@ -261,9 +261,9 @@ the <em>File</em> menu in <em>Layer Manager</em> or
 <h2>See also</h2>
 
 <em>
-<a href="index.html">GRASS GIS Reference Manual</a>
+<a href="index.html">GRASS Reference Manual</a>
 <br>
-<a href="grass.html">GRASS GIS startup program manual page</a>
+<a href="grass.html">GRASS startup program manual page</a>
 <br>
 <a href="https://grasswiki.osgeo.org/wiki/Importing_data">Importing data on GRASS Wiki</a>
 <br>

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -108,7 +108,7 @@ ENV GRASS_CONFIG="\
       --without-opengl \
       "
 
-# Set environmental variables for GRASS GIS compilation, without debug symbols
+# Set environmental variables for GRASS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
     MYLDFLAGS="-s -Wl,--no-undefined -lblas" \
     # CXX stuff:
@@ -118,7 +118,7 @@ ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
     CXXFLAGS="$MYCXXFLAGS" \
     NUMTHREADS=2
 
-# These packages are required to compile GRASS GIS.
+# These packages are required to compile GRASS.
 ENV GRASS_BUILD_PACKAGES="\
       build-base \
       bzip2-dev \
@@ -156,11 +156,11 @@ RUN echo "Install main packages";\
     apk add --no-cache --virtual .build-deps $GRASS_BUILD_PACKAGES
     # echo LANG="en_US.UTF-8" > /etc/default/locale;
 
-# Copy and install GRASS GIS
+# Copy and install GRASS
 COPY . /src/grass_build/
 WORKDIR /src/grass_build/
 
-# Configure compile and install GRASS GIS
+# Configure compile and install GRASS
 RUN echo "  => Configure and compile grass" && \
     /src/grass_build/configure $GRASS_CONFIG && \
     make -j $NUMTHREADS && \
@@ -191,7 +191,7 @@ RUN cp /usr/local/grass/gui/wxpython/xml/module_items.xml module_items.xml; \
 
 FROM common AS grass
 
-# GRASS GIS specific
+# GRASS specific
 # allow work with MAPSETs that are not owned by current user
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     SHELL="/bin/bash" \
@@ -200,7 +200,7 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8" \
     PYTHONPATH="/usr/local/grass/etc/python:$PYTHONPATH"
 
-# Copy GRASS GIS and GDAL GRASS driver from build image
+# Copy GRASS and GDAL GRASS driver from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
 COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
@@ -212,7 +212,7 @@ ENV GRASS_GISBASE=/usr/local/grass
 COPY docker/testdata/simple.laz /tmp/
 COPY docker/testdata/test_grass_python.py docker/testdata/test_grass_session.py docker/alpine/grass_tests.sh /scripts/
 
-# run GRASS GIS python session and scan the test LAZ file; some cleanup
+# run GRASS python session and scan the test LAZ file; some cleanup
 # also show installed version
 RUN ln -sf /usr/local/grass /usr/local/grass85; \
     rm -rf /tmp/grasstest_epsg_25832; \

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -1,7 +1,7 @@
-# Docker GRASS GIS (alpine linux)
+# Docker GRASS (alpine linux)
 
 Dockerfile with an [Alpine Linux](https://www.alpinelinux.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
+[GRASS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is only approximately 80 MB.
 

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -14,11 +14,11 @@ ogrinfo --formats | grep "GRASS Vectors" || echo "...failed"
 # Test PDAL
 grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
-# Test GRASS GIS Python-addon installation
+# Test GRASS Python-addon installation
 grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add && \
    grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=remove -f
 
-# Test GRASS GIS C-addon installation: raster and vector
+# Test GRASS C-addon installation: raster and vector
 grass --tmp-project XY --exec g.extension extension=r.gwr operation=add && \
    grass --tmp-project XY --exec g.extension extension=r.gwr operation=remove -f
 grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=add && \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -138,8 +138,8 @@ WORKDIR /src/grass_build
 # Cleanup potentially leftover GISRC file with wrong path to "demolocation"
 RUN rm -f /src/grass_build/dist.*/demolocation/.grassrc*
 
-# Set environmental variables for GRASS GIS compilation, without debug symbols
-# Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
+# Set environmental variables for GRASS compilation, without debug symbols
+# Set gcc/g++ environmental variables for GRASS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99 -m64"
 ENV MYLDFLAGS="-s"
 # CXX stuff:
@@ -148,7 +148,7 @@ ENV LDFLAGS="$MYLDFLAGS"
 ENV CFLAGS="$MYCFLAGS"
 ENV CXXFLAGS="$MYCXXFLAGS"
 
-# Configure compile and install GRASS GIS
+# Configure compile and install GRASS
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
@@ -183,7 +183,7 @@ ENV LDFLAGS=""
 ENV CFLAGS=""
 ENV CXXFLAGS=""
 
-# set SHELL var to avoid /bin/sh fallback in interactive GRASS GIS sessions
+# set SHELL var to avoid /bin/sh fallback in interactive GRASS sessions
 ENV SHELL=/bin/bash
 ENV LC_ALL="en_US.UTF-8"
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1
@@ -191,10 +191,10 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
 
-# Create generic GRASS GIS lib name regardless of version number
+# Create generic GRASS lib name regardless of version number
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
-# show GRASS GIS, PROJ, GDAL etc versions
+# show GRASS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
@@ -206,10 +206,10 @@ RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 
-# enable GRASS GIS Python session support
+# enable GRASS Python session support
 ## grass --config python-path
 ENV PYTHONPATH="/usr/local/grass/etc/python:${PYTHONPATH}"
-# enable GRASS GIS ctypes imports
+# enable GRASS ctypes imports
 ## grass --config path
 ENV LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
@@ -217,7 +217,7 @@ WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## run GRASS GIS python session and scan the test LAZ file
+## run GRASS python session and scan the test LAZ file
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -1,7 +1,7 @@
-# Docker GRASS GIS (Debian Linux)
+# Docker GRASS (Debian Linux)
 
 Dockerfile with an [Debian Linux](https://www.debian.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
+[GRASS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 

--- a/docker/testdata/test_docker_image.sh
+++ b/docker/testdata/test_docker_image.sh
@@ -31,9 +31,9 @@ export DEMOLOCATION=/tmp/demolocation/PERMANENT
 printf "\n############\nTesting PDAL with laz:\n############\n"
 grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
-# Test GRASS GIS Python-addon installation
+# Test GRASS Python-addon installation
 # add dependency
-printf "\n############\nTesting GRASS GIS Python-addon installation:\n############\n"
+printf "\n############\nTesting GRASS Python-addon installation:\n############\n"
 /usr/bin/python3 -m pip install --no-cache-dir scikit-learn
 
 grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add && \
@@ -42,14 +42,14 @@ grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add &&
 # cleanup dependency
 /usr/bin/python3 -m pip uninstall -y scikit-learn
 
-# Test GRASS GIS C-addon installation: raster and vector
-printf "\n############\nTesting GRASS GIS C-addon installation:\n############\n"
+# Test GRASS C-addon installation: raster and vector
+printf "\n############\nTesting GRASS C-addon installation:\n############\n"
 grass --tmp-project XY --exec g.extension extension=r.gwr operation=add && \
 	   grass --tmp-project XY --exec g.extension extension=r.gwr operation=remove -f
 grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=add && \
 	   grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=remove -f
 
-# show GRASS GIS, PROJ, GDAL etc versions
+# show GRASS, PROJ, GDAL etc versions
 printf "\n############\nPrinting GRASS, PDAL and Python versions:\n############\n"
 grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \

--- a/docker/testdata/test_grass_python.py
+++ b/docker/testdata/test_grass_python.py
@@ -4,10 +4,10 @@ import grass.script as gs
 
 # hint: do not use ~ as an alias for HOME
 with gs.setup.init(
-    # run in PERMANENT mapset of demolocation in GRASS GIS source
+    # run in PERMANENT mapset of demolocation in GRASSrce
     os.environ["DEMOLOCATION"]  # "/grassdata/demolocation/PERMANENT",
 ):
-    print("grass-setup: tests for PROJ, GDAL, PDAL, GRASS GIS")
+    print("grass-setup: tests for PROJ, GDAL, PDAL, GRASS")
     print(gs.parse_command("g.gisenv", flags="s"))
 
     # simple test: just scan the LAZ file

--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -1,4 +1,4 @@
-# Import GRASS GIS Python bindings (requires 8.4+) and test r.in.pdal
+# Import GRASS Python bindings (requires 8.4+) and test r.in.pdal
 
 # PYTHONPATH=$(grass --config python-path) python
 
@@ -10,7 +10,7 @@ gs.create_project(project, epsg="25832")
 
 # hint: do not use ~ as an alias for HOME
 with gs.setup.init(project):
-    print("GRASS GIS session: tests for PROJ, GDAL, PDAL, GRASS GIS")
+    print("GRASS session: tests for PROJ, GDAL, PDAL, GRASS")
     print(gs.parse_command("g.gisenv", flags="s"))
 
     # simple test: just scan the LAZ file

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -269,7 +269,7 @@ COPY . /src/grass_build/
 
 WORKDIR /src/grass_build
 
-# Set environmental variables for GRASS GIS compilation, without debug symbols
+# Set environmental variables for GRASS compilation, without debug symbols
 # Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99"
 ENV MYLDFLAGS="-s"

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -270,7 +270,7 @@ COPY . /src/grass_build/
 WORKDIR /src/grass_build
 
 # Set environmental variables for GRASS compilation, without debug symbols
-# Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
+# Set gcc/g++ environmental variables for GRASS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99"
 ENV MYLDFLAGS="-s"
 # CXX stuff:
@@ -279,7 +279,7 @@ ENV LDFLAGS="$MYLDFLAGS"
 ENV CFLAGS="$MYCFLAGS"
 ENV CXXFLAGS="$MYCXXFLAGS"
 
-# Configure compile and install GRASS GIS
+# Configure compile and install GRASS
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN ./configure $GRASS_CONFIG \
@@ -307,7 +307,7 @@ RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gd
 # Leave build stage
 FROM grass_gis AS grass_gis_final
 
-# GRASS GIS specific
+# GRASS specific
 # allow work with MAPSETs that are not owned by current user
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     SHELL="/bin/bash" \
@@ -318,27 +318,27 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH" \
     GDAL_DRIVER_PATH="/usr/lib/gdalplugins"
 
-# Copy GRASS GIS from build image
+# Copy GRASS from build image
 COPY --link --from=build /usr/local/bin/* /usr/local/bin/
 COPY --link --from=build /usr/local/grass85 /usr/local/grass85/
 COPY --link --from=build /src/site-packages /usr/lib/python3.10/
 COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 # COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
 
-# Create generic GRASS GIS lib name regardless of version number
+# Create generic GRASS lib name regardless of version number
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
-# show GRASS GIS, PROJ, GDAL etc versions
+# show GRASS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
 
 WORKDIR /scripts
 
-# enable GRASS GIS Python session support
+# enable GRASS Python session support
 ## grass --config python-path
 ENV PYTHONPATH="/usr/local/grass/etc/python:${PYTHONPATH}"
-# enable GRASS GIS ctypes imports
+# enable GRASS ctypes imports
 ## grass --config path
 ENV LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
@@ -346,7 +346,7 @@ WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## run GRASS GIS python session and scan the test LAZ file
+## run GRASS python session and scan the test LAZ file
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -1,7 +1,7 @@
-# Docker GRASS GIS (Ubuntu Linux)
+# Docker GRASS (Ubuntu Linux)
 
 Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
+[GRASS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 
@@ -100,7 +100,7 @@ $ DOCKER_BUILDKIT=1 docker build  \
 
 ## Test the docker image
 
-Note: Adjust the volume mount to the path of the GRASS GIS source code directory.
+Note: Adjust the volume mount to the path of the GRASS source code directory.
 
 ```bash
 # Test basic functionality

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -174,8 +174,8 @@ WORKDIR /src/grass_build
 # Cleanup potentially leftover GISRC file with wrong path to "demolocation"
 RUN rm -f /src/grass_build/dist.*/demolocation/.grassrc*
 
-# Set environmental variables for GRASS GIS compilation, without debug symbols
-# Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
+# Set environmental variables for GRASS compilation, without debug symbols
+# Set gcc/g++ environmental variables for GRASS compilation, without debug symbols
 ENV MYCFLAGS="-O2 -std=gnu99 -m64"
 ENV MYLDFLAGS="-s"
 # CXX stuff:
@@ -184,7 +184,7 @@ ENV LDFLAGS="$MYLDFLAGS"
 ENV CFLAGS="$MYCFLAGS"
 ENV CXXFLAGS="$MYCXXFLAGS"
 
-# Configure compile and install GRASS GIS
+# Configure compile and install GRASS
 # wxGUI require
 # --with-nls
 # --with-x
@@ -224,7 +224,7 @@ ENV LDFLAGS=""
 ENV CFLAGS=""
 ENV CXXFLAGS=""
 
-# set SHELL var to avoid /bin/sh fallback in interactive GRASS GIS sessions
+# set SHELL var to avoid /bin/sh fallback in interactive GRASS sessions
 ENV SHELL=/bin/bash
 ENV LC_ALL="en_US.UTF-8"
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1
@@ -232,10 +232,10 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
 
-# Create generic GRASS GIS lib name regardless of version number
+# Create generic GRASS lib name regardless of version number
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
-# show GRASS GIS, PROJ, GDAL etc versions
+# show GRASS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
@@ -247,10 +247,10 @@ RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 
-# enable GRASS GIS Python session support
+# enable GRASS Python session support
 ## grass --config python-path
 ENV PYTHONPATH="/usr/local/grass/etc/python:${PYTHONPATH}"
-# enable GRASS GIS ctypes imports
+# enable GRASS ctypes imports
 ## grass --config path
 ENV LD_LIBRARY_PATH="/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
@@ -258,7 +258,7 @@ WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## run GRASS GIS python session and scan the test LAZ file
+## run GRASS python session and scan the test LAZ file
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file

--- a/docker/ubuntu_wxgui/README.md
+++ b/docker/ubuntu_wxgui/README.md
@@ -1,7 +1,7 @@
-# Docker GRASS GIS (Ubuntu Linux)
+# Docker GRASS (Ubuntu Linux)
 
 Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
+[GRASS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 

--- a/general/g.gisenv/g.gisenv.md
+++ b/general/g.gisenv/g.gisenv.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*g.gisenv* outputs and modifies the user's current GRASS GIS variable
+*g.gisenv* outputs and modifies the user's current GRASS variable
 settings. When a user runs GRASS, certain variables are set specifying
 the GRASS data base, project, mapset, peripheral device drivers, etc.,
 being used in the current GRASS session. These variable name settings

--- a/general/g.parser/test.pl
+++ b/general/g.parser/test.pl
@@ -26,7 +26,7 @@ use strict;
 # %end
 
 if ( !$ENV{'GISBASE'} ) {
-    printf(STDERR  "You must be in GRASS GIS to run this program.\n");
+    printf(STDERR  "You must be in GRASS to run this program.\n");
     exit 1;
 }
 

--- a/general/g.parser/test.sh
+++ b/general/g.parser/test.sh
@@ -26,7 +26,7 @@
 # %end
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program." 1>&2
+    echo "You must be in GRASS to run this program." 1>&2
     exit 1
 fi
 

--- a/general/g.version/g.version.md
+++ b/general/g.version/g.version.md
@@ -1,14 +1,14 @@
 ## DESCRIPTION
 
 *g.version* prints to standard output the GRASS version number, date,
-the GRASS GIS copyright (**-c** flag), and GRASS build information
+the GRASS copyright (**-c** flag), and GRASS build information
 (**-b** flag).
 
 ## NOTES
 
 This program requires no command line arguments; the user simply types
 *g.version* on the command line to see the version number and date of
-the GRASS GIS software currently being run by the user.
+the GRASS software currently being run by the user.
 
 Information about GRASS GIS core [GIS
 Library](https://grass.osgeo.org/programming8/gislib.html) can be
@@ -115,16 +115,16 @@ libgis date: 2024-04-27T09:38:49+00:00
 <!-- markdownlint-restore -->
 
 Note: if `revision=exported` is reported instead of the git hash then
-the `git` program was not available during compilation of GRASS GIS and
+the `git` program was not available during compilation of GRASS and
 the source code did not contain the `.git/` subdirectory (requires e.g.
-to `git clone` the GRASS GIS [software
+to `git clone` the GRASS [software
 repository](https://github.com/OSGeo/grass/).)
 
-## Citing GRASS GIS
+## Citing GRASS
 
 The GRASS Development Team has invested significant time and effort in
-creating GRASS GIS, please cite it when using it for data analysis. The
-GRASS GIS [Web site](https://grass.osgeo.org/about/license/) offers
+creating GRASS, please cite it when using it for data analysis. The
+GRASS [Web site](https://grass.osgeo.org/about/license/) offers
 citations in different styles.
 
 ## AUTHORS

--- a/grasslib.dox
+++ b/grasslib.dox
@@ -1,10 +1,10 @@
-/*! \mainpage GRASS GIS 8 Programmer's Manual
+/*! \mainpage GRASS 8 Programmer's Manual
 <!-- * doxygenized from "GRASS 5 Programmer's Manual"
        by M. Neteler 2/2004
      * updated 8/2005, 2006-2025
   -->
 
-<a href="https://grass.osgeo.org">GRASS GIS</a> (<b>Geographic
+<a href="https://grass.osgeo.org">GRASS</a> (<b>Geographic
 Resources Analysis Support System</b>) is an open source, free
 software <em>Geographical Information System</em> (GIS) with raster,
 topological %vector, image processing, and graphics production
@@ -41,7 +41,7 @@ href="https://grass.osgeo.org">https://grass.osgeo.org</a>
   original:
   doc/grass_arch.odg
 -->
-\image html "grass_arch.png" "GRASS GIS Architecture"
+\image html "grass_arch.png" "GRASS Architecture"
 
 \section libsOverview Libraries
 
@@ -113,7 +113,7 @@ href="https://grass.osgeo.org">https://grass.osgeo.org</a>
 
 \subsection pythonlibs Python API
 
- - python:	See GRASS GIS Python library (https://grass.osgeo.org/grass-devel/manuals/libpython/)
+ - python:	See GRASS Python library (https://grass.osgeo.org/grass-devel/manuals/libpython/)
 
 \subsection projlibs Projection Libraries
 

--- a/imagery/i.topo.corr/test_i.topo.corr_synthetic_DEM_NC.sh
+++ b/imagery/i.topo.corr/test_i.topo.corr_synthetic_DEM_NC.sh
@@ -6,7 +6,7 @@
 #   grass ~/grassdata/nc_spm_08_grass7/user1
 
 if test "$GISBASE" = ""; then
- echo "You must be in GRASS GIS to run this program."
+ echo "You must be in GRASS to run this program."
  exit
 fi
 

--- a/include/Make/Doxyfile_arch_html.in
+++ b/include/Make/Doxyfile_arch_html.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "GRASS GIS @GRASS_VERSION_MAJOR@ Programmer's Manual"
+PROJECT_NAME           = "GRASS @GRASS_VERSION_MAJOR@ Programmer's Manual"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/include/Make/Doxyfile_arch_latex.in
+++ b/include/Make/Doxyfile_arch_latex.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "GRASS GIS @GRASS_VERSION_MAJOR@ Programmer's Manual"
+PROJECT_NAME           = "GRASS @GRASS_VERSION_MAJOR@ Programmer's Manual"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/lib/external/ccmath/ccmathlib.dox
+++ b/lib/external/ccmath/ccmathlib.dox
@@ -14,7 +14,7 @@ by Daniel A. Atkinson
 
 A mathematics library coded in the C-language containing functions for linear algebra, numerical integration, geometry and trigonometry, curve fitting, roots and optimization, Fourier analysis, simulation generation, statistics, special functions, sorts and searches, time series models, complex arithmetic, and high precision math.
 
-Note: reduces version included in GRASS GIS:
+Note: reduces version included in GRASS:
 
 \section ccmathfunctions List of functions
 

--- a/lib/gis/colors/grass
+++ b/lib/gis/colors/grass
@@ -1,4 +1,4 @@
-# Generic green color rule for GRASS GIS
+# Generic green color rule for GRASS
 # designed with the help of matplotlib/viscm utility;
 # interpolated to a 0-100% proportional rule file with the help of interpln()
 # function in SciLab; aimed at providing a basic color ramp complying with

--- a/lib/gmath/gmathlib.dox
+++ b/lib/gmath/gmathlib.dox
@@ -458,7 +458,7 @@ Additions: Brad Douglas
 <BR>
 <P>
 This chapter provides an explanation of how numerical algebra routines from
-LAPACK/BLAS can be accessed through the GRASS GIS library "gmath". Most of
+LAPACK/BLAS can be accessed through the GRASS library "gmath". Most of
 the functions are wrapper modules for linear algebra problems, a few are locally
 implemented.
 <BR>

--- a/lib/ogsf/ogsflib.dox
+++ b/lib/ogsf/ogsflib.dox
@@ -1,4 +1,4 @@
-/*! \page ogsflib GRASS GIS OGSF Library
+/*! \page ogsflib GRASS OGSF Library
 <!-- doxygenized from "GRASS 5 Programmer's Manual"
      by M. Neteler 2/2004
      Updated by Martin Landa <landa.martin gmail.com> in 6/2011

--- a/lib/pngdriver/pngdriverlib.dox
+++ b/lib/pngdriver/pngdriverlib.dox
@@ -1,4 +1,4 @@
-/*! \page pngdriverlib GRASS GIS PNG Display Driver Library
+/*! \page pngdriverlib GRASS PNG Display Driver Library
 
 by GRASS Development Team (https://grass.osgeo.org)
 

--- a/lib/proj/README.txt
+++ b/lib/proj/README.txt
@@ -1,4 +1,4 @@
-Projection string management: GRASS GIS relies on GDAL/PROJ.
+Projection string management: GRASS relies on GDAL/PROJ.
 
 EPGS DB management: see https://github.com/OSGeo/libgeotiff/tree/master/libgeotiff
 
@@ -43,7 +43,7 @@ PROJ_DEBUG=ON CPL_DEBUG=ON gdaltransform -s_srs EPSG:4326 -t_srs "+proj=longlat 
 -100 40
 -99.9995941840488 39.9999941029394 0
 
-# Testing using GRASS GIS
+# Testing using GRASS
 PROJ_DEBUG=ON CPL_DEBUG=ON m.proj proj_in="+init=epsg:4326" proj_out="+proj=longlat +datum=NAD27" coordinates=-100,40 -d
 -99.99959418|39.99999410|0.00000000
 

--- a/lib/proj/projlib.dox
+++ b/lib/proj/projlib.dox
@@ -7,9 +7,9 @@ by GRASS Development Team
 
 https://grass.osgeo.org
 
-\section projintro GRASS GIS and the PROJ projection library
+\section projintro GRASS and the PROJ projection library
 
-GRASS GIS utilizes the PROJ library (<a
+GRASS utilizes the PROJ library (<a
 href="https://proj.org">https://proj.org</a>) originally
 developed by Gerald Evenden/USGS (Cartographic Projection Procedures
 for the UNIX Environment -- A User's Manual, Evenden, 1990, Open-file
@@ -50,7 +50,7 @@ and grid).
 
 Note that datum transformation is handled exclusively by PROJ 6 and later.
 In the case that GRASS is compiled with PROJ 5 or older, the datum
-management is still done within GRASS GIS. Only in that case,
+management is still done within GRASS. Only in that case,
 if a warning appears that a certain datum is not recognised by GRASS and
 no parameters found, the datum transformation parameters have to be
 added to $GISBASE/etc/proj/datum.table (and also $GISBASE/etc/proj/datumtransform.table

--- a/lib/vector/vectorlib.dox
+++ b/lib/vector/vectorlib.dox
@@ -294,7 +294,7 @@ Information about categories holds \ref line_cats data structure.
 \section vlibAttributes Attributes
 
 For a user-centric view about attribute management, see the explanations
-in the <a href="https://grasswiki.osgeo.org/wiki/Vector_Database_Management">GRASS GIS Wiki</a>.
+in the <a href="https://grasswiki.osgeo.org/wiki/Vector_Database_Management">GRASS Wiki</a>.
 
 The attribute data are stored in external database. Connection with the
 database is done through drivers based on \ref dbmilib. Records in a

--- a/python/grass/docs/src/gunittest_running_tests.rst
+++ b/python/grass/docs/src/gunittest_running_tests.rst
@@ -108,9 +108,9 @@ Running tests and creating report
 
 Currently there is full support only for running all the tests in
 the small (basic) version of GRASS sample Location for North Carolina
-(see `GRASS GIS sample data`).
+(see `GRASS sample data`).
 
-.. _GRASS GIS sample data: https://grass.osgeo.org/download/sample-data
+.. _GRASS sample data: https://grass.osgeo.org/download/sample-data
 
 
 Example Bash script to run be used as a cron job

--- a/python/grass/docs/src/gunittest_running_tests.rst
+++ b/python/grass/docs/src/gunittest_running_tests.rst
@@ -148,7 +148,7 @@ Example Bash script to run be used as a cron job
 
     GRASSDATA="/grassdata/tests-grassdata"
 
-    echo "Nightly GRASS GIS test started: $NOW" >> $LOGFILE
+    echo "Nightly GRASS test started: $NOW" >> $LOGFILE
 
     # compile current source code from scratch
     cd $GRASSSRC
@@ -178,7 +178,7 @@ Example Bash script to run be used as a cron job
     # so publish or archive results
     rsync -rtvu --delete $REPORTS/ "/var/www/html/grassgistestreports"
 
-    echo "Nightly ($NOW) GRASS GIS test finished: $(date $DATE_FLAGS)" >> $LOGFILE
+    echo "Nightly ($NOW) GRASS test finished: $(date $DATE_FLAGS)" >> $LOGFILE
 
 A script similar to this one can be used as a cron job, on most Linux systems
 using ``crontab -e`` and adding a line similar to the following one::

--- a/python/grass/docs/src/pygrass_gis.rst
+++ b/python/grass/docs/src/pygrass_gis.rst
@@ -24,7 +24,7 @@ Region management
 The :class:`~pygrass.gis.region.Region` class it is useful to obtain
 information about the computational region and to change it. Details
 about the GRASS computational region management can be found in
-the `GRASS GIS Wiki: Computational region
+the `GRASS Wiki: Computational region
 <https://grasswiki.osgeo.org/wiki/Computational_region>`_.
 
 The classes are part of the :mod:`~pygrass.gis` module.

--- a/python/grass/docs/src/pygrass_index.rst
+++ b/python/grass/docs/src/pygrass_index.rst
@@ -47,9 +47,9 @@ References
   System (GIS)*. ISPRS International Journal of
   Geo-Information. 2(1):201-219. `doi:10.3390/ijgi2010201
   <https://doi.org/10.3390/ijgi2010201>`_
-* `Python related articles in the GRASS GIS Wiki
+* `Python related articles in the GRASS Wiki
   <https://grasswiki.osgeo.org/wiki/Category:Python>`_
-* `GRASS GIS 8 Programmer's Manual
+* `GRASS 8 Programmer's Manual
   <https://grass.osgeo.org/programming8/>`_
 
 This project has been funded with support from the `Google Summer of

--- a/python/grass/docs/src/pygrass_raster.rst
+++ b/python/grass/docs/src/pygrass_raster.rst
@@ -3,8 +3,8 @@
 Introduction to Raster classes
 ==============================
 
-Details about the GRASS GIS raster architecture can be found in the
-`GRASS GIS 8 Programmer's Manual: GRASS Raster Library
+Details about the GRASS raster architecture can be found in the
+`GRASS 8 Programmer's Manual: GRASS Raster Library
 <https://grass.osgeo.org/programming8/rasterlib.html>`_.
 
 PyGRASS uses 3 different raster classes, that respect the 3 different

--- a/python/grass/docs/src/pygrass_vector.rst
+++ b/python/grass/docs/src/pygrass_vector.rst
@@ -1,7 +1,7 @@
 Introduction to Vector classes
 ==============================
 
-Details about the GRASS GIS vector architecture can be found in the
+Details about the GRASS vector architecture can be found in the
 `GRASS GIS 8 Programmer's Manual: GRASS Vector Library
 <https://grass.osgeo.org/programming8/vectorlib.html>`_.
 

--- a/python/grass/docs/src/pygrass_vector.rst
+++ b/python/grass/docs/src/pygrass_vector.rst
@@ -2,12 +2,12 @@ Introduction to Vector classes
 ==============================
 
 Details about the GRASS vector architecture can be found in the
-`GRASS GIS 8 Programmer's Manual: GRASS Vector Library
+`GRASS 8 Programmer's Manual: GRASS Vector Library
 <https://grass.osgeo.org/programming8/vectorlib.html>`_.
 
 PyGRASS has two classes for vector maps: :ref:`Vector-label` and
 :ref:`VectorTopo-label`.  As the names suggest, the Vector class is
-for vector maps, while VectorTopo opens vector maps with `GRASS GIS
+for vector maps, while VectorTopo opens vector maps with `GRASS
 topology <https://grass.osgeo.org/programming8/vlibTopology.html>`_.
 VectorTopo is an extension of the Vector class, so supports all the
 Vector class methods, with additions. The classes are part of the

--- a/python/grass/docs/src/script_intro.rst
+++ b/python/grass/docs/src/script_intro.rst
@@ -134,7 +134,7 @@ Providing GRASS module interface to a script
 
 The options which has something like ``G_OPT_R_INPUT`` after the word
 ``option`` are called standard options. Their list is accessible
-in GRASS GIS `C API documentation`_ of ``STD_OPT`` enum from ``gis.h`` file.
+in GRASS `C API documentation`_ of ``STD_OPT`` enum from ``gis.h`` file.
 Always use standard options if possible. They are not only easier to use
 but also ensure consistency across the modules and easier maintanenace
 in case of updates to the parameters parsing system.

--- a/python/grass/docs/src/temporal_framework.rst
+++ b/python/grass/docs/src/temporal_framework.rst
@@ -415,7 +415,7 @@ References
 ----------
 
 * Gebbert, S., Pebesma, E., 2014. *TGRASS: A temporal GIS for field based environmental modeling*. Environmental Modelling & Software. 2(1):201-219. `doi:10.1016/j.envsoft.2013.11.001 <https://doi.org/10.1016/j.envsoft.2013.11.001>`_
-* `TGRASS related articles in the GRASS GIS Wiki <https://grasswiki.osgeo.org/wiki/Temporal_data_processing>`_
+* `TGRASS related articles in the GRASS Wiki <https://grasswiki.osgeo.org/wiki/Temporal_data_processing>`_
 * Supplementary material of the publication *The GRASS GIS Temporal Framework*
   to be published in
   *International Journal of Geographical Information Science* in 2017, Download

--- a/vector/vectorintro.md
+++ b/vector/vectorintro.md
@@ -1,9 +1,9 @@
 ---
-description: Vector data processing in GRASS GIS
+description: Vector data processing in GRASS
 index: vector
 ---
 
-# Vector data processing in GRASS GIS
+# Vector data processing in GRASS
 
 ## Vector maps in general
 
@@ -17,13 +17,13 @@ space and are independent of the GIS's computation region.
 
 ## Attribute management
 
-The default database driver used by GRASS GIS 8 is SQLite. GRASS GIS
+The default database driver used by GRASS GIS 8 is SQLite. GRASS
 handles multiattribute vector data by default. The *db.\** set of
 commands provides basic SQL support for attribute management, while the
 *v.db.\** set of commands operates on vector maps.
 
 Note: The list of available database drivers can vary in various binary
-distributions of GRASS GIS, for details see [SQL support in GRASS
+distributions of GRASS, for details see [SQL support in GRASS
 GIS](sql.md).
 
 ## Vector data import and export
@@ -41,7 +41,7 @@ the vector geometry is not imported. The *v.out.\** set of commands
 exports to various formats. To import and export only attribute tables,
 use [db.in.ogr](db.in.ogr.md) and [db.out.ogr](db.out.ogr.md).
 
-GRASS GIS vector map exchange between different projects (same
+GRASS vector map exchange between different projects (same
 projection) can be done in a lossless way using the [v.pack](v.pack.md)
 and [v.unpack](v.unpack.md) modules.
 


### PR DESCRIPTION
My first pass of a series of renames of GRASS GIS to GRASS. Since there are more than 3000 matches of "GRASS GIS", I'm limiting the scope.

I also exclude instances where "GRASS GIS" is historically accurate, like when talking about GRASS GIS 4, GRASS GIS 6, etc..
Also excluding the titles in citations, the actual shortcut names of the OSGeo4W installer (as tricky: it is removing a file on install/uninstall, so it needs to be done right, so addressing later). Ignores the citing/citation files, as unsure for now.

- Renames the "GRASS GIS 8 Programmer's Manual" to "GRASS 8 Programmer's Manual" 
- Renames the python reference too (including the man/ scripts that generate it)
- Renames in the top level files (except for what listed above, to keep easy ones here)
- Renames in script files, like the shell script tests' "You must be in GRASS GIS to run this program."
- Renames in Dockerfile comments
- Smaller other places, that wouldn't be grouped in other narrow scoped PRs