### PR TITLE
d.legend.vect: Fix Uninitialized Variable Issue in draw.c

### DIFF
--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -53,6 +53,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
     /* Draw title */
     title_h = 0;
     title_w = 0;
+    row_ind = 0.0;
     if (strlen(title) > 0) {
         D_font(tit_font);
         D_text_size(tit_size, tit_size);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1415801)