### PR TITLE
lib/vector/Vlib: Fix Resource Leak Issue in dangles.c

### DIFF
--- a/lib/vector/Vlib/dangles.c
+++ b/lib/vector/Vlib/dangles.c
@@ -258,4 +258,7 @@ static void dangles(struct Map_info *Map, int type, int option,
     } /* node <= nnodes */
     G_verbose_message(_("%s lines: %d"), lmsg, lines_removed);
     G_verbose_message(_("%s dangles: %d"), lmsg, dangles_removed);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_list(List);
+    Vect_destroy_cats_struct(Cats);
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207790, 1207791, 1207792)
Used Vect_destroy_line_struct(), Vect_destroy_list(), Vect_destroy_cats_struct() to fix this issue.