### PR TITLE
chore: Rename GRASS GIS to GRASS in most of the repo

### DIFF
--- a/db/databaseintro.html
+++ b/db/databaseintro.html
@@ -1,4 +1,4 @@
-<!-- meta page description: Database management in GRASS GIS -->
+<!-- meta page description: Database management in GRASS -->
 <!-- meta page index: database -->
 <h3>Attribute management in general</h3>
 
@@ -9,7 +9,7 @@ on the vector map (see <a href="vectorintro.html">Vector introduction</a>).
 
 <h3>Available drivers</h3>
 
-Available drivers are listed in <a href="sql.html">SQL support in GRASS GIS</a>.
+Available drivers are listed in <a href="sql.html">SQL support in GRASS</a>.
 <p>
 <b>Notes</b>:<br>
 The DBF driver provides only very limited SQL

--- a/db/databaseintro.md
+++ b/db/databaseintro.md
@@ -14,7 +14,7 @@ map (see [Vector introduction](vectorintro.md)).
 
 ## Available drivers
 
-Available drivers are listed in [SQL support in GRASS GIS](sql.md).
+Available drivers are listed in [SQL support in GRASS](sql.md).
 
 **Notes**:  
 The DBF driver provides only very limited SQL support (as DBF is not an

--- a/db/db.connect/db.connect.html
+++ b/db/db.connect/db.connect.html
@@ -4,7 +4,7 @@
 These parameters are then taken as default values by modules so that the
 user does not need to enter the parameters each time.
 <p>
-The default database backend in GRASS GIS
+The default database backend in GRASS
 is <a href="grass-sqlite.html">SQLite</a> (since version 7).
 
 <h2>NOTES</h2>

--- a/db/db.connect/db.connect.md
+++ b/db/db.connect/db.connect.md
@@ -4,7 +4,7 @@
 These parameters are then taken as default values by modules so that the
 user does not need to enter the parameters each time.
 
-The default database backend in GRASS GIS is [SQLite](grass-sqlite.md)
+The default database backend in GRASS is [SQLite](grass-sqlite.md)
 (since version 7).
 
 ## NOTES

--- a/db/db.createdb/db.createdb.html
+++ b/db/db.createdb/db.createdb.html
@@ -13,7 +13,7 @@ supported.
 
 <h3>Create a new SQLite file-based database</h3>
 
-Note that the standard GRASS GIS SQLite database is by default
+Note that the standard GRASS SQLite database is by default
 generated in the user's current mapset. This example shows an
 out-of-mapset database file creation:
 

--- a/db/db.createdb/db.createdb.md
+++ b/db/db.createdb/db.createdb.md
@@ -11,7 +11,7 @@ database drivers are supported.
 
 ### Create a new SQLite file-based database
 
-Note that the standard GRASS GIS SQLite database is by default generated
+Note that the standard GRASS SQLite database is by default generated
 in the user's current mapset. This example shows an out-of-mapset
 database file creation:
 

--- a/db/db.dropdb/db.dropdb.html
+++ b/db/db.dropdb/db.dropdb.html
@@ -9,7 +9,7 @@ supported.
 
 <h3>Drop (delete) an existing database connected through SQLite driver</h3>
 
-Note that the standard GRASS GIS SQLite database is by default
+Note that the standard GRASS SQLite database is by default
 found in the user's current mapset. This example shows an
 out-of-mapset database removal:
 

--- a/db/db.dropdb/db.dropdb.md
+++ b/db/db.dropdb/db.dropdb.md
@@ -8,7 +8,7 @@
 
 ### Drop (delete) an existing database connected through SQLite driver
 
-Note that the standard GRASS GIS SQLite database is by default found in
+Note that the standard GRASS SQLite database is by default found in
 the user's current mapset. This example shows an out-of-mapset database
 removal:
 

--- a/db/db.login/db.login.html
+++ b/db/db.login/db.login.html
@@ -54,7 +54,7 @@ db.login driver=pg database=mydb user=bacava password=""
 </em>
 
 <p>
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 
 <h2>AUTHOR</h2>
 

--- a/db/db.login/db.login.md
+++ b/db/db.login/db.login.md
@@ -46,7 +46,7 @@ db.login driver=pg database=mydb user=bacava password=""
 *[db.connect](db.connect.md), [db.test](db.test.md),
 [db.tables](db.tables.md)*
 
-[SQL support in GRASS GIS](sql.md)
+[SQL support in GRASS](sql.md)
 
 ## AUTHOR
 

--- a/db/drivers/dbf/grass-dbf.html
+++ b/db/drivers/dbf/grass-dbf.html
@@ -100,7 +100,7 @@ SQL parser error: syntax error, unexpected NAME processing 'IN'..
 </pre></div>
 indicates that an unsupported SQL statement (here, 'IN') was used. The only
 solution is to switch the DBMI backend to a real SQL engine (SQLite,
-PostgreSQL, MySQL etc.). See <a href="sql.html">SQL support in GRASS GIS</a>.
+PostgreSQL, MySQL etc.). See <a href="sql.html">SQL support in GRASS</a>.
 
 <p>
 An error message such as:
@@ -119,6 +119,6 @@ column names on the fly.
 
 <em>
 <a href="db.connect.html">db.connect</a>,
-<a href="sql.html">SQL support in GRASS GIS</a><br>
+<a href="sql.html">SQL support in GRASS</a><br>
 <a href="http://shapelib.maptools.org/dbf_api.html">DBF Specifications</a> (Shapelib)
 </em>

--- a/db/drivers/dbf/grass-dbf.md
+++ b/db/drivers/dbf/grass-dbf.md
@@ -100,8 +100,7 @@ SQL parser error: syntax error, unexpected NAME processing 'IN'..
 
 indicates that an unsupported SQL statement (here, 'IN') was used. The
 only solution is to switch the DBMI backend to a real SQL engine
-(SQLite, PostgreSQL, MySQL etc.). See [SQL support in GRASS
-GIS](sql.md).
+(SQLite, PostgreSQL, MySQL etc.). See [SQL support in GRASS](sql.md).
 
 An error message such as:
 
@@ -117,6 +116,6 @@ different column names on the fly.
 
 ## SEE ALSO
 
-*[db.connect](db.connect.md), [SQL support in GRASS GIS](sql.md)  
+*[db.connect](db.connect.md), [SQL support in GRASS](sql.md)  
 [DBF Specifications](http://shapelib.maptools.org/dbf_api.html)
 (Shapelib)*

--- a/db/drivers/mysql/grass-mesql.html
+++ b/db/drivers/mysql/grass-mesql.html
@@ -62,5 +62,5 @@ as part of a project for <a href="https://www.atac.roma.it/">ATAC</a>.
 
 <em>
 <a href="db.connect.html">db.connect</a>,
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 </em>

--- a/db/drivers/mysql/grass-mesql.md
+++ b/db/drivers/mysql/grass-mesql.md
@@ -62,4 +62,4 @@ Credits: Development of the driver was sponsored by
 
 ## SEE ALSO
 
-*[db.connect](db.connect.md), [SQL support in GRASS GIS](sql.md)*
+*[db.connect](db.connect.md), [SQL support in GRASS](sql.md)*

--- a/db/drivers/mysql/grass-mysql.html
+++ b/db/drivers/mysql/grass-mysql.html
@@ -122,5 +122,5 @@ as part of a project for <a href="https://www.atac.roma.it/">ATAC</a>.
 
 <em>
 <a href="db.connect.html">db.connect</a>,
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 </em>

--- a/db/drivers/mysql/grass-mysql.md
+++ b/db/drivers/mysql/grass-mysql.md
@@ -109,4 +109,4 @@ Credits: Development of the driver was sponsored by
 
 ## SEE ALSO
 
-*[db.connect](db.connect.md), [SQL support in GRASS GIS](sql.md)*
+*[db.connect](db.connect.md), [SQL support in GRASS](sql.md)*

--- a/db/drivers/odbc/grass-odbc.html
+++ b/db/drivers/odbc/grass-odbc.html
@@ -160,5 +160,5 @@ which should print the database connection through ODBC to the defined RDBMS.
 <a href="db.connect.html">db.connect</a>,
 <a href="v.db.connect.html">v.db.connect</a>,
 <a href="https://www.unixodbc.org">unixODBC web site</a>,
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 </em>

--- a/db/drivers/odbc/grass-odbc.md
+++ b/db/drivers/odbc/grass-odbc.md
@@ -143,4 +143,4 @@ RDBMS.
 ## SEE ALSO
 
 *[db.connect](db.connect.md), [v.db.connect](v.db.connect.md), [unixODBC
-web site](https://www.unixodbc.org), [SQL support in GRASS GIS](sql.md)*
+web site](https://www.unixodbc.org), [SQL support in GRASS](sql.md)*

--- a/db/drivers/ogr/grass-ogr.html
+++ b/db/drivers/ogr/grass-ogr.html
@@ -6,7 +6,7 @@ by <em><a href="v.external.html">v.external</a></em>.
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 </em>
 
 <p>

--- a/db/drivers/ogr/grass-ogr.md
+++ b/db/drivers/ogr/grass-ogr.md
@@ -8,6 +8,6 @@ This driver is principally only used by *[v.external](v.external.md)*.
 
 ## SEE ALSO
 
-*[SQL support in GRASS GIS](sql.md)*
+*[SQL support in GRASS](sql.md)*
 
 *[v.external](v.external.md)*

--- a/db/drivers/postgres/grass-pg.html
+++ b/db/drivers/postgres/grass-pg.html
@@ -134,9 +134,9 @@ GIS vector format converter and library, e.g. ArcInfo or SHAPE to PostGIS.<br>
 </em>
 
 <p>
-<a href="databaseintro.html">Database management in GRASS GIS</a><br>
+<a href="databaseintro.html">Database management in GRASS</a><br>
 <a href="database.html">Help pages for database modules</a><br>
-<a href="sql.html">SQL support in GRASS GIS</a><br>
+<a href="sql.html">SQL support in GRASS</a><br>
 
 <h2>REFERENCES</h2>
 

--- a/db/drivers/postgres/grass-pg.md
+++ b/db/drivers/postgres/grass-pg.md
@@ -126,9 +126,9 @@ v.info -t test
 
 *[db.connect](db.connect.md), [db.execute](db.execute.md)*
 
-[Database management in GRASS GIS](databaseintro.md)  
+[Database management in GRASS](databaseintro.md)  
 [Help pages for database modules](database.md)  
-[SQL support in GRASS GIS](sql.md)  
+[SQL support in GRASS](sql.md)  
 
 ## REFERENCES
 

--- a/db/drivers/sqlite/grass-sqlite.html
+++ b/db/drivers/sqlite/grass-sqlite.html
@@ -72,7 +72,7 @@ echo "
 </em>
 <br><br>
 <em>
-  <a href="sql.html">SQL support in GRASS GIS</a>
+  <a href="sql.html">SQL support in GRASS</a>
 </em>
 <br><br>
 <em>

--- a/db/drivers/sqlite/grass-sqlite.md
+++ b/db/drivers/sqlite/grass-sqlite.md
@@ -53,7 +53,7 @@ sqlitebrowser "$GISDBASE/$LOCATION_NAME/$MAPSET"/sqlite/sqlite.db
 *[db.connect](db.connect.md), [db.execute](db.execute.md),
 [db.select](db.select.md)*  
   
-*[SQL support in GRASS GIS](sql.md)*  
+*[SQL support in GRASS](sql.md)*  
   
 *[SQLite web site](https://www.sqlite.org), [SQLite
 manual](https://www.sqlite.org/quickstart.html), [sqlite - Management

--- a/display/d.legend.vect/d.legend.vect.html
+++ b/display/d.legend.vect/d.legend.vect.html
@@ -33,7 +33,7 @@ Modules <em><a href="d.vect.html">d.vect</a></em> and
 have a flag <b>-s</b>
 which removes the particular vector or thematic vector from vector legend.
 <p>The order of entries is defined by the order in Layer Manager (if used
-in GRASS GIS GUI). If that's not desired, one can export the legend file
+in GRASS GUI). If that's not desired, one can export the legend file
 into a text file using parameter <b>output</b>, change the order of entries
 (see section Notes for format description) and then upload the modified file
 with parameter <b>input</b>.

--- a/display/d.legend.vect/d.legend.vect.md
+++ b/display/d.legend.vect/d.legend.vect.md
@@ -33,7 +33,7 @@ Modules *[d.vect](d.vect.md)* and
 the particular vector or thematic vector from vector legend.
 
 The order of entries is defined by the order in Layer Manager (if used
-in GRASS GIS GUI). If that's not desired, one can export the legend file
+in GRASS GUI). If that's not desired, one can export the legend file
 into a text file using parameter **output**, change the order of entries
 (see section Notes for format description) and then upload the modified
 file with parameter **input**. Parameter **output** defines path to the

--- a/display/d.linegraph/d.linegraph.html
+++ b/display/d.linegraph/d.linegraph.html
@@ -42,12 +42,12 @@ Colors specified by <b>y_color</b> option are used for drawing the lines
 in the graph. If multiple Y data files are used, an equal number of
 colors may be used to control the colors of the lines. Colors will be
 assigned to Y data in respect to the sequence of instantiation on the
-command line. It can be one of GRASS GIS named colors or the RGB
+command line. It can be one of GRASS named colors or the RGB
 values from 0-255 separated by colons (RRR:GGG:BBB).
 
 <p>
 Alternatively, the user can use the <b>color_table</b> option to specify one
-of the GRASS GIS predefined color tables.
+of the GRASS predefined color tables.
 
 <p>
 By default, a series of colors will be chosen by the module if none are
@@ -60,8 +60,8 @@ reproducible results.
 <p>
 The color to be used for titles, axis lines, tics, and scale numbers
 is determined by the <b>title_color</b> option. The user can provide
-one of the GRASS GIS named colors (such as gray, white, or black)
-or use the GRASS GIS colon-separated format for RGB (RRR:GGG:BBB).
+one of the GRASS named colors (such as gray, white, or black)
+or use the GRASS colon-separated format for RGB (RRR:GGG:BBB).
 
 <h3>Titles, labels, and tics</h3>
 
@@ -105,7 +105,7 @@ multiplied by a factor of 10 before graphing).
 Depending on the user's needs, it might be easier or more appropriate
 to use a 3rd party tool such as xgraph, gnuplot, Matplotlib in Python,
 or R instead of <em>d.linegraph</em>.
-For a more general solution for plotting in GRASS GIS, the user is
+For a more general solution for plotting in GRASS, the user is
 advised to use the <em><a href="d.graph.html">d.graph</a></em> module.
 
 <h2>EXAMPLE</h2>

--- a/display/d.linegraph/d.linegraph.md
+++ b/display/d.linegraph/d.linegraph.md
@@ -40,11 +40,11 @@ Colors specified by **y_color** option are used for drawing the lines in
 the graph. If multiple Y data files are used, an equal number of colors
 may be used to control the colors of the lines. Colors will be assigned
 to Y data in respect to the sequence of instantiation on the command
-line. It can be one of GRASS GIS named colors or the RGB values from
+line. It can be one of GRASS named colors or the RGB values from
 0-255 separated by colons (RRR:GGG:BBB).
 
 Alternatively, the user can use the **color_table** option to specify
-one of the GRASS GIS predefined color tables.
+one of the GRASS predefined color tables.
 
 By default, a series of colors will be chosen by the module if none are
 provided upon invocation. The order of default colors is red, green,
@@ -55,8 +55,8 @@ reproducible results.
 
 The color to be used for titles, axis lines, tics, and scale numbers is
 determined by the **title_color** option. The user can provide one of
-the GRASS GIS named colors (such as gray, white, or black) or use the
-GRASS GIS colon-separated format for RGB (RRR:GGG:BBB).
+the GRASS named colors (such as gray, white, or black) or use the
+GRASS colon-separated format for RGB (RRR:GGG:BBB).
 
 ### Titles, labels, and tics
 
@@ -94,7 +94,7 @@ multiplied by a factor of 10 before graphing).
 Depending on the user's needs, it might be easier or more appropriate to
 use a 3rd party tool such as xgraph, gnuplot, Matplotlib in Python, or R
 instead of *d.linegraph*. For a more general solution for plotting in
-GRASS GIS, the user is advised to use the *[d.graph](d.graph.md)*
+GRASS, the user is advised to use the *[d.graph](d.graph.md)*
 module.
 
 ## EXAMPLE

--- a/doc/examples/raster/r.example/r.example.html
+++ b/doc/examples/raster/r.example/r.example.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>r.example</em> does practically do nothing, except
-for illustrating GRASS GIS raster programming. It copies
+for illustrating GRASS raster programming. It copies
 over an existing raster map to a new raster map.
 See the source code for details.
 

--- a/doc/grass_database.html
+++ b/doc/grass_database.html
@@ -68,7 +68,7 @@ reference system.
 GRASS projects can be safely copied or moved as any other directories.
 Compressed projects are usually what GRASS users exchange between each other
 when they want to share a lot of data.
-For example, GRASS GIS sample data are provided as projects.
+For example, GRASS sample data are provided as projects.
 
 <p>
 Note that a GRASS project used to be called <em>location</em> and
@@ -151,7 +151,7 @@ users. The PERMANENT mapset is useful for providing general spatial
 data (e.g. an elevation model), accessible but write-protected to all
 users who are working with the same GRASS project as the database owner.
 To manipulate or add data to PERMANENT, the owner can start
-GRASS GIS and choose the relevant project and the PERMANENT mapset.
+GRASS and choose the relevant project and the PERMANENT mapset.
 
 <p>
 The PERMANENT mapset also contains the <code>DEFAULT_WIND</code> file which holds

--- a/doc/projectionintro.html
+++ b/doc/projectionintro.html
@@ -1,4 +1,4 @@
-<!-- meta page description: Projections and spatial transformations in GRASS GIS-->
+<!-- meta page description: Projections and spatial transformations in GRASS-->
 <h3>Projection management in general</h3>
 
 A GRASS project is referenced with a single projection and coordinate system

--- a/general/g.filename/g.filename.html
+++ b/general/g.filename/g.filename.html
@@ -5,7 +5,7 @@ the full file name, including it's path, for mapset elements, like raster,
 vector and site maps, region definitions and imagery groups.
 <p>The list of element names to search for is not fixed; any subdirectory of the
 mapset directory is a valid element name.
-<p>However, the user can find the list of standard GRASS GIS element names in
+<p>However, the user can find the list of standard GRASS element names in
 the file <code>$GISBASE/etc/element_list</code>. This is the file which
 g.remove/g.rename/g.copy use to determine which files need to be
 deleted/renamed/copied for a given entity type.

--- a/general/g.filename/g.filename.md
+++ b/general/g.filename/g.filename.md
@@ -7,7 +7,7 @@ vector and site maps, region definitions and imagery groups.
 The list of element names to search for is not fixed; any subdirectory
 of the mapset directory is a valid element name.
 
-However, the user can find the list of standard GRASS GIS element names
+However, the user can find the list of standard GRASS element names
 in the file `$GISBASE/etc/element_list`. This is the file which
 g.remove/g.rename/g.copy use to determine which files need to be
 deleted/renamed/copied for a given entity type.

--- a/general/g.gisenv/g.gisenv.html
+++ b/general/g.gisenv/g.gisenv.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>g.gisenv</em> outputs and modifies the user's current GRASS GIS
+<em>g.gisenv</em> outputs and modifies the user's current GRASS
 variable settings.
 
 When a user runs GRASS, certain variables are set specifying the GRASS

--- a/general/g.gui/g.gui.html
+++ b/general/g.gui/g.gui.html
@@ -5,7 +5,7 @@ Interface (GUI) from the command line prompt or to change the
 default User Interface (UI) settings.
 
 <p>
-GRASS GIS comes with both a wxPython-based GUI
+GRASS comes with both a wxPython-based GUI
 aka <em><a href="wxGUI.html">wxGUI</a></em> (<b>ui=wxpython</b>) and
 command line text-based UI (<b>ui=text</b>).
 

--- a/general/g.gui/g.gui.md
+++ b/general/g.gui/g.gui.md
@@ -4,7 +4,7 @@ The *g.gui* module allows user to start the Graphical User Interface
 (GUI) from the command line prompt or to change the default User
 Interface (UI) settings.
 
-GRASS GIS comes with both a wxPython-based GUI aka *[wxGUI](wxGUI.md)*
+GRASS comes with both a wxPython-based GUI aka *[wxGUI](wxGUI.md)*
 (**ui=wxpython**) and command line text-based UI (**ui=text**).
 
 ## NOTES

--- a/general/g.message/g.message.html
+++ b/general/g.message/g.message.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>g.message</em> prints a message, warning, progress info, or fatal error
-in the GRASS GIS way.
+in the GRASS way.
 
 This program is to be used in Shell/Perl/Python scripts, so the author does not
 need to use the <code>echo</code> program. The advantage of <em>g.message</em> is

--- a/general/g.message/g.message.md
+++ b/general/g.message/g.message.md
@@ -1,7 +1,7 @@
 ## DESCRIPTION
 
 *g.message* prints a message, warning, progress info, or fatal error in
-the GRASS GIS way. This program is to be used in Shell/Perl/Python
+the GRASS way. This program is to be used in Shell/Perl/Python
 scripts, so the author does not need to use the `echo` program. The
 advantage of *g.message* is that it formats messages just like other
 GRASS modules do and that its functionality is influenced by the

--- a/general/g.parser/g.parser.html
+++ b/general/g.parser/g.parser.html
@@ -455,7 +455,7 @@ if __name__ == "__main__":
 # %end
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program." 1&gt;&amp;2
+    echo "You must be in GRASS to run this program." 1&gt;&amp;2
     exit 1
 fi
 
@@ -517,7 +517,7 @@ use strict;
 # %end
 
 if ( !$ENV{'GISBASE'} ) {
-    printf(STDERR  "You must be in GRASS GIS to run this program.\n");
+    printf(STDERR  "You must be in GRASS to run this program.\n");
     exit 1;
 }
 
@@ -548,8 +548,8 @@ printf ("Value of GIS_OPT_vect: '%s'\n", $ENV{'GIS_OPT_VECTOR'});
 
 <h3>Easy creation of a script</h3>
 
-By using the <b>--script</b> flag with any GRASS GIS module (must be run in
-a GRASS GIS session) header, description, keywords, parameters, flags and
+By using the <b>--script</b> flag with any GRASS module (must be run in
+a GRASS session) header, description, keywords, parameters, flags and
 a template main Python script section will be printed in the terminal which
 can be saved to a file and used for further script programming.
 <p>
@@ -677,7 +677,7 @@ Overview table: <a href="parser_standard_options.html">Parser standard options</
 
 <p>
 Related Wiki pages:
-<a href="https://grasswiki.osgeo.org/wiki/Category:Linking_to_other_languages">Using GRASS GIS with other programming languages</a>
+<a href="https://grasswiki.osgeo.org/wiki/Category:Linking_to_other_languages">Using GRASS with other programming languages</a>
 
 <h2>AUTHOR</h2>
 

--- a/general/g.parser/g.parser.md
+++ b/general/g.parser/g.parser.md
@@ -445,7 +445,7 @@ if __name__ == "__main__":
 # %end
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program." 1>&2
+    echo "You must be in GRASS to run this program." 1>&2
     exit 1
 fi
 
@@ -507,7 +507,7 @@ use strict;
 # %end
 
 if ( !$ENV{'GISBASE'} ) {
-    printf(STDERR  "You must be in GRASS GIS to run this program.\n");
+    printf(STDERR  "You must be in GRASS to run this program.\n");
     exit 1;
 }
 
@@ -538,8 +538,8 @@ printf ("Value of GIS_OPT_vect: '%s'\n", $ENV{'GIS_OPT_VECTOR'});
 
 ### Easy creation of a script
 
-By using the **--script** flag with any GRASS GIS module (must be run in
-a GRASS GIS session) header, description, keywords, parameters, flags
+By using the **--script** flag with any GRASS module (must be run in
+a GRASS session) header, description, keywords, parameters, flags
 and a template main Python script section will be printed in the
 terminal which can be saved to a file and used for further script
 programming.
@@ -665,7 +665,7 @@ Overview table: [Parser standard options](parser_standard_options.md)
 [Style Guide: Developing Python
 scripts](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md#developing-python-scripts)
 
-Related Wiki pages: [Using GRASS GIS with other programming
+Related Wiki pages: [Using GRASS with other programming
 languages](https://grasswiki.osgeo.org/wiki/Category:Linking_to_other_languages)
 
 ## AUTHOR

--- a/general/g.region/g.region.html
+++ b/general/g.region/g.region.html
@@ -125,7 +125,7 @@ options for changing region is used (<b>res=</b>, <b>raster=</b>, etc).
 This can be used for example to print modified region values for further use
 without actually modifying the current region.
 Similarly, <b>-o</b> flag forces to update current region file even when e.g., only
-printing was specified. Flag <b>-o</b> was added in GRASS GIS version 8 to simulate
+printing was specified. Flag <b>-o</b> was added in GRASS version 8 to simulate
 <em>g.region</em> behavior in prior versions when current region file was
 always updated unless <b>-u</b> was specified.
 

--- a/general/g.version/g.version.html
+++ b/general/g.version/g.version.html
@@ -1,17 +1,17 @@
 <h2>DESCRIPTION</h2>
 
 <em>g.version</em> prints to standard output the GRASS version number,
-date, the GRASS GIS copyright (<b>-c</b> flag), and GRASS build information
+date, the GRASS copyright (<b>-c</b> flag), and GRASS build information
 (<b>-b</b> flag).
 
 <h2>NOTES</h2>
 
 This program requires no command line arguments; the user simply types
 <em>g.version</em> on the command line to see the version number and
-date of the GRASS GIS software currently being run by the user.
+date of the GRASS software currently being run by the user.
 
 <p>
-Information about GRASS GIS
+Information about GRASS
 core <a href="https://grass.osgeo.org/programming8/gislib.html">GIS
 Library</a> can be printed by <b>-r</b> flag.
 
@@ -70,16 +70,16 @@ sqlite=3.36.0
 </pre></div>
 
 Note: if <code>revision=exported</code> is reported instead of the git hash then the
-<code>git</code> program was not available during compilation of GRASS GIS and the
+<code>git</code> program was not available during compilation of GRASS and the
 source code did not contain the <code>.git/</code> subdirectory (requires e.g. to
-<code>git clone</code> the GRASS GIS <a href="https://github.com/OSGeo/grass/">software repository</a>.)
+<code>git clone</code> the GRASS <a href="https://github.com/OSGeo/grass/">software repository</a>.)
 
-<h2>Citing GRASS GIS</h2>
+<h2>Citing GRASS</h2>
 
 The GRASS Development Team has invested significant time and effort
-in creating GRASS GIS, please cite it when using it for data analysis.
+in creating GRASS, please cite it when using it for data analysis.
 
-The GRASS GIS <a href="https://grass.osgeo.org/about/license/">Web site</a>
+The GRASS <a href="https://grass.osgeo.org/about/license/">Web site</a>
 offers citations in different styles.
 <!-- TODO: g.version should offer this right away -->
 

--- a/general/g.version/g.version.md
+++ b/general/g.version/g.version.md
@@ -10,7 +10,7 @@ This program requires no command line arguments; the user simply types
 *g.version* on the command line to see the version number and date of
 the GRASS software currently being run by the user.
 
-Information about GRASS GIS core [GIS
+Information about GRASS core [GIS
 Library](https://grass.osgeo.org/programming8/gislib.html) can be
 printed by **-r** flag.
 

--- a/general/g.version/main.c
+++ b/general/g.version/main.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     G_add_keyword(_("copyright"));
     G_add_keyword(_("version"));
     G_add_keyword(_("license"));
-    module->label = _("Displays GRASS GIS version info.");
+    module->label = _("Displays GRASS version info.");
     module->description =
         _("Optionally also prints build or copyright information.");
 
@@ -257,8 +257,7 @@ int main(int argc, char *argv[])
             case SHELL:
                 fprintf(stdout, "libgis_revision=\n");
                 fprintf(stdout, "libgis_date=\n");
-                G_warning(
-                    "GRASS GIS libgis version and date number not available");
+                G_warning("GRASS libgis version and date number not available");
                 /* this can be alternatively fatal error or it can cause
                    fatal error later */
                 break;
@@ -272,13 +271,12 @@ int main(int argc, char *argv[])
             case JSON:
                 G_json_object_set_null(root_object, "libgis_revision");
                 G_json_object_set_null(root_object, "libgis_date");
-                G_warning(
-                    "GRASS GIS libgis version and date number not available");
+                G_warning("GRASS libgis version and date number not available");
                 break;
             }
         }
         if (no_libgis) {
-            G_debug(1, _("GRASS GIS libgis version and date number don't have "
+            G_debug(1, _("GRASS libgis version and date number don't have "
                          "the expected format."
                          " Trying to print the original strings..."));
             G_debug(1, _("GIS_H_VERSION=\"%s\""), GIS_H_VERSION);

--- a/imagery/i.albedo/testsuite/test_i_albedo.py
+++ b/imagery/i.albedo/testsuite/test_i_albedo.py
@@ -4,7 +4,7 @@ from grass.gunittest.main import test
 
 
 class TestIAlbedo(TestCase):
-    """Regression tests for the i.albedo GRASS GIS module."""
+    """Regression tests for the i.albedo GRASS module."""
 
     output_raster = "albedo_output"
 

--- a/imagery/i.biomass/testsuite/test_i_biomass.py
+++ b/imagery/i.biomass/testsuite/test_i_biomass.py
@@ -5,7 +5,7 @@ from grass.gunittest.main import test
 
 
 class TestIBiomass(TestCase):
-    """Regression tests for the i.biomass GRASS GIS module."""
+    """Regression tests for the i.biomass GRASS module."""
 
     input_rasters = {
         "fpar": "test_fpar",

--- a/imagery/i.cca/testsuite/test_i_cca.py
+++ b/imagery/i.cca/testsuite/test_i_cca.py
@@ -4,7 +4,7 @@ import grass.script as gs
 
 
 class TestICCA(TestCase):
-    """Regression and invariance tests for the i.cca GRASS GIS module."""
+    """Regression and invariance tests for the i.cca GRASS module."""
 
     group_name = "cca_group"
     subgroup_name = "cca_subgroup"

--- a/imagery/i.fft/testsuite/test_i_fft.py
+++ b/imagery/i.fft/testsuite/test_i_fft.py
@@ -5,7 +5,7 @@ from grass.gunittest.main import test
 
 
 class TestIFFT(TestCase):
-    """Regression tests for the i.fft GRASS GIS module."""
+    """Regression tests for the i.fft GRASS module."""
 
     input_raster = "test_input"
     real_output = "fft_real"

--- a/imagery/i.ifft/testsuite/test_i_ifft.py
+++ b/imagery/i.ifft/testsuite/test_i_ifft.py
@@ -5,7 +5,7 @@ from grass.gunittest.main import test
 
 
 class TestIIFFT(TestCase):
-    """Regression tests for the i.ifft GRASS GIS module."""
+    """Regression tests for the i.ifft GRASS module."""
 
     real_input = "real_input_raster"
     imag_input = "imag_input_raster"

--- a/imagery/i.modis.qc/i.modis.qc.html
+++ b/imagery/i.modis.qc/i.modis.qc.html
@@ -504,7 +504,7 @@ This value is then transformed into GRASS NULLs when data is imported through
 will not give the expected range of values in the different QC bits. Therefore,
 before using <em>i.modis.qc</em>, the user needs to set the NULL value in QC bands
 back to zero (i.e.: <code>r.null map=QC_band null=0</code>) or just edit the metadata with GDAL
-utilities before importing into GRASS GIS. This is a known issue for MOD11A2
+utilities before importing into GRASS. This is a known issue for MOD11A2
 (8-day LST product), but other MODIS products might be affected as well.
 
 <h2>TODO</h2>

--- a/imagery/i.modis.qc/i.modis.qc.md
+++ b/imagery/i.modis.qc/i.modis.qc.md
@@ -476,7 +476,7 @@ those QC bands will not give the expected range of values in the
 different QC bits. Therefore, before using *i.modis.qc*, the user needs
 to set the NULL value in QC bands back to zero (i.e.:
 `r.null map=QC_band null=0`) or just edit the metadata with GDAL
-utilities before importing into GRASS GIS. This is a known issue for
+utilities before importing into GRASS. This is a known issue for
 MOD11A2 (8-day LST product), but other MODIS products might be affected
 as well.
 

--- a/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.html
+++ b/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.html
@@ -41,7 +41,7 @@ all the steps can be performed separately by running the appropriate modules.
 </ul>
 
 <p>
-The ortho-rectification procedure in GRASS GIS places the image pixels on
+The ortho-rectification procedure in GRASS places the image pixels on
 the surface of the earth by matching the coordinate system of the aerial
 image in pixels (<em>image coordinate system</em>) and the coordinate
 system of the camera sensor in millimetres (<em>photo coordinate system</em>)

--- a/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.md
+++ b/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.md
@@ -26,7 +26,7 @@ performed separately by running the appropriate modules.
 - *Ortho-rectification*
   1. Ortho-rectify imagery group: [i.ortho.rectify](i.ortho.rectify.md)
 
-The ortho-rectification procedure in GRASS GIS places the image pixels
+The ortho-rectification procedure in GRASS places the image pixels
 on the surface of the earth by matching the coordinate system of the
 aerial image in pixels (*image coordinate system*) and the coordinate
 system of the camera sensor in millimetres (*photo coordinate system*)

--- a/imagery/i.smap/testsuite/test_i_smap.py
+++ b/imagery/i.smap/testsuite/test_i_smap.py
@@ -4,7 +4,7 @@ from grass.gunittest.main import test
 
 
 class TestISmap(TestCase):
-    """Regression tests for i.smap GRASS GIS module."""
+    """Regression tests for i.smap GRASS module."""
 
     group_name = "test_smap_group"
     subgroup_name = "test_smap_subgroup"

--- a/imagery/i.target/testsuite/test_i_target.py
+++ b/imagery/i.target/testsuite/test_i_target.py
@@ -5,7 +5,7 @@ from grass.gunittest.main import test
 
 
 class TestITarget(TestCase):
-    """Regression tests for the i.target GRASS GIS module."""
+    """Regression tests for the i.target GRASS module."""
 
     @classmethod
     def setUpClass(cls):

--- a/imagery/i.zc/testsuite/test_i_zc.py
+++ b/imagery/i.zc/testsuite/test_i_zc.py
@@ -5,7 +5,7 @@ from grass.gunittest.main import test
 
 
 class TestIZC(TestCase):
-    """Regression tests for the i.zc GRASS GIS module."""
+    """Regression tests for the i.zc GRASS module."""
 
     input_raster = "input_raster"
     output_raster = "output_raster"

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -1,14 +1,14 @@
-<!-- meta page description: Image processing in GRASS GIS -->
+<!-- meta page description: Image processing in GRASS -->
 <!-- meta page index: imagery -->
 <h3>Image processing in general</h3>
 
-GRASS GIS provides a powerful suite of tools for the processing and
+GRASS provides a powerful suite of tools for the processing and
 analysis of geospatial raster data, including satellite imagery and
 aerial photography. Its image processing capabilities encompass a broad
 range of preprocessing operations, such as data import, georeferencing,
 radiometric calibration, and atmospheric correction. It is particularly
 suited for handling Earth observation data, enabling the analysis of
-multispectral and temporal datasets. GRASS GIS supports advanced
+multispectral and temporal datasets. GRASS supports advanced
 functionalities such as image classification, sensor fusion, and point
 cloud statistics. The calculation of vegetation indices further enables
 analyses of environmental, agricultural, and land cover dynamics. An
@@ -34,7 +34,7 @@ equation <code>(y = a * x + b)</code> to encode the radiance-at-sensor
 in 8 to 16 bits. DNs can be turned back into physical values by
 applying the reverse formula <code>(x = (y - b) / a)</code>.
 <p>
-The GRASS GIS module <a href="i.landsat.toar.html">i.landsat.toar</a>
+The GRASS module <a href="i.landsat.toar.html">i.landsat.toar</a>
 easily transforms Landsat DN to radiance-at-sensor (top of atmosphere,
 TOA). The equivalent module for ASTER data is
 <a href="i.aster.toar.html">i.aster.toar</a>.
@@ -53,7 +53,7 @@ comparability between Earth surface images taken at different
 times, atmospheric need to be removed converting at-sensor values
 which are top of atmosphere to surface reflectance values.
 <p>
-In GRASS GIS, there are two ways to apply atmospheric correction for
+In GRASS, there are two ways to apply atmospheric correction for
 satellite imagery. A simple, less accurate way for Landsat is with
 <a href="i.landsat.toar.html">i.landsat.toar</a>,
 using the DOS correction method. The more accurate way is using
@@ -64,7 +64,7 @@ which ranges theoretically from 0% to 100%. Note that this level of
 data correction is the proper level of correction to calculate
 vegetation indices.
 <p>
-In GRASS GIS, image data are identical to <a href="rasterintro.html">raster data</a>.
+In GRASS, image data are identical to <a href="rasterintro.html">raster data</a>.
 However, a couple of commands are explicitly dedicated to image
 processing. The geographic boundaries of the raster/imagery file are
 described by the north, south, east, and west fields. These values
@@ -114,7 +114,7 @@ signature files of one imagery or raster group can be used to classify
 a different group with identical semantic labels.
 
 <div align="center" style="margin: 10px">
-<img src="band_references_scheme.png" alt="GRASS GIS band references scheme" width="600" height="435" border="0"><br>
+<img src="band_references_scheme.png" alt="GRASS band references scheme" width="600" height="435" border="0"><br>
 <i>
     New enhanced classification workflow involving semantic labels.
 </i>
@@ -286,7 +286,7 @@ Several modules support the calculation of the energy balance:
 <h3>See also</h3>
 
 <ul>
-<li> GRASS GIS Wiki page: <a href="https://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a></li>
+<li> GRASS Wiki page: <a href="https://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a></li>
 <li>The GRASS 4
     <em><a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
      Processing manual</a></em></li>

--- a/imagery/imageryintro.md
+++ b/imagery/imageryintro.md
@@ -1,19 +1,19 @@
 ---
-description: Image processing in GRASS GIS
+description: Image processing in GRASS
 index: imagery
 ---
 
-# Image processing in GRASS GIS
+# Image processing in GRASS
 
 ## Image processing in general
 
-GRASS GIS provides a powerful suite of tools for the processing and
+GRASS provides a powerful suite of tools for the processing and
 analysis of geospatial raster data, including satellite imagery and
 aerial photography. Its image processing capabilities encompass a broad
 range of preprocessing operations, such as data import, georeferencing,
 radiometric calibration, and atmospheric correction. It is particularly
 suited for handling Earth observation data, enabling the analysis of
-multispectral and temporal datasets. GRASS GIS supports advanced
+multispectral and temporal datasets. GRASS supports advanced
 functionalities such as image classification, sensor fusion, and point
 cloud statistics. The calculation of vegetation indices further enables
 analyses of environmental, agricultural, and land cover dynamics. An
@@ -38,7 +38,7 @@ encode the radiance-at-sensor in 8 to 16 bits. DNs can be turned back
 into physical values by applying the reverse formula
 `(x = (y - b) / a)`.
 
-The GRASS GIS module [i.landsat.toar](i.landsat.toar.md) easily
+The GRASS module [i.landsat.toar](i.landsat.toar.md) easily
 transforms Landsat DN to radiance-at-sensor (top of atmosphere, TOA).
 The equivalent module for ASTER data is [i.aster.toar](i.aster.toar.md).
 For other satellites, [r.mapcalc](r.mapcalc.md) can be employed.
@@ -55,7 +55,7 @@ Earth surface images taken at different times, atmospheric need to be
 removed converting at-sensor values which are top of atmosphere to
 surface reflectance values.
 
-In GRASS GIS, there are two ways to apply atmospheric correction for
+In GRASS, there are two ways to apply atmospheric correction for
 satellite imagery. A simple, less accurate way for Landsat is with
 [i.landsat.toar](i.landsat.toar.md), using the DOS correction method.
 The more accurate way is using [i.atcorr](i.atcorr.md) (which supports
@@ -65,7 +65,7 @@ represent surface
 theoretically from 0% to 100%. Note that this level of data correction
 is the proper level of correction to calculate vegetation indices.
 
-In GRASS GIS, image data are identical to [raster data](rasterintro.md).
+In GRASS, image data are identical to [raster data](rasterintro.md).
 However, a couple of commands are explicitly dedicated to image
 processing. The geographic boundaries of the raster/imagery file are
 described by the north, south, east, and west fields. These values
@@ -109,7 +109,7 @@ signature files of imagery classification tools. Therefore, signature
 files of one imagery or raster group can be used to classify a different
 group with identical semantic labels.
 
-![GRASS GIS band references scheme](band_references_scheme.png)  
+![GRASS band references scheme](band_references_scheme.png)  
 *New enhanced classification workflow involving semantic labels.*
 
 With [r.support](r.support.md) any sort of semantic label the user
@@ -254,7 +254,7 @@ Several modules support the calculation of the energy balance:
 
 ## See also
 
-- GRASS GIS Wiki page: [Image
+- GRASS Wiki page: [Image
   processing](https://grasswiki.osgeo.org/wiki/Image_processing)
 - The GRASS 4 *[Image Processing
   manual](https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf)*

--- a/include/grass/gmath.h
+++ b/include/grass/gmath.h
@@ -7,7 +7,7 @@
  * Last updated: $Id$
  *
 
- * This file is part of GRASS GIS. It is free software. You can
+ * This file is part of GRASS. It is free software. You can
  * redistribute it and/or modify it under the terms of
  * the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option)

--- a/include/grass/la.h
+++ b/include/grass/la.h
@@ -7,17 +7,17 @@
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
  * \author David D. Gray, ddgray@armacde.demon co uk
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2000-2007
  */
 
 #ifndef HAVE_LIBBLAS
-#error GRASS GIS is not configured with BLAS (la.h cannot be included)
+#error GRASS is not configured with BLAS (la.h cannot be included)
 #endif
 
 #ifndef HAVE_LIBLAPACK
-#error GRASS GIS is not configured with LAPACK (la.h cannot be included)
+#error GRASS is not configured with LAPACK (la.h cannot be included)
 #endif
 
 #ifndef GRASS_LA_H

--- a/lib/db/sqlp/sql.html
+++ b/lib/db/sqlp/sql.html
@@ -1,4 +1,4 @@
-<!-- meta page description: SQL support in GRASS GIS -->
+<!-- meta page description: SQL support in GRASS -->
 
 <!-- this file is lib/db/sqlp/sql.html -->
 
@@ -8,7 +8,7 @@ category number (attribute ID, usually the "cat" integer column). The
 category numbers are stored both in the vector geometry and the
 attribute table.
 <p>
-GRASS GIS supports various RDBMS
+GRASS supports various RDBMS
 (<a href="https://en.wikipedia.org/wiki/Relational_database_management_system">Relational
 database management system</a>) and embedded databases. SQL
 (<a href="https://en.wikipedia.org/wiki/Sql">Structured Query
@@ -18,14 +18,14 @@ database driver selected.
 
 <h2>Database drivers</h2>
 
-The default database driver used by GRASS GIS 8 is SQLite. GRASS GIS
+The default database driver used by GRASS 8 is SQLite. GRASGRASS
 handles multiattribute vector data by default. The <em>db.*</em> set of
 commands  provides basic SQL support for attribute management, while the
 <em>v.db.*</em> set of commands operates on vector maps.
 
 <p>
 Note: The list of available database drivers can vary in various binary
-distributions of GRASS GIS:
+distributions of GRASS:
 <p>
 <table class="border">
 <tr><td><a href="grass-sqlite.html">sqlite</a></td><td>Data storage in SQLite database files (default DB backend)</td>
@@ -232,7 +232,7 @@ v.db.update vectormap column=species qcolumn="CASE WHEN col1 &gt;= 1 THEN cat WH
 </em>
 
 <p>
-<a href="databaseintro.html">Database management in GRASS GIS</a>,
+<a href="databaseintro.html">Database management in GRASS</a>,
 <a href="database.html">Help pages for database modules</a>
 
 <h2>AUTHOR</h2>

--- a/lib/db/sqlp/sql.md
+++ b/lib/db/sqlp/sql.md
@@ -1,8 +1,8 @@
 ---
-description: SQL support in GRASS GIS
+description: SQL support in GRASS
 ---
 
-# SQL support in GRASS GIS
+# SQL support in GRASS
 
 Vector points, lines and areas usually have attribute data that are
 stored in DBMS. The attributes are linked to each vector object using a
@@ -10,7 +10,7 @@ category number (attribute ID, usually the "cat" integer column). The
 category numbers are stored both in the vector geometry and the
 attribute table.
 
-GRASS GIS supports various RDBMS ([Relational database management
+GRASS supports various RDBMS ([Relational database management
 system](https://en.wikipedia.org/wiki/Relational_database_management_system))
 and embedded databases. SQL ([Structured Query
 Language](https://en.wikipedia.org/wiki/Sql)) queries are directly
@@ -19,13 +19,13 @@ commands depends on the RDMBS and database driver selected.
 
 ## Database drivers
 
-The default database driver used by GRASS GIS 8 is SQLite. GRASS GIS
+The default database driver used by GRASS 8 is SQLite. GRASS
 handles multiattribute vector data by default. The *db.\** set of
 commands provides basic SQL support for attribute management, while the
 *v.db.\** set of commands operates on vector maps.
 
 Note: The list of available database drivers can vary in various binary
-distributions of GRASS GIS:
+distributions of GRASS:
 
 |                           |                                                            |                                             |
 |---------------------------|------------------------------------------------------------|---------------------------------------------|
@@ -212,7 +212,7 @@ v.db.update vectormap column=species qcolumn="CASE WHEN col1 >= 1 THEN cat WHEN 
 [db.execute](db.execute.md), [v.db.connect](v.db.connect.md),
 [v.db.select](v.db.select.md), [v.db.update](v.db.update.md)*
 
-[Database management in GRASS GIS](databaseintro.md), [Help pages for
+[Database management in GRASS](databaseintro.md), [Help pages for
 database modules](database.md)
 
 ## AUTHOR

--- a/lib/external/README.md
+++ b/lib/external/README.md
@@ -1,12 +1,12 @@
 # How to add a new external library
 
 The following procedure will walk you through adding a new third-party
-library to GRASS GIS.
+library to GRASS.
 
 ## License
 
 Before you start, make sure that the library you want to include is in
-compliance with the GRASS GIS licence.
+compliance with the GRASS license.
 
 ### Approved Third-Party Licenses
 

--- a/lib/gis/ascii_chk.c
+++ b/lib/gis/ascii_chk.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/basename.c
+++ b/lib/gis/basename.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  */
 
 #include <grass/gis.h>

--- a/lib/gis/colors.desc
+++ b/lib/gis/colors.desc
@@ -15,7 +15,7 @@ evi: enhanced vegetative index colors
 fahrenheit: blue to red for Fahrenheit temperature
 forest_cover: percentage of forest cover
 gdd: accumulated growing degree days
-grass: GRASS GIS green (perceptually uniform)
+grass: GRASS green (perceptually uniform)
 greens: white to green
 grey: grey scale
 grey1.0: grey scale for raster values between 0.0-1.0

--- a/lib/gis/commas.c
+++ b/lib/gis/commas.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/copy_file.c
+++ b/lib/gis/copy_file.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * MODULE:       GRASS GIS library - copy_file.c
+ * MODULE:       GRASS library - copy_file.c
  * AUTHOR(S):    Paul Kelly
  * PURPOSE:      Function to copy one file to another.
  * COPYRIGHT:    (C) 2007 by the GRASS Development Team

--- a/lib/gis/debug.c
+++ b/lib/gis/debug.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  */
 
 #include <stdio.h>

--- a/lib/gis/done_msg.c
+++ b/lib/gis/done_msg.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/gisinit.c
+++ b/lib/gis/gisinit.c
@@ -8,7 +8,7 @@
    This program is free software under the GNU General Public License
    (>=v2). Read the file COPYING that comes with GRASS for details.
 
-   \author GRASS GIS Development Team
+   \author GRASS Development Team
  */
 
 #include <stdio.h>
@@ -78,16 +78,15 @@ void G__gisinit(const char *version, const char *pgm)
             G_warning(_("Module built against version %s but "
                         "trying to use version %s. "
                         "In case of errors you need to rebuild the module "
-                        "against GRASS GIS version %s."),
+                        "against GRASS version %s."),
                       version, GIS_H_VERSION, GRASS_VERSION_STRING);
         }
         else {
-            G_fatal_error(
-                _("Module built against version %s but "
-                  "trying to use version %s. "
-                  "You need to rebuild GRASS GIS or untangle multiple "
-                  "installations."),
-                version, GIS_H_VERSION);
+            G_fatal_error(_("Module built against version %s but "
+                            "trying to use version %s. "
+                            "You need to rebuild GRASS or untangle multiple "
+                            "installations."),
+                          version, GIS_H_VERSION);
         }
     }
 
@@ -129,16 +128,15 @@ void G__no_gisinit(const char *version)
             G_warning(_("Module built against version %s but "
                         "trying to use version %s. "
                         "In case of errors you need to rebuild the module "
-                        "against GRASS GIS version %s."),
+                        "against GRASS version %s."),
                       version, GIS_H_VERSION, GRASS_VERSION_STRING);
         }
         else {
-            G_fatal_error(
-                _("Module built against version %s but "
-                  "trying to use version %s. "
-                  "You need to rebuild GRASS GIS or untangle multiple "
-                  "installations."),
-                version, GIS_H_VERSION);
+            G_fatal_error(_("Module built against version %s but "
+                            "trying to use version %s. "
+                            "You need to rebuild GRASS or untangle multiple "
+                            "installations."),
+                          version, GIS_H_VERSION);
         }
     }
     gisinit();

--- a/lib/gis/gislib.dox
+++ b/lib/gis/gislib.dox
@@ -1,4 +1,4 @@
-/*! \page gislib GRASS GIS General Library (aka GIS Library)
+/*! \page gislib GRASS General Library (aka GIS Library)
 <!-- doxygenized from "GRASS 5 Programmer's Manual"
      by M. Neteler 2/2004, 2005, 2006
   -->

--- a/lib/gis/is.c
+++ b/lib/gis/is.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2001-2014
  */

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2004-2008
  */

--- a/lib/gis/overwrite.c
+++ b/lib/gis/overwrite.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team, Martin Landa <landa.martin gmail.com>
+ * \author GRASS Development Team, Martin Landa <landa.martin gmail.com>
  */
 
 #include <stdlib.h>

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -52,7 +52,7 @@ void G__usage_html(void)
             " <meta http-equiv=\"content-language\" content=\"en-us\">\n");
     fprintf(stdout, " <meta name=\"viewport\" content=\"width=device-width, "
                     "initial-scale=1\">\n");
-    fprintf(stdout, " <title>%s - GRASS GIS manual</title>\n", st->pgm_name);
+    fprintf(stdout, " <title>%s - GRASS manual</title>\n", st->pgm_name);
     fprintf(stdout, " <meta name=\"description\" content=\"%s", st->pgm_name);
     if (st->module_info.description)
         fprintf(stdout, ": %s\">", st->module_info.description);

--- a/lib/gis/parser_rest.c
+++ b/lib/gis/parser_rest.c
@@ -44,7 +44,7 @@ void G__usage_rest(void)
         fprintf(stdout, "=");
     }
     fprintf(stdout, "\n");
-    fprintf(stdout, "%s - GRASS GIS manual\n", st->pgm_name);
+    fprintf(stdout, "%s - GRASS manual\n", st->pgm_name);
     fprintf(stdout, "=================");
     for (s = 0; s <= strlen(st->pgm_name); s++) {
         fprintf(stdout, "=");

--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -727,8 +727,8 @@ struct Option *G_define_standard_option(int opt)
         Opt->type = TYPE_STRING;
         Opt->required = NO;
         Opt->multiple = NO;
-        Opt->label = _("GRASS GIS database directory");
-        Opt->description = _("Default: path to the current GRASS GIS database");
+        Opt->label = _("GRASS database directory");
+        Opt->description = _("Default: path to the current GRASS database");
         Opt->gisprompt = "old,dbase,dbase";
         Opt->key_desc = "path";
         break;

--- a/lib/gis/percent.c
+++ b/lib/gis/percent.c
@@ -8,7 +8,7 @@
    This program is free software under the GNU General Public License
    (>=v2). Read the file COPYING that comes with GRASS for details.
 
-   \author GRASS GIS Development Team
+   \author GRASS Development Team
  */
 
 #include <stdio.h>

--- a/lib/gis/rhumbline.c
+++ b/lib/gis/rhumbline.c
@@ -21,7 +21,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/strlcat.c
+++ b/lib/gis/strlcat.c
@@ -6,7 +6,7 @@
  * If available, G_strlcat() calls system strlcat(), otherwise it uses
  * implementation by Todd C. Miller of OpenBSD.
  *
- * Addition to GRASS GIS by Nicklas Larsson, 2024
+ * Addition to GRASS by Nicklas Larsson, 2024
  *
  * Original OpenBSD implementation notes:
  *

--- a/lib/gis/testsuite/gis_lib_str_color.py
+++ b/lib/gis/testsuite/gis_lib_str_color.py
@@ -30,26 +30,26 @@ class StringToColorTestCase(TestCase):
         self.assertEqual(b.value, blue, msg="Wrong number for blue (%s)" % colors)
 
     def test_grass_format(self):
-        """Test GRASS GIS color format (RRR:GGG:BBB)"""
+        """Test GRASS color format (RRR:GGG:BBB)"""
         self.convert_color("50:150:250", 50, 150, 250)
 
     def test_grass_format_black(self):
-        """Test GRASS GIS color black color"""
+        """Test GRASS color black color"""
         self.convert_color("0:0:0", 0, 0, 0)
 
     def test_grass_format_white(self):
-        """Test GRASS GIS color white color"""
+        """Test GRASS color white color"""
         self.convert_color("255:255:255", 255, 255, 255)
 
     def test_grass_format_separators(self):
-        """Test GRASS GIS color format with all allowed separators"""
+        """Test GRASS color format with all allowed separators"""
         self.convert_color("50,150,250", 50, 150, 250)
         self.convert_color("50:150:250", 50, 150, 250)
         self.convert_color("50;150;250", 50, 150, 250)
         self.convert_color("50 150 250", 50, 150, 250)
 
     def test_grass_format_multiple_separators(self):
-        """Test GRASS GIS color format with duplicated separators"""
+        """Test GRASS color format with duplicated separators"""
         self.convert_color("50, 150, 250", 50, 150, 250)
         self.convert_color("50::150:250", 50, 150, 250)
         self.convert_color("50  ; 150 ; 250", 50, 150, 250)
@@ -93,11 +93,11 @@ class StringToColorTestCase(TestCase):
         self.convert_color("#FFFFFF", 255, 255, 255)
 
     def test_grass_named_black(self):
-        """Test GRASS GIS color black color"""
+        """Test GRASS color black color"""
         self.convert_color("black", 0, 0, 0)
 
     def test_grass_named_white(self):
-        """Test GRASS GIS color white color"""
+        """Test GRASS color white color"""
         self.convert_color("white", 255, 255, 255)
 
 

--- a/lib/gis/wind_2_box.c
+++ b/lib/gis/wind_2_box.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/wind_limits.c
+++ b/lib/gis/wind_limits.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/wind_overlap.c
+++ b/lib/gis/wind_overlap.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/wr_cellhd.c
+++ b/lib/gis/wr_cellhd.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gis/writ_zeros.c
+++ b/lib/gis/writ_zeros.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 1999-2014
  */

--- a/lib/gmath/dalloc.c
+++ b/lib/gmath/dalloc.c
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2004-2006
  */

--- a/lib/gmath/fft.c
+++ b/lib/gmath/fft.c
@@ -18,7 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2001-2006
  */

--- a/lib/gmath/findzc.c
+++ b/lib/gmath/findzc.c
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  * \author Brad Douglas - rez at touchofmadness com
  *
  * \date 2006

--- a/lib/gmath/ialloc.c
+++ b/lib/gmath/ialloc.c
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2004-2006
  */

--- a/lib/gmath/la.c
+++ b/lib/gmath/la.c
@@ -9,7 +9,7 @@
  * 2006-11-23
  * 2015-01-20
 
- * This file is part of GRASS GIS. It is free software. You can
+ * This file is part of GRASS. It is free software. You can
  * redistribute it and/or modify it under the terms of
  * the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option)

--- a/lib/init/grass.html
+++ b/lib/init/grass.html
@@ -52,7 +52,7 @@
 <dd> Prints GRASS configuration parameters (options: arch, build, compiler, date, path, python_path, revision, svn_revision, version)
 
 <dt><b>--exec EXECUTABLE</b>
-<dd> Execute GRASS module or script. The provided executable will be executed in a GRASS GIS non-interactive session.
+<dd> Execute GRASS module or script. The provided executable will be executed in a GRASS non-interactive session.
 
 <dt><b>--tmp-project</b>
 <dd> Run using a temporary project which is created based on the given
@@ -93,7 +93,7 @@ following ways:
 
 <h2>DESCRIPTION</h2>
 
-<p>This command is used to launch GRASS GIS. It will parse the command
+<p>This command is used to launch GRASS. It will parse the command
 line arguments and then initialize GRASS for the user. Since GRASS
 modules require a specific environment, this program must be called
 before any other GRASS module can run. The command line arguments are
@@ -124,7 +124,7 @@ the subprocess itself can be interactive if that is what the user requires.
 
 <h3>Config flag</h3>
 
-The flag <b>--config option</b> prints GRASS GIS configuration and
+The flag <b>--config option</b> prints GRASS configuration and
 version parameters, with the options:
 
 <ul>
@@ -141,7 +141,7 @@ version parameters, with the options:
 
 <h2>SAMPLE DATA</h2>
 
-The GRASS GIS project provides several free sample geospatial datasets
+The GRASS project provides several free sample geospatial datasets
 as ready-to-use projects. They are available to download at
 <a href="https://grass.osgeo.org/download/sample-data/">https://grass.osgeo.org/download/sample-data/</a>.
 
@@ -363,7 +363,7 @@ A very simple Python script ("test.py") may look like this:
 # import GRASS Python bindings (see also pygrass)
 import grass.script as gs
 
-gs.message('Current GRASS GIS environment:')
+gs.message('Current GRASS environment:')
 print(gs.gisenv())
 
 gs.message('Available raster maps:')
@@ -480,10 +480,10 @@ GRASS_PYTHON environmental variable.
 List of <a href="variables.html">GRASS environment variables</a>
 
 <p>
-<a href="https://grass.osgeo.org">GRASS GIS Web site</a><br>
-<a href="https://grasswiki.osgeo.org/wiki/">GRASS GIS User Wiki</a><br>
-<a href="https://github.com/OSGeo/grass/issues">GRASS GIS Bug Tracker</a><br>
-<a href="https://grass.osgeo.org/programming8/">GRASS GIS 8 Programmer's Manual</a>
+<a href="https://grass.osgeo.org">GRASS Web site</a><br>
+<a href="https://grasswiki.osgeo.org/wiki/">GRASS User Wiki</a><br>
+<a href="https://github.com/OSGeo/grass/issues">GRASS Bug Tracker</a><br>
+<a href="https://grass.osgeo.org/programming8/">GRASS 8 Programmer's Manual</a>
 
 <h2>AUTHORS (of this page)</h2>
 

--- a/lib/init/helptext.html
+++ b/lib/init/helptext.html
@@ -1,26 +1,26 @@
-<!-- meta page description: GRASS GIS Quickstart -->
+<!-- meta page description: GRASS Quickstart -->
 
 <p>
-When <a href="grass.html">launching</a> GRASS GIS for the first time, you will open a
+When <a href="grass.html">launching</a> GRASS for the first time, you will open a
 <b>default project</b> "world_latlog_wgs84" where you can find a map layer
 called "country_boundaries" showing a world map in the WGS84 coordinate system.
 </p>
 
 <center>
-  <img src="grass_start.png" alt="[GRASS GIS after first startup]">
+  <img src="grass_start.png" alt="[GRASS after first startup]">
 </center>
 
 <br>
 <p>
 The main component of the Data tab is the <em>Data Catalog</em>
-which shows the GRASS GIS hierarchical structure consisting of
+which shows the GRASS hierarchical structure consisting of
 database <img src="grassdb.png" alt="[GRASS Database]">,
 project <img src="location.png" alt="[project]"> and
 mapset <img src="mapset.png" alt="[mapset]">.
 </p>
 <dl>
   <dt><img src="grassdb.png" alt="[GRASS Database]">&nbsp;<b>GRASS database</b> (directory with projects)</dt>
-  <dd>Running GRASS GIS for the first time, a folder named "grassdata" is automatically
+  <dd>Running GRASS for the first time, a folder named "grassdata" is automatically
     created. Depending on your operating system, you can find it in your $HOME
     directory (*nix) or My Documents (MS Windows).</dd>
   <dt><img src="location.png" alt="[project]">&nbsp;<b>project</b> (previously called location)</dt>
@@ -30,14 +30,14 @@ mapset <img src="mapset.png" alt="[mapset]">.
     a new project corresponding to your system.</dd>
   <dt><img src="mapset.png" alt="[mapset]">&nbsp;<b>mapset</b> (a subproject)</dt>
   <dd>Each project can have many mapsets for managing different aspects of
-    a project or project's subregions. When creating a new project, GRASS GIS
+    a project or project's subregions. When creating a new project, GRASS
     automatically creates a special mapset called PERMANENT where the core
     data for the project can be stored.</dd>
 </dl>
 
 <p>
 For more info about data hierarchy, see
-<a href="grass_database.html">GRASS GIS Database</a> page.
+<a href="grass_database.html">GRASS Database</a> page.
 </p>
 
 <h2>GRASS started in the default project, now what?</h2>
@@ -83,17 +83,17 @@ To analyze your data, search for a tool in the Modules tab.
 
 <h2>Text-based startup and project creation</h2>
 
-GRASS GIS can be run entirely without using the graphical user interface.
-See <a href="grass.html">examples</a> of running GRASS GIS from a command line.
+GRASS can be run entirely without using the graphical user interface.
+See <a href="grass.html">examples</a> of running GRASS from a command line.
 
 <h2>See also</h2>
 
 <em>
- <a href="index.html">GRASS GIS Reference Manual</a>
+ <a href="index.html">GRASS Reference Manual</a>
 <br>
- <a href="grass.html">GRASS GIS startup program manual page</a>
+ <a href="grass.html">GRASS startup program manual page</a>
  <br>
- <a href="https://grass.osgeo.org/learn/">GRASS GIS tutorials and books</a>
+ <a href="https://grass.osgeo.org/learn/">GRASS tutorials and books</a>
 </em>
 
 <p>

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 
 
-# Note that unlike rest of GRASS GIS, here we are using unittest package
+# Note that unlike rest of GRASS, here we are using unittest package
 # directly. The grass.gunittest machinery for mapsets is not needed here.
 # How this plays out together with the rest of testing framework is yet to be
 # determined.
@@ -29,7 +29,7 @@ import subprocess
 class TestTmpMapset(unittest.TestCase):
     """Tests --tmp-mapset option of grass command"""
 
-    # TODO: here we need a name of or path to the main GRASS GIS executable
+    # TODO: here we need a name of or path to the main GRASS executable
     # TODO: support OSGeo4W executable with:
     # executable = "grass" if os.name != "nt" else "grass85.bat"
     executable = "grass" if os.name != "nt" else "grass.bat"

--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -5,7 +5,7 @@ used and modified during script execution. Variables allow scripts to
 store and manipulate values dynamically, making them more flexible and
 reusable.
 
-In GRASS GIS, there are two types of variables:
+In GRASS, there are two types of variables:
 <ul>
 <li><a href="#setting-shell-environment-variables">shell
 environment</a> variables,</li>
@@ -396,7 +396,7 @@ PERMANENT
     Setting to '1' effectively disables parallel processing.</dd>
 
   <dt>TMPDIR, TEMP, TMP</dt>
-  <dd>[Various GRASS GIS commands and wxGUI]<br>
+  <dd>[Various GRASS commands and wxGUI]<br>
   <!-- what about Windows %TEMP% and https://trac.osgeo.org/grass/ticket/560#comment:21 ? -->
       The default wxGUI temporary directory is chosen from a
       platform-dependent list, but the user can control the selection of

--- a/lib/raster/auto_mask.c
+++ b/lib/raster/auto_mask.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  * \author Vaclav Petras (environmental variable and refactoring)
  */
 

--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -8,7 +8,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2000-2008
  */
@@ -32,7 +32,7 @@ static int initialized = 0; /** Is set when engine is initialized */
 static int init(void);
 
 /**
- * \brief Initialize GRASS GIS engine.
+ * \brief Initialize GRASS engine.
  *
  * Initializes GIS engine and ensures a valid mapset is available.
  *

--- a/lib/raster/testsuite/rast_parse_color_rule.py
+++ b/lib/raster/testsuite/rast_parse_color_rule.py
@@ -66,14 +66,14 @@ class ParseSingleColorRuleColorsTestCase(TestCase):
         self.assertEqual(b.value, blue, msg="Wrong number for blue (%s)" % colors)
 
     def test_grass_format_separators(self):
-        """Test GRASS GIS color format with all allowed separators"""
+        """Test GRASS color format with all allowed separators"""
         self.convert_rule("15% 50,150,250", 15, 50, 150, 250)
         self.convert_rule("15% 50:150:250", 15, 50, 150, 250)
         self.convert_rule("15 50;150;250", 15, 50, 150, 250)
         self.convert_rule("15 50 150 250", 15, 50, 150, 250)
 
     def test_grass_format_multiple_separators(self):
-        """Test GRASS GIS color format with duplicated separators"""
+        """Test GRASS color format with duplicated separators"""
         self.convert_rule("15%  50, 150, 250", 15, 50, 150, 250)
         self.convert_rule("15%   50::150:250", 15, 50, 150, 250)
         self.convert_rule("15   50  ; 150 ; 250", 15, 50, 150, 250)
@@ -96,7 +96,7 @@ class ParseSingleColorRuleColorsTestCase(TestCase):
         self.convert_rule("15 #fB9A99", 15, 251, 154, 153)
 
     def test_grass_named(self):
-        """Test GRASS GIS named colors"""
+        """Test GRASS named colors"""
         self.convert_rule("15% black   ", 15, 0, 0, 0)
         self.convert_rule("15    white", 15, 255, 255, 255)
         self.convert_rule("   15 white", 15, 255, 255, 255)

--- a/lib/raster3d/rle.c
+++ b/lib/raster3d/rle.c
@@ -266,7 +266,7 @@ void Rast3d_rle_decode(char *src, char *dst, int nofElts, int eltLength,
 /*---------------------------------------------------------------------------*/
 
 /* TODO: Find out if this function used at all.
- * Seems to be some leftover from the early pre-SVN days of GRASS GIS.
+ * Seems to be some leftover from the early pre-SVN days of GRASS.
  * Maris, 2018.
  */
 void test_rle(void)

--- a/lib/segment/address.c
+++ b/lib/segment/address.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/close.c
+++ b/lib/segment/close.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2018
  */

--- a/lib/segment/flush.c
+++ b/lib/segment/flush.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/format.c
+++ b/lib/segment/format.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2018
  */

--- a/lib/segment/get.c
+++ b/lib/segment/get.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2018
  */

--- a/lib/segment/get_row.c
+++ b/lib/segment/get_row.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2018
  */

--- a/lib/segment/open.c
+++ b/lib/segment/open.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2018
  */

--- a/lib/segment/pagein.c
+++ b/lib/segment/pagein.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/pageout.c
+++ b/lib/segment/pageout.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/put.c
+++ b/lib/segment/put.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2018
  */

--- a/lib/segment/put_row.c
+++ b/lib/segment/put_row.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2018
  */

--- a/lib/segment/release.c
+++ b/lib/segment/release.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/seek.c
+++ b/lib/segment/seek.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/lib/segment/setup.c
+++ b/lib/segment/setup.c
@@ -6,7 +6,7 @@
  * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
- * \author GRASS GIS Development Team
+ * \author GRASS Development Team
  *
  * \date 2005-2009
  */

--- a/macos/ReadMe.md
+++ b/macos/ReadMe.md
@@ -1,11 +1,11 @@
-# Build GRASS GIS with Anaconda
+# Build GRASS with Anaconda
 
-This is a script package for automated build of GRASS GIS as a macOS
+This is a script package for automated build of GRASS as a macOS
 application bundle (GRASS-x.x.app).
 
 The building script `build_grass_app.bash` will do all the steps – creating App
 bundle, installing Conda dependencies (using the package manager Miniforge),
-to patching, compiling and installing GRASS GIS – to end up with an
+to patching, compiling and installing GRASS – to end up with an
 installed GRASS.app in `/Applications`. It can also create a compressed dmg
 file if so wished.
 

--- a/macos/build_grass_app.bash
+++ b/macos/build_grass_app.bash
@@ -4,7 +4,7 @@
 #
 # TOOL:         build_grass_app.bash
 # AUTHOR(s):    Nicklas Larsson
-# PURPOSE:      Build and bundle GRASS GIS app for macOS
+# PURPOSE:      Build and bundle GRASS app for macOS
 # COPYRIGHT:    (c) 2020-2025 Nicklas Larsson and the GRASS Development Team
 #               (c) 2020 Michael Barton
 #               (c) 2018 Eric Hutton, Community Surface Dynamics Modeling
@@ -88,7 +88,7 @@ fi
 
 function display_usage () { cat <<- _EOF_
 
-GRASS GIS build script for Anaconda.
+GRASS build script for Anaconda.
 
 Description...
 
@@ -679,8 +679,8 @@ fi
 
 patch_grass
 
-begingroup "Build and install GRASS GIS"
-# configure and compile GRASS GIS
+begingroup "Build and install GRASS"
+# configure and compile GRASS
 
 pushd "$grassdir" > /dev/null || exit
 

--- a/macos/files/configure-grass.sh
+++ b/macos/files/configure-grass.sh
@@ -4,7 +4,7 @@
 #
 # TOOL:         configure-grass.sh
 # AUTHOR(s):    Nicklas Larsson
-# PURPOSE:      Sets up configure and compiler flags and configures GRASS GIS
+# PURPOSE:      Sets up configure and compiler flags and configures GRASS
 # COPYRIGHT:    (c) 2020-2025 Nicklas Larsson and the GRASS Development Team
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/macos/files/grass.sh.in
+++ b/macos/files/grass.sh.in
@@ -7,7 +7,7 @@
 #               William Kyngesburye - kyngchaos@kyngchaos.com
 #               Eric Hutton
 #               Michael Barton - michael.barton@asu.edu
-# PURPOSE:      The GRASS GIS startup script for the macOS application.
+# PURPOSE:      The GRASS startup script for the macOS application.
 # COPYRIGHT:    (c) 2000-2025 by the GRASS Development Team
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -33,9 +33,7 @@ modclass = sys.argv[2]
 
 filename = modclass + ".txt"
 with open(filename + ".tmp", "wb") as f:
-    write_rest_header(
-        f, "GRASS GIS %s Reference Manual: %s" % (grass_version, modclass)
-    )
+    write_rest_header(f, "GRASS %s Reference Manual: %s" % (grass_version, modclass))
     if modclass.lower() not in {"general", "miscellaneous", "postscript"}:
         f.write(
             modclass_intro_tmpl.substitute(

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -35,7 +35,7 @@ classes.sort()
 # begin full index:
 filename = "full_index.txt"
 with open(filename + ".tmp", "wb") as f:
-    write_rest_header(f, "GRASS GIS %s Reference Manual: Full index" % grass_version)
+    write_rest_header(f, "GRASS %s Reference Manual: Full index" % grass_version)
 
     # generate main index of all modules:
     f.write(full_index_header)

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -9,7 +9,7 @@ header1_tmpl = string.Template(
 <html>
 <head>
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
- <title>${title} - GRASS GIS Manual</title>
+ <title>${title} - GRASS Manual</title>
  <meta name="Author" content="GRASS Development Team">
  <meta http-equiv="content-language" content="en-us">
  <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -18,7 +18,7 @@ header1_tmpl = string.Template(
 
 macosx_tmpl = string.Template(
     r"""
- <meta name="AppleTitle" content="GRASS GIS ${grass_version} Help">
+ <meta name="AppleTitle" content="GRASS ${grass_version} Help">
  <meta name="AppleIcon" content="GRASS-${grass_mmver}/grass_icon.png">
  <meta name="robots" content="anchors">
 """
@@ -34,10 +34,10 @@ header2_tmpl = string.Template(
 <a href="index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
 <hr class="header">
 
-<h2>GRASS GIS ${grass_version} Reference Manual</h2>
+<h2>GRASS ${grass_version} Reference Manual</h2>
 
 <p><b>Geographic Resources Analysis Support System</b>, commonly
-referred to as <a href="https://grass.osgeo.org">GRASS GIS</a>, is a <a
+referred to as <a href="https://grass.osgeo.org">GRASS</a>, is a <a
 href="https://en.wikipedia.org/wiki/Geographic_information_system">Geographic
 Information System</a> (GIS) used for geospatial data management and
 analysis, image processing, graphics/maps production, spatial
@@ -62,7 +62,7 @@ overview_tmpl = string.Template(
     <tr>
       <td width="33%" valign="top" class="box"><h3>&nbsp;Quick Introduction</h3>
       <ul>
-       <li class="box"><a href="helptext.html">How to start with GRASS GIS</a></li>
+       <li class="box"><a href="helptext.html">How to start with GRASS</a></li>
        <li class="box"><span>Index of <a href="topics.html">topics</a> and <a href="keywords.html">keywords</a></span></li>
       </ul>
       <p>
@@ -96,7 +96,7 @@ overview_tmpl = string.Template(
       </td>
       <td width="33%" valign="top" class="box"><h3>&nbsp;General</h3>
        <ul>
-        <li class="box"><a href="grass.html">GRASS GIS startup manual</a></li>
+        <li class="box"><a href="grass.html">GRASS startup manual</a></li>
         <li class="box"><a href="general.html">General commands manual</a></li>
        </ul>
         <h3>&nbsp;Addons</h3>
@@ -137,7 +137,7 @@ overview_tmpl = string.Template(
       <td width="33%" valign="top" class="box"><h3>&nbsp;Database</h3>
        <ul>
         <li class="box"><a href="databaseintro.html">Intro: database management</a></li>
-        <li class="box"><a href="sql.html">SQL support in GRASS GIS</a></li>
+        <li class="box"><a href="sql.html">SQL support in GRASS</a></li>
         <li class="box"><a href="database.html">Database commands manual</a></li>
        </ul>
       </td>
@@ -163,9 +163,9 @@ overview_tmpl = string.Template(
       </td>
       <td width="33%" valign="top" class="box"><h3>&nbsp;Python</h3>
        <ul>
-        <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/index.html">GRASS GIS Python library documentation</a></li>
+        <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/index.html">GRASS Python library documentation</a></li>
         <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/pygrass_index.html">PyGRASS documentation</a></li>
-        <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/grass.jupyter.html">GRASS GIS in Jupyter Notebooks</a></li>
+        <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/grass.jupyter.html">GRASS in Jupyter Notebooks</a></li>
        </ul>
       </td>
     </tr>
@@ -211,7 +211,7 @@ footer_tmpl = string.Template(  # TODO: https://trac.osgeo.org/grass/ticket/3987
 <p>
 &copy; 2003-${year}
 <a href="https://grass.osgeo.org">GRASS Development Team</a>,
-GRASS GIS ${grass_version} Reference Manual
+GRASS ${grass_version} Reference Manual
 </p>
 
 </div>
@@ -310,7 +310,7 @@ headerkeywords_tmpl = r"""
 
 <a href="index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
 <hr class="header">
-<h2>Keywords - Index of GRASS GIS modules</h2>
+<h2>Keywords - Index of GRASS modules</h2>
 """
 # "
 
@@ -402,7 +402,7 @@ header_graphical_index_tmpl = """\
 
 <a href="index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
 <hr class="header">
-<h2>Graphical index of GRASS GIS modules</h2>
+<h2>Graphical index of GRASS modules</h2>
 """
 
 

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -22,7 +22,7 @@ os.chdir(rest_dir)
 
 filename = "index.txt"
 with open(filename + ".tmp", "w") as f:
-    write_rest_header(f, "GRASS GIS %s Reference Manual" % grass_version, True)
+    write_rest_header(f, "GRASS %s Reference Manual" % grass_version, True)
     write_rest_cmd_overview(f)
     write_rest_footer(f, "index.txt")
 

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -39,17 +39,17 @@ desc_override = {
 header2_tmpl = string.Template(
     r"""
 ==================================================================
-GRASS GIS ${grass_version} Reference Manual
+GRASS ${grass_version} Reference Manual
 ==================================================================
 .. figure:: grass_logo.png
    :align: center
    :alt: GRASS logo
 
-GRASS GIS ${grass_version} Reference Manual
+GRASS ${grass_version} Reference Manual
 --------------------------------------------------------------------
 
 **Geographic Resources Analysis Support System**, commonly
-referred to as `GRASS GIS <https://grass.osgeo.org>`_, is a `Geographic
+referred to as `GRASS <https://grass.osgeo.org>`_, is a `Geographic
 Information System <https://en.wikipedia.org/wiki/Geographic_information_system>`_
 (GIS) used for geospatial data management and analysis, image processing,
 graphics/maps production, spatial modeling, and visualization. GRASS is
@@ -123,7 +123,7 @@ Database
 .. toctree::
     :maxdepth: 1
 
-        SQL support in GRASS GIS <sql>
+        SQL support in GRASS <sql>
         Database commands manual <database>
 
 General
@@ -170,7 +170,7 @@ footer_tmpl = string.Template(
 --------------
 
 :doc:`Manual main page <index>` \| :doc:`Full Index <full_index>`
- 2003-2025 `GRASS Development Team <https://grass.osgeo.org>`_, GRASS GIS ${grass_version} Reference Manual
+ 2003-2025 `GRASS Development Team <https://grass.osgeo.org>`_, GRASS ${grass_version} Reference Manual
 """  # noqa: E501
 )
 

--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -1,6 +1,6 @@
 ;----------------------------------------------------------------------------------------------------------------------------
 
-;GRASS GIS Installer for Windows
+;GRASS Installer for Windows
 ;Written by Marco Pasetti
 ;Updated for OSGeo4W by Colin Nielsen, Helmut Kudrnovsky, and Martin Landa
 ;Last Update: $Id$
@@ -463,7 +463,7 @@ FunctionEnd
 
 ;----------------------------------------------------------------------------------------------------------------------------
 
-;launch Grass Gis by exit the installation wizard
+;launch GRASS by exit the installation wizard
 
 Function LaunchGrass
 

--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -4,7 +4,7 @@
 #
 # MODULE:	crosscompile.sh
 # AUTHOR(S):	Huidae Cho <grass4u gmail.com>
-# PURPOSE:	Builds a cross-compiled portable package of GRASS GIS
+# PURPOSE:	Builds a cross-compiled portable package of GRASS
 # COPYRIGHT:	(C) 2019-2021 by Huidae Cho and the GRASS Development Team
 #
 #		This program is free software under the GNU General Public

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -8,7 +8,7 @@
 #
 # By default, the script will look for the source code in the current directory
 # and create bin.x86_64-w64-mingw32\grass$ver.bat (run this batch file to start
-# GRASS GIS) and dist.x86_64-w64-mingw32\etc\env.bat.
+# GRASS) and dist.x86_64-w64-mingw32\etc\env.bat.
 #
 
 # stop on errors

--- a/mswindows/osgeo4w/grass.bat.tmpl
+++ b/mswindows/osgeo4w/grass.bat.tmpl
@@ -13,6 +13,6 @@ call "%OSGEO4W_ROOT%\apps\grass\grass@POSTFIX@\etc\env.bat"
 @echo off
 
 rem
-rem Launch GRASS GIS
+rem Launch GRASS
 rem
 "%GRASS_PYTHON%" "%GISBASE%\etc\grass@POSTFIX@.py" %*

--- a/mswindows/osgeo4w/libpng-config
+++ b/mswindows/osgeo4w/libpng-config
@@ -10,7 +10,7 @@
 # and license in png.h
 
 # Modeled after libxml-config.
-# Adopted for GRASS GIS by Huidae Cho
+# Adopted for GRASS by Huidae Cho
 
 prefix="${OSGEO4W_ROOT_MSYS}"
 version="$(sed '/^#define PNG_LIBPNG_VER_STRING/!d; s/^[^"]*"\|"//g' ${prefix}/include/libpng*/png.h)"

--- a/mswindows/osgeo4w/setup.hint.tmpl
+++ b/mswindows/osgeo4w/setup.hint.tmpl
@@ -1,5 +1,5 @@
-sdesc: "GRASS GIS - daily builds of development version"
-ldesc: "Geographic Resources Analysis Support System (GRASS GIS) - daily builds of the main branch from Git"
+sdesc: "GRASS - daily builds of development version"
+ldesc: "Geographic Resources Analysis Support System (GRASS) - daily builds of the main branch from Git"
 category: Desktop
 requires: liblas gdal303-runtime proj81-runtime avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2-binary zstd python3-pywin32
 maintainer: MartinLanda

--- a/python/grass/__init__.py
+++ b/python/grass/__init__.py
@@ -10,7 +10,7 @@
 #           License (>=v2). Read the file COPYING that comes with GRASS
 #           for details.
 
-"""Top-level GRASS GIS Python package
+"""Top-level GRASS Python package
 
 Importing the package (or any subpackage) initializes translation functions
 so that the function ``_`` appears in the global namespace (as an additional built-in).
@@ -22,7 +22,7 @@ import os
 
 # Setup translations
 #
-# The translations in the GRASS GIS Python package grass, GRASS Python modules
+# The translations in the GRASS Python package grass, GRASS Python modules
 # (scripts), and the wxPython GUI (wxGUI) are handled as application translations,
 # rather than Python module or package translations. This means that that translation
 # function called `_` (underscore) is added to buildins namespace. When the grass

--- a/python/grass/app/data.py
+++ b/python/grass/app/data.py
@@ -1,4 +1,4 @@
-"""Provides functions for the main GRASS GIS executable
+"""Provides functions for the main GRASS executable
 
 (C) 2020-2025 by Vaclav Petras and the GRASS Development Team
 
@@ -51,7 +51,7 @@ def get_possible_database_path():
 
 
 def create_database_directory():
-    """Creates the standard GRASS GIS directory.
+    """Creates the standard GRASS directory.
     Creates database directory named grassdata in the standard location
     according to the platform.
 

--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -1,4 +1,4 @@
-"""Provides functions for the main GRASS GIS executable
+"""Provides functions for the main GRASS executable
 
 (C) 2024-2025 by Vaclav Petras and the GRASS Development Team
 
@@ -89,7 +89,7 @@ class RuntimePaths:
 def get_grass_config_dir(major_version, minor_version, env):
     """Get configuration directory
 
-    Determines path of GRASS GIS user configuration directory.
+    Determines path of GRASS user configuration directory.
     """
     if env.get("GRASS_CONFIG_DIR"):
         # use GRASS_CONFIG_DIR environmental variable is defined

--- a/python/grass/benchmark/__init__.py
+++ b/python/grass/benchmark/__init__.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #
@@ -10,7 +10,7 @@
 #            License (>=v2). Read the file COPYING that comes with GRASS
 #            for details.
 
-"""Benchmarking for GRASS GIS modules
+"""Benchmarking for GRASS modules
 
 This subpackage of the grass package is experimental and the API can change anytime.
 The API of the package is defined by what is imported in the top-level ``__init__.py``

--- a/python/grass/benchmark/__main__.py
+++ b/python/grass/benchmark/__main__.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/app.py
+++ b/python/grass/benchmark/app.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -3,7 +3,7 @@
 # AUTHOR(S): Aaron Saw Min Sern <aaronsms u nus edu>
 #            Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/testsuite/test_benchmark.py
+++ b/python/grass/benchmark/testsuite/test_benchmark.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/benchmark/testsuite/test_benchmark_cli.py
+++ b/python/grass/benchmark/testsuite/test_benchmark_cli.py
@@ -2,7 +2,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Benchmarking for GRASS GIS modules
+# PURPOSE:   Benchmarking for GRASS modules
 #
 # COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
 #

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -404,7 +404,7 @@ texinfo_documents = [
         project,
         "GRASS Development Team",
         "PythonLib",
-        "Documentation for Python API of GRASS GIS",
+        "Documentation for Python API of GRASS",
         "Miscellaneous",
     ),
 ]

--- a/python/grass/docs/src/pygrass_index.rst
+++ b/python/grass/docs/src/pygrass_index.rst
@@ -17,8 +17,8 @@ for the new GUI. Due to this Python became more and more important
 and developers converted all shell scripts from GRASS GIS 6 to Python
 for GRASS GIS 7.
 
-To work with *PyGRASS* you need an up-to-date version of GRASS
-GIS. The only action before starting to work with *PyGRASS* is
+To work with *PyGRASS* you need an up-to-date version of GRASS.
+The only action before starting to work with *PyGRASS* is
 to launch GRASS 8 and from the console launch *python* or
 *ipython* (the second one is the recommended way).
 

--- a/python/grass/exceptions/__init__.py
+++ b/python/grass/exceptions/__init__.py
@@ -1,4 +1,4 @@
-"""GRASS GIS interface to Python exceptions"""
+"""GRASS interface to Python exceptions"""
 
 import subprocess
 

--- a/python/grass/grassdb/checks.py
+++ b/python/grass/grassdb/checks.py
@@ -1,5 +1,5 @@
 """
-Checking objects in a GRASS GIS Spatial Database
+Checking objects in a GRASS Spatial Database
 
 (C) 2020 by the GRASS Development Team
 This program is free software under the GNU General Public
@@ -27,7 +27,7 @@ def mapset_exists(path: str | os.PathLike[str], location=None, mapset=None) -> b
 
     Either only *path* is provided or all three parameters need to be provided.
 
-    :param path: Path to a Mapset or to a GRASS GIS database directory
+    :param path: Path to a Mapset or to a GRASS database directory
     :param location: name of a Location if not part of *path*
     :param mapset: name of a Mapset if not part of *path*
     """
@@ -41,7 +41,7 @@ def mapset_exists(path: str | os.PathLike[str], location=None, mapset=None) -> b
 def location_exists(path: str | os.PathLike[str], location=None) -> bool:
     """Returns True whether location path exists.
 
-    :param path: Path to a Location or to a GRASS GIS database directory
+    :param path: Path to a Location or to a GRASS database directory
     :param location: name of a Location if not part of *path*
     """
     if location:
@@ -57,7 +57,7 @@ def is_mapset_valid(path: str | os.PathLike[str], location=None, mapset=None) ->
 
     Either only *path* is provided or all three parameters need to be provided.
 
-    :param path: Path to a Mapset or to a GRASS GIS database directory
+    :param path: Path to a Mapset or to a GRASS database directory
     :param location: name of a Location if not part of *path*
     :param mapset: name of a Mapset if not part of *path*
     """
@@ -75,7 +75,7 @@ def is_mapset_valid(path: str | os.PathLike[str], location=None, mapset=None) ->
 def is_location_valid(path: str | os.PathLike[str], location=None) -> bool:
     """Return True if GRASS Location is valid
 
-    :param path: Path to a Location or to a GRASS GIS database directory
+    :param path: Path to a Location or to a GRASS database directory
     :param location: name of a Location if not part of *path*
     """
     # DEFAULT_WIND file should not be required until you do something
@@ -255,7 +255,7 @@ def get_mapset_invalid_reason(database, location, mapset, none_for_no_reason=Fal
     The goal is to provide the most suitable error message
     (rather than to do a quick check).
 
-    :param database: Path to GRASS GIS database directory
+    :param database: Path to GRASS database directory
     :param location: name of a Location
     :param mapset: name of a Mapset
     :returns: translated message
@@ -315,7 +315,7 @@ def get_location_invalid_reason(
     diagnostic. When this function fails to find reason for invalidity, other
     the caller can continue the investigation in their context.
 
-    :param database: Path to GRASS GIS database directory
+    :param database: Path to GRASS database directory
     :param location: name of a Location
     :param none_for_no_reason: When True, return None when reason is unknown
     :returns: translated message or None

--- a/python/grass/grassdb/config.py
+++ b/python/grass/grassdb/config.py
@@ -1,5 +1,5 @@
 """
-Set global variables for objects in a GRASS GIS Spatial Database
+Set global variables for objects in a GRASS Spatial Database
 
 (C) 2020 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/python/grass/grassdb/create.py
+++ b/python/grass/grassdb/create.py
@@ -1,5 +1,5 @@
 """
-Create objects in GRASS GIS Spatial Database
+Create objects in GRASS Spatial Database
 
 (C) 2020 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/python/grass/grassdb/data.py
+++ b/python/grass/grassdb/data.py
@@ -1,5 +1,5 @@
 """
-Manipulate data in mapsets in GRASS GIS Spatial Database
+Manipulate data in mapsets in GRASS Spatial Database
 
 (C) 2020 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -1,5 +1,5 @@
 """
-Managing existing objects in a GRASS GIS Spatial Database
+Managing existing objects in a GRASS Spatial Database
 
 (C) 2020 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/python/grass/gunittest/README.md
+++ b/python/grass/gunittest/README.md
@@ -1,4 +1,4 @@
-# Testing GRASS GIS source code and modules
+# Testing GRASS source code and modules
 
 For more information on the test suite and unit tests, visit:
 

--- a/python/grass/gunittest/__init__.py
+++ b/python/grass/gunittest/__init__.py
@@ -3,7 +3,7 @@ GRASS Python testing framework module for running from command line
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras, Soeren Gebbert

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -3,7 +3,7 @@ GRASS Python testing framework test case
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/checkers.py
+++ b/python/grass/gunittest/checkers.py
@@ -3,7 +3,7 @@ GRASS Python testing framework checkers
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras, Soeren Gebbert

--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -3,7 +3,7 @@ Specialized interfaces for invoking modules for testing framework
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras, Soeren Gebbert

--- a/python/grass/gunittest/gutils.py
+++ b/python/grass/gunittest/gutils.py
@@ -1,9 +1,9 @@
 """
-Utilities related to GRASS GIS for GRASS Python testing framework
+Utilities related to GRASS for GRASS Python testing framework
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -3,7 +3,7 @@ GRASS Python testing framework test files invoker (runner)
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -3,7 +3,7 @@ GRASS Python testing framework test loading functionality
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras, Edouard Choinière

--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -3,7 +3,7 @@ GRASS Python testing framework module for running from command line
 
 Copyright (C) 2014-2021 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/multireport.py
+++ b/python/grass/gunittest/multireport.py
@@ -3,7 +3,7 @@ Testing framework module for multi report
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -3,7 +3,7 @@ Testing framework module for running tests in Python unittest fashion
 
 Copyright (C) 2014-2021 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras
@@ -73,11 +73,9 @@ def main():
     )
     # TODO: rename since every src can be used?
     parser.add_argument(
-        "--grasssrc", required=True, help="GRASS GIS source code (to take tests from)"
+        "--grasssrc", required=True, help="GRASS source code (to take tests from)"
     )
-    parser.add_argument(
-        "--grassdata", required=True, help="GRASS GIS data base (GISDBASE)"
-    )
+    parser.add_argument("--grassdata", required=True, help="GRASS data base (GISDBASE)")
     parser.add_argument(
         "--create-main-report",
         help="Create also main report for all tests",
@@ -107,7 +105,7 @@ def main():
     grass_executable = args.grassbin
 
     # Software
-    # query GRASS GIS itself for its GISBASE
+    # query GRASS itself for its GISBASE
     # we assume that the start script is available and in the PATH
     # the shell=True is here because of MS Windows? (code taken from wiki)
     startcmd = grass_executable + " --config path"
@@ -117,7 +115,7 @@ def main():
         out, err = p.communicate()
         if p.returncode != 0:
             print(
-                "ERROR: Cannot find GRASS GIS start script (%s):\n%s" % (startcmd, err),
+                "ERROR: Cannot find GRASS start script (%s):\n%s" % (startcmd, err),
                 file=sys.stderr,
             )
             return 1

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -3,7 +3,7 @@ GRASS Python testing framework module for report generation
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -3,7 +3,7 @@ Testing framework module for running tests in Python unittest fashion
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -3,7 +3,7 @@ GRASS Python testing framework utilities (general and test-specific)
 
 Copyright (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Vaclav Petras

--- a/python/grass/imaging/README
+++ b/python/grass/imaging/README
@@ -1,7 +1,7 @@
 General
 =======
 
-This is a library for manipulating (non-geospatial) images in GRASS GIS.
+This is a library for manipulating (non-geospatial) images in GRASS.
 
 The images2*.py files are a part of visvis library [1], specifically
 visvis.vvmovie. The files are from the visvis-1.8 version.

--- a/python/grass/imaging/operations.py
+++ b/python/grass/imaging/operations.py
@@ -2,7 +2,7 @@
 Image non-geospatial operations and manipulations
 
 Note: Functions in this module are experimental and are not considered
-a stable API, i.e. may change in future releases of GRASS GIS.
+a stable API, i.e. may change in future releases of GRASS.
 
 It heavily relies on PIL but unlike PIL, the functions operate on
 files instead of PIL Image objects (which are used internally).

--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -4,7 +4,7 @@
 #            Vaclav Petras <wenzeslaus gmail com>
 #            Anna Petrasova <kratochanna gmail com>
 #
-# PURPOSE:   Display classes and setup functions for running GRASS GIS
+# PURPOSE:   Display classes and setup functions for running GRASS
 #            in Jupyter Notebooks
 #
 # COPYRIGHT: (C) 2021-2022 Caitlin Haedrich, and by the GRASS Development Team
@@ -13,7 +13,7 @@
 #            License (>=v2). Read the file COPYING that comes with GRASS
 #            for details.
 
-"""A convenient GRASS GIS interface for Jupyter notebooks.
+"""A convenient GRASS interface for Jupyter notebooks.
 
 Python is a great tool for data science and scientific computing. Jupyter_ is an
 environment with computational notebooks which makes it even better tool for
@@ -22,10 +22,10 @@ code, text, and results such as figures and tables. JupyterLab is an environment
 you interact with all these parts. You can install it locally on your machine or
 use it online from some service provider.
 
-The *grass.jupyter* subpackage improves the integration of GRASS GIS and Jupyter
+The *grass.jupyter* subpackage improves the integration of GRASS and Jupyter
 notebooks compared to the standard Python API. The original version was written
 as part of Google Summer of Code in 2021 and experimental version was included in
-GRASS GIS 8.0. Since then, much more development happened adding better session
+GRASS 8.0. Since then, much more development happened adding better session
 handling and rendering of additional data types.
 
 Usage
@@ -37,12 +37,12 @@ such as *gj*, like this::
 >>> import grass.jupyter as gj
 
 .. note::
-    To import the package, you need to tell Python where the GRASS GIS Python package
+    To import the package, you need to tell Python where the GRASS Python package
     is unless you manually set this on your system or in the command line. Please, refer
     to the example notebooks linked below for an example of the full workflow.
 
 .. note::
-    On Windows, there is no system Python and GRASS GIS needs to use its own Python.
+    On Windows, there is no system Python and GRASS needs to use its own Python.
     Jupyter needs to be installed into that Python. Please, refer to the wiki_
     for Windows-specific instructions.
 

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -26,7 +26,7 @@ from .region import RegionManagerFor3D
 
 
 class Map3D:
-    """Creates and displays 3D visualization using GRASS GIS 3D rendering engine NVIZ.
+    """Creates and displays 3D visualization using GRASS 3D rendering engine NVIZ.
 
     The 3D image is created using the *render* function which uses the *m.nviz.image*
     module in the background. Additional images can be
@@ -78,7 +78,7 @@ class Map3D:
                             this region is then used for rendering
 
         When *resolution_fine* is 1, rasters are used in the resolution according
-        to the computational region as usual in GRASS GIS.
+        to the computational region as usual in GRASS.
         Setting *resolution_fine* to values higher than one, causes rasters to
         be resampled to a coarser resolution (2 for twice as coarse than computational
         region resolution). This allows for fast rendering of large rasters without

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -12,7 +12,7 @@
 #            License (>=v2). Read the file COPYING that comes with GRASS
 #            for details.
 
-"""Initialization GRASS GIS session and its finalization"""
+"""Initialization GRASS session and its finalization"""
 
 import os
 import weakref
@@ -116,7 +116,7 @@ class _JupyterGlobalSession:
     def finish(self):
         """Close the session, i.e., close the open mapset.
 
-        Subsequent calls to GRASS GIS modules will fail because there will be
+        Subsequent calls to GRASS modules will fail because there will be
         no current (open) mapset anymore.
 
         The finish procedure is done automatically when process finishes or the object

--- a/python/grass/pydispatch/__init__.py
+++ b/python/grass/pydispatch/__init__.py
@@ -11,7 +11,7 @@ In short, simple function calls are not sufficient in the GUI, event
 driven and large environment with many persistent objects because
 using simple function calls would lead to tightly coupled code. Thus,
 some better mechanism is needed such as Observer design pattern. In
-GRASS GIS, we use the Signal system which is similar to Signals used in
+GRASS, we use the Signal system which is similar to Signals used in
 PyQt and other frameworks. As the underlying library, we have chosen
 PyDispatcher because it provides very general API which enables to
 implement Signal API, wide and robust functionality which makes

--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -131,7 +131,7 @@ def _check_value(param, value):
 # TODO add documentation
 class Parameter:
     """The Parameter object store all information about a parameter of a
-    GRASS GIS module. ::
+    GRASS module. ::
 
         >>> param = Parameter(
         ...     diz=dict(

--- a/python/grass/script/__init__.py
+++ b/python/grass/script/__init__.py
@@ -1,4 +1,4 @@
-"""Python interface to launch GRASS GIS modules in scripts"""
+"""Python interface to launch GRASS modules in scripts"""
 
 from . import setup
 from .core import (

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -355,7 +355,7 @@ def make_command(
                         "To run the module <%s> add underscore at the end"
                         " of the option <%s> to avoid conflict with Python"
                         " keywords. Underscore at the beginning is"
-                        " deprecated in GRASS GIS 7.0 and has been removed"
+                        " deprecated in GRASS 7.0 and has been removed"
                         " in version 7.1."
                     )
                     % (prog, opt)
@@ -1075,7 +1075,7 @@ def parser() -> tuple[dict[str, str], dict[str, bool]]:
     https://grass.osgeo.org/grass-devel/manuals/parser_standard_options.html
     """
     if not os.getenv("GISBASE"):
-        print("You must be in GRASS GIS to run this program.", file=sys.stderr)
+        print("You must be in GRASS to run this program.", file=sys.stderr)
         sys.exit(1)
 
     cmdline = [basename(sys.argv[0])]

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -11,7 +11,7 @@ and session without using grassXY.
     import subprocess
 
     # define GRASS Database
-    # add your path to grassdata (GRASS GIS database) directory
+    # add your path to grassdata (GRASS database) directory
     gisdb = "~/grassdata"
     # the following path is the default path on MS Windows
     # gisdb = "~/Documents/grassdata"
@@ -20,8 +20,8 @@ and session without using grassXY.
     location = "nc_spm_08"
     mapset = "user1"
 
-    # path to the GRASS GIS launch script
-    # we assume that the GRASS GIS start script is available and on PATH
+    # path to the GRASS launch script
+    # we assume that the GRASS start script is available and on PATH
     # query GRASS itself for its GISBASE
     # (with fixes for specific platforms)
     # needs to be edited by the user
@@ -30,14 +30,14 @@ and session without using grassXY.
         # MS Windows
         executable = r"C:\OSGeo4W\bin\grass.bat"
         # uncomment when using standalone WinGRASS installer
-        # executable = r'C:\Program Files (x86)\GRASS GIS <version>\grass.bat'
+        # executable = r'C:\Program Files (x86)\GRASS <version>\grass.bat'
         # this can be skipped if GRASS executable is added to PATH
     elif sys.platform == "darwin":
         # Mac OS X
         version = "@GRASS_VERSION_MAJOR@.@GRASS_VERSION_MINOR@"
         executable = f"/Applications/GRASS-{version}.app/Contents/Resources/bin/grass"
 
-    # query GRASS GIS itself for its Python package path
+    # query GRASS itself for its Python package path
     grass_cmd = [executable, "--config", "python_path"]
     process = subprocess.run(grass_cmd, check=True, text=True, stdout=subprocess.PIPE)
 
@@ -51,7 +51,7 @@ and session without using grassXY.
     session = gs.setup.init(gisdb, location, mapset)
 
     # example calls
-    gs.message("Current GRASS GIS 8 environment:")
+    gs.message("Current GRASS 8 environment:")
     print(gs.gisenv())
 
     gs.message("Available raster maps:")
@@ -116,7 +116,7 @@ def set_gui_path():
 def get_install_path(path=None):
     """Get path to GRASS installation usable for setup of environmental variables.
 
-    The function tries to determine path tp GRASS GIS installation so that the
+    The function tries to determine path tp GRASS installation so that the
     returned path can be used for setup of environmental variable for GRASS runtime.
     If the search fails, None is returned.
 
@@ -283,7 +283,7 @@ def init(
 ):
     """Initialize system variables to run GRASS modules
 
-    This function is for running GRASS GIS without starting it with the
+    This function is for running GRASS without starting it with the
     standard main executable grass. No GRASS modules shall be called before
     call of this function but any module or user script can be called
     afterwards because a GRASS session has been set up. GRASS Python

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -525,7 +525,7 @@ def set_path(modulename, dirname=None, path="."):
     The function is checking if the dirname is provided and if the
     directory exists and it is available using the path
     provided as third parameter, if yes add the path to sys.path to be
-    importable, otherwise it will check on GRASS GIS standard paths.
+    importable, otherwise it will check on GRASS standard paths.
 
     """
     import sys
@@ -539,7 +539,7 @@ def set_path(modulename, dirname=None, path="."):
         # we add the path to sys.path to reach the directory (dirname)
         sys.path.append(os.path.abspath(path))
     else:
-        # running from GRASS GIS session
+        # running from GRASS session
         path = get_lib_path(modulename, dirname)
         if path is None:
             pathname = os.path.join(modulename, dirname) if dirname else modulename
@@ -613,7 +613,7 @@ def append_node_pid(name):
 
         Before you use this function for creating temporary files (i.e., normal
         files on disk, not maps and other mapset elements), see functions
-        designed for it in the GRASS GIS or standard Python library. These
+        designed for it in the GRASS or standard Python library. These
         take care of collisions already on different levels.
     """
     # We are using this node as a suffix, so we don't need to make sure it

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1432,7 +1432,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                      subset of the registered maps without "WHERE"
         :param dbif: The database interface to be used
         :param spatial_extent: Spatial extent dict and projection information
-            e.g. from g.region -ug3 with GRASS GIS region keys
+            e.g. from g.region -ug3 with GRASS region keys
             "n", "s", "e", "w", "b", "t", and "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
@@ -1508,7 +1508,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                      objects in the list without "ORDER BY"
         :param dbif: The database interface to be used
         :param spatial_extent: Spatial extent dict and projection information
-            e.g. from g.region -ug3 with GRASS GIS region keys
+            e.g. from g.region -ug3 with GRASS region keys
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
@@ -1563,7 +1563,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                       objects in the list without "ORDER BY"
         :param dbif: The database interface to be used
         :param spatial_extent: Spatial extent dict and projection information
-            e.g. from g.region -ug3 with GRASS GIS region keys
+            e.g. from g.region -ug3 with GRASS region keys
             "n", "s", "e", "w", "b", "t", and "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
@@ -1850,7 +1850,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         :param group: The columns to be used in the SQL GROUP BY statement
                       as SQL compliant string without "GROUP BY"
         :param spatial_extent: Spatial extent dict and projection information
-            e.g. from g.region -ug3 with GRASS GIS region keys
+            e.g. from g.region -ug3 with GRASS region keys
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -716,7 +716,7 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
     else:
         backup_howto = _(
             "You need to export it by "
-            "restoring the GRASS GIS version used for creating this DB."
+            "restoring the GRASS version used for creating this DB."
             "Notes: Use t.rast.export and t.vect.export "
             "to make a backup of your"
             " existing space time datasets. To save the timestamps of"
@@ -755,7 +755,7 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
                     _(
                         "Unsupported temporal database: version mismatch."
                         "\n %(backup)s Supported temporal API version is:"
-                        " %(api)i.\nPlease update your GRASS GIS "
+                        " %(api)i.\nPlease update your GRASS "
                         "installation.\nCurrent temporal database info:"
                         "%(info)s"
                     )

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -12,7 +12,7 @@ Usage:
 
 (C) 2012-2022 by the GRASS Development Team
 This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS GIS
+License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
 :authors: Soeren Gebbert

--- a/python/grass/temporal/stds_export.py
+++ b/python/grass/temporal/stds_export.py
@@ -427,17 +427,17 @@ def export_stds(
         if type_ == "strds":
             read_file.write(
                 "This space time raster dataset was exported with "
-                "t.rast.export of GRASS GIS 8\n"
+                "t.rast.export of GRASS 8\n"
             )
         elif type_ == "stvds":
             read_file.write(
                 "This space time vector dataset was exported with "
-                "t.vect.export of GRASS GIS 8\n"
+                "t.vect.export of GRASS 8\n"
             )
         elif type_ == "str3ds":
             read_file.write(
                 "This space time 3D raster dataset was exported "
-                "with t.rast3d.export of GRASS GIS 8\n"
+                "with t.rast3d.export of GRASS 8\n"
             )
         read_file.write("\n")
         read_file.write("Files:\n")
@@ -445,7 +445,7 @@ def export_stds(
             if format_ == "GTiff":
                 # 123456789012345678901234567890
                 read_file.write("       *.tif  -- GeoTIFF raster files\n")
-                read_file.write("     *.color  -- GRASS GIS raster color rules\n")
+                read_file.write("     *.color  -- GRASS raster color rules\n")
             elif format_ == "pack":
                 read_file.write(
                     "      *.pack  -- GRASS raster files packed with r.pack\n"
@@ -466,7 +466,7 @@ def export_stds(
             "%13s -- Projection information in PROJ.4 format\n" % (proj_file_name)
         )
         read_file.write(
-            "%13s -- GRASS GIS space time %s dataset information\n"
+            "%13s -- GRASS space time %s dataset information\n"
             % (init_file_name, sp.get_new_map_instance(None).get_type())
         )
         read_file.write(

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -479,7 +479,7 @@ from .temporal_operator import TemporalOperatorParser
 
 
 class TemporalAlgebraLexer:
-    """Lexical analyzer for the GRASS GIS temporal algebra"""
+    """Lexical analyzer for the GRASS temporal algebra"""
 
     # Functions that defines an if condition, temporal buffering, snapping and
     # selection of maps with temporal extent.

--- a/python/grass/temporal/temporal_operator.py
+++ b/python/grass/temporal/temporal_operator.py
@@ -144,7 +144,7 @@ from .ply import lex, yacc
 
 
 class TemporalOperatorLexer:
-    """Lexical analyzer for the GRASS GIS temporal operator"""
+    """Lexical analyzer for the GRASS temporal operator"""
 
     # Functions that defines topological relations.
     relations = {

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -68,7 +68,7 @@ from .temporal_granularity import compute_absolute_time_granularity
 
 
 class TemporalRasterAlgebraLexer(TemporalAlgebraLexer):
-    """Lexical analyzer for the GRASS GIS temporal algebra"""
+    """Lexical analyzer for the GRASS temporal algebra"""
 
     def __init__(self) -> None:
         TemporalAlgebraLexer.__init__(self)

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -62,7 +62,7 @@ from .temporal_algebra import (
 
 
 class TemporalVectorAlgebraLexer(TemporalAlgebraLexer):
-    """Lexical analyzer for the GRASS GIS temporal vector algebra"""
+    """Lexical analyzer for the GRASS temporal vector algebra"""
 
     def __init__(self) -> None:
         TemporalAlgebraLexer.__init__(self)

--- a/raster/r.buildvrt/r.buildvrt.html
+++ b/raster/r.buildvrt/r.buildvrt.html
@@ -56,7 +56,7 @@ Users may experience significant performance degradation with virtual rasters bu
 with <em>r.buildvrt</em> over GDAL-linked (<em>r.external</em>) raster maps,
 especially on slower file systems with latency like NFS. Performance degradation
 may also occur on local file systems, but is usually less severe. For such use cases
-consider using the GRASS GIS addon
+consider using the GRASS addon
 <a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.buildvrt.gdal.html">r.buildvrt.gdal</a>
 or building GDAL VRTs, e.g. with <em>gdalbuildvrt</em>.
 

--- a/raster/r.buildvrt/r.buildvrt.md
+++ b/raster/r.buildvrt/r.buildvrt.md
@@ -55,7 +55,7 @@ Users may experience significant performance degradation with virtual
 rasters built with *r.buildvrt* over GDAL-linked (*r.external*) raster
 maps, especially on slower file systems with latency like NFS.
 Performance degradation may also occur on local file systems, but is
-usually less severe. For such use cases consider using the GRASS GIS
+usually less severe. For such use cases consider using the GRASS
 addon
 [r.buildvrt.gdal](https://grass.osgeo.org/grass-stable/manuals/addons/r.buildvrt.gdal.html)
 or building GDAL VRTs, e.g. with *gdalbuildvrt*.

--- a/raster/r.compress/r.compress.html
+++ b/raster/r.compress/r.compress.html
@@ -24,7 +24,7 @@ raster maps are shrunk to roughly 1% of their original sizes.
 All newly generated raster maps are automatically stored as compressed
 data with varying methods depending on the raster format (i.e.,
 CELL: integer; FCELL: single precision; DCELL: double precision; see
-below). All GRASS GIS modules are able to read both compressed and
+below). All GRASS modules are able to read both compressed and
 uncompressed raster maps.
 
 <!-- too old and RLE only example
@@ -102,7 +102,7 @@ between speed and compression rate.
 <h3>COMPRESSION ALGORITHM DETAILS</h3>
 <!-- keep in sync with raster/rasterintro.html -->
 
-All GRASS GIS raster map types are by default ZSTD compressed if
+All GRASS raster map types are by default ZSTD compressed if
 available, otherwise ZLIB compressed. Through the environment variable
 <code>GRASS_COMPRESSOR</code> the compression method can be set to RLE,
 ZLIB, LZ4, BZIP2, or ZSTD.
@@ -129,7 +129,7 @@ FCELL and DCELL maps are never and have never been compressed with RLE.
 </dd>
 <dt><strong>ZLIB</strong></dt>
 <dd>ZLIB's deflate is the default compression method for all raster
-maps, if ZSTD is not available. GRASS GIS 8 uses by default 1 as ZLIB
+maps, if ZSTD is not available. GRASS 8 uses by default 1 as ZLIB
 compression level which is the best compromise between speed and
 compression ratio, also when compared to other available compression
 methods. Valid levels are in the range [1, 9] and can be set with the

--- a/raster/r.compress/r.compress.md
+++ b/raster/r.compress/r.compress.md
@@ -20,7 +20,7 @@ land use maps) can be greatly reduced in size. Some raster maps are
 shrunk to roughly 1% of their original sizes. All newly generated raster
 maps are automatically stored as compressed data with varying methods
 depending on the raster format (i.e., CELL: integer; FCELL: single
-precision; DCELL: double precision; see below). All GRASS GIS modules
+precision; DCELL: double precision; see below). All GRASS modules
 are able to read both compressed and uncompressed raster maps.
 
 Raster maps that are already compressed might be compressed again,
@@ -78,7 +78,7 @@ between speed and compression rate.
 
 ### COMPRESSION ALGORITHM DETAILS
 
-All GRASS GIS raster map types are by default ZSTD compressed if
+All GRASS raster map types are by default ZSTD compressed if
 available, otherwise ZLIB compressed. Through the environment variable
 `GRASS_COMPRESSOR` the compression method can be set to RLE, ZLIB, LZ4,
 BZIP2, or ZSTD.
@@ -99,7 +99,7 @@ maps are never and have never been compressed with RLE.
 
 **ZLIB**  
 ZLIB's deflate is the default compression method for all raster maps, if
-ZSTD is not available. GRASS GIS 8 uses by default 1 as ZLIB compression
+ZSTD is not available. GRASS 8 uses by default 1 as ZLIB compression
 level which is the best compromise between speed and compression ratio,
 also when compared to other available compression methods. Valid levels
 are in the range \[1, 9\] and can be set with the environment variable

--- a/raster/r.covar/r.covar.html
+++ b/raster/r.covar/r.covar.html
@@ -18,7 +18,7 @@ N real eigen values and N eigen vectors (each composed of N real numbers).
 
 <p>
 The module <em><a href="https://grass.osgeo.org/grass-stable/manuals/addons/m.eigensystem.html">m.eigensystem</a></em>
-in <a href="https://grass.osgeo.org/download/addons/">GRASS GIS Addons</a>
+in <a href="https://grass.osgeo.org/download/addons/">GRASS Addons</a>
 can be installed and used to generate the eigenvalues and vectors.
 
 <h2>EXAMPLE</h2>

--- a/raster/r.covar/r.covar.md
+++ b/raster/r.covar/r.covar.md
@@ -17,7 +17,7 @@ of N real numbers).
 
 The module
 *[m.eigensystem](https://grass.osgeo.org/grass-stable/manuals/addons/m.eigensystem.html)*
-in [GRASS GIS Addons](https://grass.osgeo.org/download/addons/) can be
+in [GRASS Addons](https://grass.osgeo.org/download/addons/) can be
 installed and used to generate the eigenvalues and vectors.
 
 ## EXAMPLE

--- a/raster/r.external.out/r.external.out.html
+++ b/raster/r.external.out/r.external.out.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>r.external.out</em> instructs GRASS GIS to write subsequently generated
+<em>r.external.out</em> instructs GRASS to write subsequently generated
 raster maps as data files (e.g. GeoTIFF) using GDAL instead of storing them
 in GRASS raster format in the current mapset.
 <p>
@@ -44,7 +44,7 @@ r.external.out -r
 gdalinfo $HOME/gisoutput/elev_filt.tif
 </pre></div>
 
-<h3>Complete workflow using only external geodata while processing in GRASS GIS</h3>
+<h3>Complete workflow using only external geodata while processing in GRASS</h3>
 
 The module <em>r.external.out</em> can be used along with
 <em>r.external</em> to process external geodata in GRASS

--- a/raster/r.external.out/r.external.out.md
+++ b/raster/r.external.out/r.external.out.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*r.external.out* instructs GRASS GIS to write subsequently generated
+*r.external.out* instructs GRASS to write subsequently generated
 raster maps as data files (e.g. GeoTIFF) using GDAL instead of storing
 them in GRASS raster format in the current mapset.
 
@@ -44,7 +44,7 @@ r.external.out -r
 gdalinfo $HOME/gisoutput/elev_filt.tif
 ```
 
-### Complete workflow using only external geodata while processing in GRASS GIS
+### Complete workflow using only external geodata while processing in GRASS
 
 The module *r.external.out* can be used along with *r.external* to
 process external geodata in GRASS while writing out the results directly

--- a/raster/r.fill.dir/r.fill.dir.html
+++ b/raster/r.fill.dir/r.fill.dir.html
@@ -30,9 +30,9 @@ known into the area where the flow direction cannot otherwise be resolved.
 <p>
 The <b>format</b> parameter is the type of format at which the user wishes to create
 the flow <b>direction</b> map.
-The flow direction map can be encoded in GRASS GIS aspect format,
+The flow direction map can be encoded in GRASS aspect format,
 ANSWERS (Beasley et.al, 1982), or AGNPS (Young et.al, 1985) format,
-so that it can be readily used as input to other GRASS GIS modules
+so that it can be readily used as input to other GRASS modules
 or the aforementioned hydrological models.
 The <i>grass</i> format gives the same category
 values as <em><a href="r.slope.aspect.html">r.slope.aspect</a></em>
@@ -69,7 +69,7 @@ raster map can further be processed to derive slopes and other
 attributes required by other hydrological models.
 
 <p>
-As any GRASS GIS module, <em>r.fill.dir</em> respects the
+As any GRASS module, <em>r.fill.dir</em> respects the
 computational region settings. Thus,
 the module can be used to generate a flow direction map for any
 sub-area within the full raster map layer. Also, <em>r.fill.dir</em>

--- a/raster/r.fill.dir/r.fill.dir.md
+++ b/raster/r.fill.dir/r.fill.dir.md
@@ -29,9 +29,9 @@ the flow direction cannot otherwise be resolved.
 
 The **format** parameter is the type of format at which the user wishes
 to create the flow **direction** map. The flow direction map can be
-encoded in GRASS GIS aspect format, ANSWERS (Beasley et.al, 1982), or
+encoded in GRASS aspect format, ANSWERS (Beasley et.al, 1982), or
 AGNPS (Young et.al, 1985) format, so that it can be readily used as
-input to other GRASS GIS modules or the aforementioned hydrological
+input to other GRASS modules or the aforementioned hydrological
 models. The *grass* format gives the same category values as
 *[r.slope.aspect](r.slope.aspect.md)* gives for aspect, i.e. angles in
 degrees counter-clockwise from east in 45 degree increments. The *agnps*
@@ -61,7 +61,7 @@ The resulting depressionless elevation raster map can further be
 processed to derive slopes and other attributes required by other
 hydrological models.
 
-As any GRASS GIS module, *r.fill.dir* respects the computational region
+As any GRASS module, *r.fill.dir* respects the computational region
 settings. Thus, the module can be used to generate a flow direction map
 for any sub-area within the full raster map layer. Also, *r.fill.dir*
 will take into account an active raster mask.

--- a/raster/r.mapcalc/testsuite/const_map_test.sh
+++ b/raster/r.mapcalc/testsuite/const_map_test.sh
@@ -13,7 +13,7 @@
 #   - how big EPSILON?
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program."
+    echo "You must be in GRASS to run this program."
     exit 1
 fi
 

--- a/raster/r.mfilter/r.mfilter.md
+++ b/raster/r.mfilter/r.mfilter.md
@@ -128,7 +128,7 @@ of cells for 9x9 matrix, benchmark on the right shows execution time for
 
 Note that parallelization is implemented only for the parallel filter,
 not the sequential one. To take advantage of the parallelization, GRASS
-GIS needs to compiled with OpenMP enabled.
+needs to compiled with OpenMP enabled.
 
 ## NOTES
 

--- a/raster/r.proj/r.proj.html
+++ b/raster/r.proj/r.proj.html
@@ -73,8 +73,7 @@ of coordinate points, since there is no topology to be preserved and
 The <em>m.proj</em> module provides a handy front end to <code>cs2cs</code>.
 
 <p>Vector maps is generally more complex, as parts of the data stored in
-the files will describe topology, and not just coordinates. In GRASS
-GIS the
+the files will describe topology, and not just coordinates. In GRASS the
 <em><a href="v.proj.html">v.proj</a></em> module is provided to reproject
 vector maps, transferring topology and attributes as well as node coordinates.
 This program uses the CRS definition and parameters which are stored in

--- a/raster/r.random.cells/r.random.cells.html
+++ b/raster/r.random.cells/r.random.cells.html
@@ -120,7 +120,7 @@ mogrify -trim r_random_cells.png
 
 <h2>REFERENCES</h2>
 
-Random Field Software for GRASS GIS by Chuck Ehlschlaeger
+Random Field Software for GRASS by Chuck Ehlschlaeger
 
 <p>  As part of my dissertation, I put together several programs that help
 GRASS (4.1 and beyond) develop uncertainty models of spatial data. I hope

--- a/raster/r.random.cells/r.random.cells.md
+++ b/raster/r.random.cells/r.random.cells.md
@@ -87,7 +87,7 @@ right) and corresponding vector points (lower right)*
 
 ## REFERENCES
 
-Random Field Software for GRASS GIS by Chuck Ehlschlaeger
+Random Field Software for GRASS by Chuck Ehlschlaeger
 
 As part of my dissertation, I put together several programs that help
 GRASS (4.1 and beyond) develop uncertainty models of spatial data. I

--- a/raster/r.resamp.bspline/r.resamp.bspline.html
+++ b/raster/r.resamp.bspline/r.resamp.bspline.html
@@ -146,7 +146,7 @@ Girona, Espa&ntilde;a. CD ISBN: 978-84-690-3886-9</li>
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHORS</h2>
 

--- a/raster/r.resamp.bspline/r.resamp.bspline.md
+++ b/raster/r.resamp.bspline/r.resamp.bspline.md
@@ -144,7 +144,7 @@ r.resamp.bspline -c input=input_raster
 [v.surf.bspline](v.surf.bspline.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHORS
 

--- a/raster/r.resamp.filter/r.resamp.filter.html
+++ b/raster/r.resamp.filter/r.resamp.filter.html
@@ -135,7 +135,7 @@ needs to compiled with OpenMP enabled.
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.resamp.filter/r.resamp.filter.md
+++ b/raster/r.resamp.filter/r.resamp.filter.md
@@ -110,7 +110,7 @@ compiled with OpenMP enabled.
 [r.resamp.rst](r.resamp.rst.md), [r.resamp.stats](r.resamp.stats.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHOR
 

--- a/raster/r.resamp.interp/r.resamp.interp.html
+++ b/raster/r.resamp.interp/r.resamp.interp.html
@@ -82,7 +82,7 @@ Resampled (bilinear) 250m resolution elevation map
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.resamp.interp/r.resamp.interp.md
+++ b/raster/r.resamp.interp/r.resamp.interp.md
@@ -72,7 +72,7 @@ Resampled (bilinear) 250m resolution elevation map
 [r.resamp.stats](r.resamp.stats.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHOR
 

--- a/raster/r.resamp.rst/r.resamp.rst.html
+++ b/raster/r.resamp.rst/r.resamp.rst.html
@@ -144,7 +144,7 @@ Conference series in applied mathematics, 59, SIAM, Philadelphia, Pennsylvania.
 <a href="v.surf.rst.html">v.surf.rst</a>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHORS</h2>
 

--- a/raster/r.resamp.rst/r.resamp.rst.md
+++ b/raster/r.resamp.rst/r.resamp.rst.md
@@ -158,7 +158,7 @@ Pennsylvania.
 [r.surf.contour](r.surf.contour.md), [v.surf.rst](v.surf.rst.md)
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHORS
 

--- a/raster/r.resamp.stats/r.resamp.stats.html
+++ b/raster/r.resamp.stats/r.resamp.stats.html
@@ -53,7 +53,7 @@ r.resamp.stats -w input=el_D782_6m output=el_D782_20m
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 <p>
 Examples how statistical functions are applied can be found in the <a href="r.neighbors.html">r.neighbors</a> module documentation.
 

--- a/raster/r.resamp.stats/r.resamp.stats.md
+++ b/raster/r.resamp.stats/r.resamp.stats.md
@@ -44,7 +44,7 @@ r.resamp.stats -w input=el_D782_6m output=el_D782_20m
 [r.resamp.interp](r.resamp.interp.md), [r.neighbors](r.neighbors.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 Examples how statistical functions are applied can be found in the
 [r.neighbors](r.neighbors.md) module documentation.

--- a/raster/r.resample/r.resample.html
+++ b/raster/r.resample/r.resample.html
@@ -44,7 +44,7 @@ is created by <em>r.resample</em>.
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.resample/r.resample.md
+++ b/raster/r.resample/r.resample.md
@@ -37,7 +37,7 @@ created by *r.resample*.
 [r.rescale](r.rescale.md), [r.resamp.interp](r.resamp.interp.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHOR
 

--- a/raster/r.surf.contour/r.surf.contour.html
+++ b/raster/r.surf.contour/r.surf.contour.html
@@ -106,7 +106,7 @@ r.univar diff
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.surf.contour/r.surf.contour.md
+++ b/raster/r.surf.contour/r.surf.contour.md
@@ -92,7 +92,7 @@ r.univar diff
 [v.to.rast](v.to.rast.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHOR
 

--- a/raster/r.surf.idw/r.surf.idw.html
+++ b/raster/r.surf.idw/r.surf.idw.html
@@ -115,7 +115,7 @@ Module <em>r.surf.idw</em> works only for integer (CELL) raster maps.
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.surf.idw/r.surf.idw.md
+++ b/raster/r.surf.idw/r.surf.idw.md
@@ -79,7 +79,7 @@ Module *r.surf.idw* works only for integer (CELL) raster maps.
 [v.surf.idw](v.surf.idw.md), [v.surf.rst](v.surf.rst.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHOR
 

--- a/raster3d/raster3dintro.html
+++ b/raster3d/raster3dintro.html
@@ -1,8 +1,8 @@
-<!-- meta page description: 3D raster data in GRASS GIS -->
+<!-- meta page description: 3D raster data in GRASS -->
 <!-- meta page index: raster3d -->
 <h3>3D raster maps in general</h3>
 
-GRASS GIS is one of the few GIS software packages with 3D raster data support.
+GRASS is one of the few GIS software packages with 3D raster data support.
 Data are stored as a 3D raster with 3D cells of a given volume.
 3D rasters are designed to support representations of
 trivariate continuous fields.
@@ -11,7 +11,7 @@ Hence space time 3D raster with different temporal resolutions
 can be created and processed.
 
 <p>
-GRASS GIS 3D raster maps use the same coordinate system as
+GRASS 3D raster maps use the same coordinate system as
 2D raster maps (row count from north to south) with an additional z dimension (depth)
 counting from bottom to top. The upper left corner (NW) is the origin.
 3D rasters are stored using a tile cache based approach. This allows arbitrary
@@ -31,7 +31,7 @@ can be specified at import time with a given import module such as
 
 <h3>Terminology and naming</h3>
 
-In GRASS GIS terminology, continuous 3D data represented by regular grid
+In GRASS terminology, continuous 3D data represented by regular grid
 or lattice is called <em>3D raster map</em>.
 3D raster map works in 3D in the same was as (2D) raster map in 2D,
 so it is called the same except for the additional 3D.
@@ -41,7 +41,7 @@ Note that terms volume and volumetric often refer to measuring
 volume (amount) of some substance which may or may not be related to 3D rasters.
 
 <p>
-Note that GRASS GIS uses the term 3D raster map or just 3D raster for short,
+Note that GRASS uses the term 3D raster map or just 3D raster for short,
 rather than 3D raster layer because term map emphasizes
 the mapping of positions to values which is the purpose of 3D raster map
 (in mathematics, map or mapping is close to a term function)
@@ -60,14 +60,14 @@ and that for example in 3D computer graphics, voxel can denote object
 with some complicated shape.
 
 <p>
-Type of map and element name in GRASS GIS is called <code>raster_3d</code>.
+Type of map and element name in GRASS is called <code>raster_3d</code>.
 The module family prefix is <code>r3</code>.
 Occasionally, 3D raster related things can be
 referred differently, for example according to a programming language standards.
 This might be the case of some functions or classes in Python.
 
 <p>
-In GRASS GIS 3D rasters as stored in tiles which are hidden from user most
+In GRASS 3D rasters as stored in tiles which are hidden from user most
 of the time. When analyzing or visualizing 3D rasters user can create
 slices or cross sections. Slices can be horizontal, vertical, or general
 plains going through a 3D raster. Slices, especially the horizontal ones, may be
@@ -117,7 +117,7 @@ merged into one 3D raster map (<a href="r.to.rast3.html">r.to.rast3</a>).
 
 <h3>3D region settings and 3D mask</h3>
 
-GRASS GIS 3D raster map processing is always performed in the current 3D region
+GRASS 3D raster map processing is always performed in the current 3D region
 settings (see <a href="g.region.html">g.region</a>, <em>-p3</em> flags), i.e.
 the current region extent, vertical extent and current 3D resolution are used.
 If the 3D resolution differs from that of the input raster map(s),
@@ -166,20 +166,20 @@ with spatial dimensions and temporal (vertical) dimension.
 
 <h3>Working with 3D visualization software</h3>
 
-GRASS GIS can be used for visualization of 3D rasters, however
+GRASS can be used for visualization of 3D rasters, however
 it has also tools to easily export the data into other visualization
 packages.
 
 <p>
-GRASS GIS 3D raster maps can be exported to VTK
+GRASS 3D raster maps can be exported to VTK
 using <a href="r3.out.vtk.html">r3.out.vtk</a>.
 VTK files can be visualized with the
 <em><a href="https://vtk.org">VTK Toolkit</a></em>,
 <em><a href="https://www.paraview.org">Paraview</a></em> and
 <em><a href="https://github.com/enthought/mayavi">MayaVi</a></em>.
-Moreover, GRASS GIS 2D raster maps can be exported to VTK with
+Moreover, GRASS 2D raster maps can be exported to VTK with
 <a href="r.out.vtk.html">r.out.vtk</a>
-and GRASS GIS vector maps can be exported to VTK with
+and GRASS vector maps can be exported to VTK with
 <a href="v.out.vtk.html">v.out.vtk</a>.
 
 <p>

--- a/scripts/db.out.ogr/db.out.ogr.html
+++ b/scripts/db.out.ogr/db.out.ogr.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>db.out.ogr</em> exports GRASS GIS attribute tables into various formats
+<em>db.out.ogr</em> exports GRASS attribute tables into various formats
 as supported by the OGR driver on the local system (CSV, DBF,
 PostgreSQL, SQLite, MySQL, ODBC, etc.).
 <p>
@@ -14,19 +14,19 @@ is linked as non-default layer to a vector map.
 
 <h2>EXAMPLES</h2>
 
-<h3>Export of GRASS GIS attribute table to a CSV table file (default format)</h3>
+<h3>Export of GRASS attribute table to a CSV table file (default format)</h3>
 
 <div class="code"><pre>
 db.out.ogr input=precip_30ynormals output=precip_30ynormals.csv
 </pre></div>
 
-<h3>Export of a GRASS GIS attribute table to a DBF table</h3>
+<h3>Export of a GRASS attribute table to a DBF table</h3>
 
 <div class="code"><pre>
 db.out.ogr input=precip_30ynormals output=precip_30ynormals.dbf format=DBF
 </pre></div>
 
-<h3>Export of GRASS GIS attribute table into a PostgreSQL table</h3>
+<h3>Export of GRASS attribute table into a PostgreSQL table</h3>
 
 <div class="code"><pre>
 db.out.ogr input=precip_30ynormals \

--- a/scripts/db.out.ogr/db.out.ogr.md
+++ b/scripts/db.out.ogr/db.out.ogr.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*db.out.ogr* exports GRASS GIS attribute tables into various formats as
+*db.out.ogr* exports GRASS attribute tables into various formats as
 supported by the OGR driver on the local system (CSV, DBF, PostgreSQL,
 SQLite, MySQL, ODBC, etc.).
 
@@ -14,19 +14,19 @@ linked as non-default layer to a vector map.
 
 ## EXAMPLES
 
-### Export of GRASS GIS attribute table to a CSV table file (default format)
+### Export of GRASS attribute table to a CSV table file (default format)
 
 ```sh
 db.out.ogr input=precip_30ynormals output=precip_30ynormals.csv
 ```
 
-### Export of a GRASS GIS attribute table to a DBF table
+### Export of a GRASS attribute table to a DBF table
 
 ```sh
 db.out.ogr input=precip_30ynormals output=precip_30ynormals.dbf format=DBF
 ```
 
-### Export of GRASS GIS attribute table into a PostgreSQL table
+### Export of GRASS attribute table into a PostgreSQL table
 
 ```sh
 db.out.ogr input=precip_30ynormals \

--- a/scripts/g.download.project/g.download.project.html
+++ b/scripts/g.download.project/g.download.project.html
@@ -3,7 +3,7 @@
 <em>g.download.project</em> downloads an archived (e.g.,
 <code>.zip</code> or <code>.tar.gz</code>) project (previously called
 location) from a given URL
-and unpacks it to a specified or current GRASS GIS Spatial Database.
+and unpacks it to a specified or current GRASS Spatial Database.
 URL can be also a local file on the disk.
 
 If the archive contains a directory which contains a project, the module
@@ -13,7 +13,7 @@ Other projects or any other files are ignored.
 
 <h2>EXAMPLES</h2>
 
-<h3>Download the full GRASS GIS sample project within a running session</h3>
+<h3>Download the full GRASS sample project within a running session</h3>
 
 Download and unpack the full North Carolina sample project into the user's
 HOME directory:
@@ -22,7 +22,7 @@ HOME directory:
 g.download.project url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 </pre></div>
 
-<h3>Download the full GRASS GIS sample project in a temporary session</h3>
+<h3>Download the full GRASS sample project in a temporary session</h3>
 
 In a temporary session, download and unpack the full North Carolina sample project
 into the user's HOME directory:

--- a/scripts/g.download.project/g.download.project.md
+++ b/scripts/g.download.project/g.download.project.md
@@ -2,7 +2,7 @@
 
 *g.download.project* downloads an archived (e.g., `.zip` or `.tar.gz`)
 project (previously called location) from a given URL and unpacks it to
-a specified or current GRASS GIS Spatial Database. URL can be also a
+a specified or current GRASS Spatial Database. URL can be also a
 local file on the disk. If the archive contains a directory which
 contains a project, the module will recognize that and use the project
 automatically. The first directory which is a project is used. Other
@@ -10,7 +10,7 @@ projects or any other files are ignored.
 
 ## EXAMPLES
 
-### Download the full GRASS GIS sample project within a running session
+### Download the full GRASS sample project within a running session
 
 Download and unpack the full North Carolina sample project into the
 user's HOME directory:
@@ -19,7 +19,7 @@ user's HOME directory:
 g.download.project url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 ```
 
-### Download the full GRASS GIS sample project in a temporary session
+### Download the full GRASS sample project in a temporary session
 
 In a temporary session, download and unpack the full North Carolina
 sample project into the user's HOME directory:

--- a/scripts/g.extension.all/g.extension.all.py
+++ b/scripts/g.extension.all/g.extension.all.py
@@ -171,7 +171,7 @@ def find_addon_name(addons):
     if grass_version != "unknown":
         major, minor, patch = grass_version.split(".")
     else:
-        gs.fatal(_("Unable to get GRASS GIS version."))
+        gs.fatal(_("Unable to get GRASS version."))
     url = "https://grass.osgeo.org/addons/grass{major}/modules.xml".format(
         major=major,
     )

--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -4,8 +4,8 @@
 
 <em>g.extension</em> downloads and installs, removes or updates
 extensions (addons) from the official
-<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS GIS Addons repository</a>
-or from user-specified source code repositories into the local GRASS GIS
+<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS Addons repository</a>
+or from user-specified source code repositories into the local GRASS
 installation.
 <p>
 Two types of extensions are supported:
@@ -14,7 +14,7 @@ Two types of extensions are supported:
     the need of special dependencies.</li>
 <li>Source code (mostly written in C programming language; may also be written
     in C++, Fortran or other languages): while on MS-Windows systems the requested
-    GRASS GIS extension is downloaded pre-compiled from the GRASS GIS site, on Unix
+    GRASS extension is downloaded pre-compiled from the GRASS site, on Unix
     based systems the installation is preceded by the automated download of the
     extension's source code along with subsequent compilation and installation.
     This requires a compiler environment to be present on the user's computer.</li>
@@ -22,17 +22,17 @@ Two types of extensions are supported:
 
 <h3>Managing installed extensions</h3>
 
-<p>Re-running <em>g.extension</em> on an installed GRASS GIS Addon
+<p>Re-running <em>g.extension</em> on an installed GRASS Addon
 extension re-installs the requested extension which may include
 updates.
 <p>
-To bulk-update all locally installed GRASS GIS extensions,
+To bulk-update all locally installed GRASS extensions,
 <em><a href="g.extension.all.html">g.extension.all</a></em> module
 is available.
 
 <h3>Where the extensions are installed</h3>
 
-GRASS GIS extensions are installed by <em>g.extension</em> into a dedicated
+GRASS extensions are installed by <em>g.extension</em> into a dedicated
 directory.
 The default is a directory for application data and settings inside
 the user's home directory.
@@ -42,7 +42,7 @@ The name of the directory is stored in the <code>GRASS_ADDON_BASE</code>
 environmental variable.
 
 <p>
-The flag <b>-s</b> changes this install target directory to the GRASS GIS
+The flag <b>-s</b> changes this install target directory to the GRASS
 installation directory
 (determined by <code>GISBASE</code> environmental variable, e.g. <code>/usr/</code>)
 rather than the default directory defined as per  <code>GRASS_ADDON_BASE</code>
@@ -53,13 +53,13 @@ rather than the default directory defined as per  <code>GRASS_ADDON_BASE</code>
 <p>
 The place where the extensions are installed can be customized by
 the option <b>prefix</b>. Ensuring that these extensions will be accessible
-in GRASS GIS is in this case in the responsibility of the user.
+in GRASS is in this case in the responsibility of the user.
 
 <h3>Source code sources and repositories</h3>
 
-<h4>GRASS GIS Addons repository on GitHub</h4>
+<h4>GRASS Addons repository on GitHub</h4>
 By default, <em>g.extension</em> installs extensions from the official
-GRASS GIS Addons GitHub repository. However, different sources can be specified
+GRASS Addons GitHub repository. However, different sources can be specified
 using the <b>url</b> option.
 
 <p>
@@ -117,7 +117,7 @@ MS-Windows.
 
 On MS-Windows systems, where compilation tools are typically not readily
 locally installed, <em>g.extension</em> downloads a precompiled executable
-from the GRASS GIS project server. On all other operating systems
+from the GRASS project server. On all other operating systems
 where it is not difficult to install compilation tools,
 <em>g.extension</em> downloads the source code of the requested
 extension (addon) and compiles it locally.
@@ -160,7 +160,7 @@ g.extension extension=r.stream.distance proxy="http=http://username:password@pro
 
 <h3>Managing the extensions</h3>
 
-List all available extensions in the official GRASS GIS Addons repository:
+List all available extensions in the official GRASS Addons repository:
 
 <div class="code"><pre>
 g.extension -l
@@ -209,7 +209,7 @@ only official repository is supported on this platform.
 
 <h3>Install a specific version from Addons</h3>
 
-To install a specific version from GRASS GIS Addons, specify the full
+To install a specific version from GRASS Addons, specify the full
 URL pointing to Trac code browser and include Subversion revision
 number. For example, this installs the version number 57854 of
 r.local.relief module:
@@ -256,7 +256,7 @@ present on the user's computer.
 
 <h3>ERROR: Please install GRASS development package</h3>
 
-While GRASS GIS is available on the user's computer, the respective development
+While GRASS is available on the user's computer, the respective development
 package is lacking. If GRASS was installed from a (Linux) repository, also the
 grass-dev* package (commonly named "grass-dev" or "grass-devel", sometimes along
 with the version number) must be installed.
@@ -268,7 +268,7 @@ with the version number) must be installed.
 </em>
 
 <p>
-<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS GIS 8 Addons Manual pages</a>
+<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS 8 Addons Manual pages</a>
 <br>
 <a href="https://grasswiki.osgeo.org/wiki/GRASS_AddOns">GRASS Addons</a> wiki page.
 

--- a/scripts/g.extension/g.extension.md
+++ b/scripts/g.extension/g.extension.md
@@ -1,9 +1,9 @@
 ## DESCRIPTION
 
 *g.extension* downloads and installs, removes or updates extensions
-(addons) from the official [GRASS GIS Addons
+(addons) from the official [GRASS Addons
 repository](https://grass.osgeo.org/grass8/manuals/addons/) or from
-user-specified source code repositories into the local GRASS GIS
+user-specified source code repositories into the local GRASS
 installation.
 
 Two types of extensions are supported:
@@ -12,30 +12,30 @@ Two types of extensions are supported:
   (usually) the need of special dependencies.
 - Source code (mostly written in C programming language; may also be
   written in C++, Fortran or other languages): while on MS-Windows
-  systems the requested GRASS GIS extension is downloaded pre-compiled
-  from the GRASS GIS site, on Unix based systems the installation is
+  systems the requested GRASS extension is downloaded pre-compiled
+  from the GRASS site, on Unix based systems the installation is
   preceded by the automated download of the extension's source code
   along with subsequent compilation and installation. This requires a
   compiler environment to be present on the user's computer.
 
 ### Managing installed extensions
 
-Re-running *g.extension* on an installed GRASS GIS Addon extension
+Re-running *g.extension* on an installed GRASS Addon extension
 re-installs the requested extension which may include updates.
 
-To bulk-update all locally installed GRASS GIS extensions,
+To bulk-update all locally installed GRASS extensions,
 *[g.extension.all](g.extension.all.md)* module is available.
 
 ### Where the extensions are installed
 
-GRASS GIS extensions are installed by *g.extension* into a dedicated
+GRASS extensions are installed by *g.extension* into a dedicated
 directory. The default is a directory for application data and settings
 inside the user's home directory. On GNU/Linux it is
 `$HOME/.grass8/addons`, on MS-Windows it is
 `%APPDATA%\Roaming\GRASS8\addons`. The name of the directory is stored
 in the `GRASS_ADDON_BASE` environmental variable.
 
-The flag **-s** changes this install target directory to the GRASS GIS
+The flag **-s** changes this install target directory to the GRASS
 installation directory (determined by `GISBASE` environmental variable,
 e.g. `/usr/`) rather than the default directory defined as per
 `GRASS_ADDON_BASE` (see also documentation for
@@ -44,14 +44,14 @@ permission to write to `GISBASE` or `GRASS_ADDON_BASE`.
 
 The place where the extensions are installed can be customized by the
 option **prefix**. Ensuring that these extensions will be accessible in
-GRASS GIS is in this case in the responsibility of the user.
+GRASS is in this case in the responsibility of the user.
 
 ### Source code sources and repositories
 
-#### GRASS GIS Addons repository on GitHub
+#### GRASS Addons repository on GitHub
 
 By default, *g.extension* installs extensions from the official GRASS
-GIS Addons GitHub repository. However, different sources can be
+Addons GitHub repository. However, different sources can be
 specified using the **url** option.
 
 Individual extensions can also be installed by providing a URL to the
@@ -107,7 +107,7 @@ MS-Windows.
 
 On MS-Windows systems, where compilation tools are typically not readily
 locally installed, *g.extension* downloads a precompiled executable from
-the GRASS GIS project server. On all other operating systems where it is
+the GRASS project server. On all other operating systems where it is
 not difficult to install compilation tools, *g.extension* downloads the
 source code of the requested extension (addon) and compiles it locally.
 This applies for both C and Python modules as well as any other
@@ -150,7 +150,7 @@ g.extension extension=r.stream.distance proxy="http=http://username:password@pro
 
 ### Managing the extensions
 
-List all available extensions in the official GRASS GIS Addons
+List all available extensions in the official GRASS Addons
 repository:
 
 ```sh
@@ -203,7 +203,7 @@ official repository is supported on this platform.
 
 ### Install a specific version from Addons
 
-To install a specific version from GRASS GIS Addons, specify the full
+To install a specific version from GRASS Addons, specify the full
 URL pointing to Trac code browser and include Subversion revision
 number. For example, this installs the version number 57854 of
 r.local.relief module:
@@ -247,7 +247,7 @@ environment must be present on the user's computer.
 
 ### ERROR: Please install GRASS development package
 
-While GRASS GIS is available on the user's computer, the respective
+While GRASS is available on the user's computer, the respective
 development package is lacking. If GRASS was installed from a (Linux)
 repository, also the grass-dev\* package (commonly named "grass-dev" or
 "grass-devel", sometimes along with the version number) must be
@@ -257,7 +257,7 @@ installed.
 
 *[g.extension.all](g.extension.all.md)*
 
-[GRASS GIS 8 Addons Manual
+[GRASS 8 Addons Manual
 pages](https://grass.osgeo.org/grass8/manuals/addons/)  
 [GRASS Addons](https://grasswiki.osgeo.org/wiki/GRASS_AddOns) wiki page.
 

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -81,19 +81,19 @@
 
 # %flag
 # % key: l
-# % description: List available extensions in the official GRASS GIS Addons repository
+# % description: List available extensions in the official GRASS Addons repository
 # % guisection: Print
 # % suppress_required: yes
 # %end
 # %flag
 # % key: c
-# % description: List available extensions in the official GRASS GIS Addons repository including module description
+# % description: List available extensions in the official GRASS Addons repository including module description
 # % guisection: Print
 # % suppress_required: yes
 # %end
 # %flag
 # % key: g
-# % description: List available extensions in the official GRASS GIS Addons repository (shell script style)
+# % description: List available extensions in the official GRASS Addons repository (shell script style)
 # % guisection: Print
 # % suppress_required: yes
 # %end
@@ -201,7 +201,7 @@ else:
 
 class GitAdapter:
     """
-    Basic class for listing and downloading GRASS GIS AddOns using git
+    Basic class for listing and downloading GRASS AddOns using git
 
     """
 
@@ -313,7 +313,7 @@ class GitAdapter:
         """Return commit hash reference and names for remote branches of
         a git repository
 
-        :param url: URL to git repository, defaults to the official GRASS GIS
+        :param url: URL to git repository, defaults to the official GRASS
                     addon repository
         """
         branch_list = gs.Popen(
@@ -330,7 +330,7 @@ class GitAdapter:
         """Return commit hash reference and names for remote branches of
         a git repository
 
-        :param url: URL to git repository, defaults to the official GRASS GIS
+        :param url: URL to git repository, defaults to the official GRASS
                     addon repository
         """
         default_branch = gs.Popen(
@@ -2366,7 +2366,7 @@ def check_style_file(name):
         gs.warning(
             _(
                 "Unable to create '{filename}': {error}."
-                " Is the GRASS GIS documentation package installed?"
+                " Is the GRASS documentation package installed?"
                 " Installation continues,"
                 " but documentation may not look right."
             ).format(filename=addons_file, error=error)
@@ -2853,7 +2853,7 @@ def main():
         else:
             if original_url == "" or flags["o"]:
                 # Query GitHub API only if extension will be downloaded
-                # from official GRASS GIS addons repository
+                # from official GRASS addons repository
                 get_addons_paths(gg_addons_base_dir=options["prefix"])
             source, url = resolve_source_code(
                 name=options["extension"],

--- a/scripts/g.search.modules/g.search.modules.html
+++ b/scripts/g.search.modules/g.search.modules.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em>g.search.module</em> searches for given keyword in GRASS GIS modules name,
+<em>g.search.module</em> searches for given keyword in GRASS modules name,
 description, keywords and optionally manpages, too. Also installed addons are
 considered in the search.
 

--- a/scripts/g.search.modules/g.search.modules.md
+++ b/scripts/g.search.modules/g.search.modules.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*g.search.module* searches for given keyword in GRASS GIS modules name,
+*g.search.module* searches for given keyword in GRASS modules name,
 description, keywords and optionally manpages, too. Also installed
 addons are considered in the search.
 

--- a/scripts/i.band.library/i.band.library.html
+++ b/scripts/i.band.library/i.band.library.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>i.band.library</em> prints available band information of multispectral data
-defined by GRASS GIS. The following multispectral sensors are supported
+defined by GRASS. The following multispectral sensors are supported
 by default (other band reference registry files can be added, see below):
 
 <p>
@@ -111,8 +111,7 @@ Earth Engine API</a> for example) to address multi spectral satellite
 images series. GRASS supports a multi-band raster layer approach
 basically with the imagery group concept
 (<em><a href="i.group.html">i.group</a></em>). A new semantic label
-concept is designed in order to support image collections in GRASS
-GIS.
+concept is designed in order to support image collections in GRASS.
 
 <h3>Band reference registry files</h3>
 
@@ -176,7 +175,7 @@ whole series or by specific <i>shortcut</i>_<i>band</i>
 identifier.
 
 <p>
-System-defined registry files are located in GRASS GIS installation
+System-defined registry files are located in GRASS installation
 directory (<code>$GISBASE/etc/i.band.library</code>). Note that
 currently <i>i.band.library</i> allows managing only system-defined registry
 files. Support for user-defined registry files is planned to be

--- a/scripts/i.band.library/i.band.library.md
+++ b/scripts/i.band.library/i.band.library.md
@@ -1,7 +1,7 @@
 ## DESCRIPTION
 
 *i.band.library* prints available band information of multispectral data
-defined by GRASS GIS. The following multispectral sensors are supported
+defined by GRASS. The following multispectral sensors are supported
 by default (other band reference registry files can be added, see
 below):
 
@@ -101,7 +101,7 @@ API](https://developers.google.com/earth-engine/tutorial_api_04) for
 example) to address multi spectral satellite images series. GRASS
 supports a multi-band raster layer approach basically with the imagery
 group concept (*[i.group](i.group.md)*). A new semantic label concept is
-designed in order to support image collections in GRASS GIS.
+designed in order to support image collections in GRASS.
 
 ### Band reference registry files
 
@@ -160,7 +160,7 @@ Band reference identifier defined by **pattern** option is given by a
 *shortcut* in order to print band reference information for whole series
 or by specific *shortcut*\_*band* identifier.
 
-System-defined registry files are located in GRASS GIS installation
+System-defined registry files are located in GRASS installation
 directory (`$GISBASE/etc/i.band.library`). Note that currently
 *i.band.library* allows managing only system-defined registry files.
 Support for user-defined registry files is planned to be implemented,

--- a/scripts/i.colors.enhance/testsuite/test_i_colors_enhance.py
+++ b/scripts/i.colors.enhance/testsuite/test_i_colors_enhance.py
@@ -4,7 +4,7 @@ from grass.gunittest.main import test
 
 
 class TestColorsEnhance(TestCase):
-    """Regression test suite for i.colors.enhance module in GRASS GIS."""
+    """Regression test suite for i.colors.enhance module in GRASS."""
 
     @classmethod
     def setUpClass(cls):

--- a/scripts/i.image.mosaic/i.image.mosaic.html
+++ b/scripts/i.image.mosaic/i.image.mosaic.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>i.image.mosaic</em> mosaics several images or raster maps using the
-GRASS GIS map calculator, and extends the colormap to the range of all images.
+GRASS map calculator, and extends the colormap to the range of all images.
 
 <h2>SEE ALSO</h2>
 

--- a/scripts/i.image.mosaic/i.image.mosaic.md
+++ b/scripts/i.image.mosaic/i.image.mosaic.md
@@ -1,7 +1,7 @@
 ## DESCRIPTION
 
 *i.image.mosaic* mosaics several images or raster maps using the GRASS
-GIS map calculator, and extends the colormap to the range of all images.
+map calculator, and extends the colormap to the range of all images.
 
 ## SEE ALSO
 

--- a/scripts/r.pack/r.pack.html
+++ b/scripts/r.pack/r.pack.html
@@ -2,7 +2,7 @@
 
 <em>r.pack</em> collects raster map elements and support files and
 compressed them using <em>gzip</em> algorithm for copying. The resulting
-packed file can be afterwards unpacked within a GRASS GIS session
+packed file can be afterwards unpacked within a GRASS session
 by <em><a href="r.unpack.html">r.unpack</a></em>.
 
 Since the selected raster map is not exported but natively stored, the

--- a/scripts/r.pack/r.pack.md
+++ b/scripts/r.pack/r.pack.md
@@ -2,7 +2,7 @@
 
 *r.pack* collects raster map elements and support files and compressed
 them using *gzip* algorithm for copying. The resulting packed file can
-be afterwards unpacked within a GRASS GIS session by
+be afterwards unpacked within a GRASS session by
 *[r.unpack](r.unpack.md)*. Since the selected raster map is not exported
 but natively stored, the current region is not respected. Hence *r.pack*
 stores the entire raster map.

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -14,7 +14,7 @@
 #############################################################################
 
 # %module
-# % description: Exports a raster map as GRASS GIS specific archive file
+# % description: Exports a raster map as GRASS specific archive file
 # % keyword: raster
 # % keyword: export
 # % keyword: copying

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -14,7 +14,7 @@
 #############################################################################
 
 # %module
-# % description: Imports a GRASS GIS specific raster archive file (packed with r.pack) as a raster map
+# % description: Imports a GRASS specific raster archive file (packed with r.pack) as a raster map
 # % keyword: raster
 # % keyword: import
 # % keyword: copying
@@ -126,7 +126,7 @@ def main():
     elif os.path.exists("coor"):
         grass.fatal(
             _(
-                "This GRASS GIS pack file contains vector data. Use "
+                "This GRASS pack file contains vector data. Use "
                 "v.unpack to unpack <{name}>"
             ).format(name=map_name)
         )

--- a/scripts/v.centroids/v.centroids.html
+++ b/scripts/v.centroids/v.centroids.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-In GRASS GIS, a centroid is a point within a closed ring of boundaries.
+In GRASS, a centroid is a point within a closed ring of boundaries.
 A vector area is defined as composite entity consisting of a set of
 closed boundaries and a centroid. The attribute information associated
 with this area is linked to the centroid.

--- a/scripts/v.centroids/v.centroids.md
+++ b/scripts/v.centroids/v.centroids.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-In GRASS GIS, a centroid is a point within a closed ring of boundaries.
+In GRASS, a centroid is a point within a closed ring of boundaries.
 A vector area is defined as composite entity consisting of a set of
 closed boundaries and a centroid. The attribute information associated
 with this area is linked to the centroid. The *v.centroids* module adds

--- a/scripts/v.db.update/v.db.update.html
+++ b/scripts/v.db.update/v.db.update.html
@@ -62,7 +62,7 @@ v.db.update mygeodetic_pts col=zval qcol="CAST(z_value AS double precision)" \
 
 <h3>Updating of columns with on the fly calculation (SQLite extended functions)</h3>
 
-Note: this requires SQLite extended functions. For details see the GRASS GIS Wiki
+Note: this requires SQLite extended functions. For details see the GRASS Wiki
 (compilation of <a href="https://grasswiki.osgeo.org/wiki/Build_SQLite_extension_on_Linux">libsqlitefunctions.so</a>
 and <a href="https://grasswiki.osgeo.org/wiki/Build_SQLite_extension_on_windows">libsqlitefunctions.dll</a>).
 <p>

--- a/scripts/v.db.update/v.db.update.md
+++ b/scripts/v.db.update/v.db.update.md
@@ -65,7 +65,7 @@ v.db.update mygeodetic_pts col=zval qcol="CAST(z_value AS double precision)" \
 ### Updating of columns with on the fly calculation (SQLite extended functions)
 
 Note: this requires SQLite extended functions. For details see the GRASS
-GIS Wiki (compilation of
+Wiki (compilation of
 [libsqlitefunctions.so](https://grasswiki.osgeo.org/wiki/Build_SQLite_extension_on_Linux)
 and
 [libsqlitefunctions.dll](https://grasswiki.osgeo.org/wiki/Build_SQLite_extension_on_windows)).

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -188,7 +188,7 @@ def sql_escape(text):
 
     Simple support for direct creation of SQL statements. This function,
     column_value_to_where, and updates_to_sql need a rewrite with a more systematic
-    solution for generating statements in Python for GRASS GIS attribute engine.
+    solution for generating statements in Python for GRASS attribute engine.
     """
     if isinstance(text, str):
         return text.replace("'", "''")

--- a/scripts/v.dissolve/v_dissolve.ipynb
+++ b/scripts/v.dissolve/v_dissolve.ipynb
@@ -23,7 +23,7 @@
     "import subprocess\n",
     "import sys\n",
     "\n",
-    "# Ask GRASS GIS where its Python packages are.\n",
+    "# Ask GRASS where its Python packages are.\n",
     "sys.path.append(\n",
     "    subprocess.check_output([\"grass\", \"--config\", \"python_path\"], text=True).strip()\n",
     ")\n",

--- a/scripts/v.pack/v.pack.py
+++ b/scripts/v.pack/v.pack.py
@@ -15,7 +15,7 @@
 #############################################################################
 
 # %module
-# % description: Exports a vector map as GRASS GIS specific archive file
+# % description: Exports a vector map as GRASS specific archive file
 # % keyword: vector
 # % keyword: export
 # % keyword: copying

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -15,7 +15,7 @@
 #############################################################################
 
 # %module
-# % description: Imports a GRASS GIS specific vector archive file (packed with v.pack) as a vector map
+# % description: Imports a GRASS specific vector archive file (packed with v.pack) as a vector map
 # % keyword: vector
 # % keyword: import
 # % keyword: copying
@@ -134,10 +134,7 @@ def main():
         pass
     elif os.path.exists(os.path.join(data_name, "cell")):
         grass.fatal(
-            _(
-                "This GRASS GIS pack file contains raster data. Use "
-                "r.unpack to unpack <%s>"
-            )
+            _("This GRASS pack file contains raster data. Use r.unpack to unpack <%s>")
             % map_name
         )
     else:

--- a/scripts/windows_sh_launch.bat
+++ b/scripts/windows_sh_launch.bat
@@ -2,7 +2,7 @@ REM Unfortunately not translatable messages here
 
 IF "%GRASS_SHELL%"=="" (
     ECHO The GRASS_SHELL environmental variable is not defined.
-    ECHO To use Bash/Shell scripts in GRASS GIS,
+    ECHO To use Bash/Shell scripts in GRASS,
     ECHO set the variable using something like:
     ECHO SET GRASS_SHELL="C:\path\to\bash.exe"
     EXIT /b

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -1,7 +1,7 @@
-# Singularity GRASS GIS (Debian Linux)
+# Singularity GRASS (Debian Linux)
 
 Singularityfile with an [Debian Linux](https://www.debian.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
+[GRASS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 560 MB.
 

--- a/singularity/debian/singularityfile_debian
+++ b/singularity/debian/singularityfile_debian
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: debian:bullseye
 
 %help
-Singularity container for GRASS GIS to be run into GRASS main directory
+Singularity container for GRASS to be run into GRASS main directory
 
 %labels
   Maintainer Luca Delucchi
@@ -117,9 +117,9 @@ Singularity container for GRASS GIS to be run into GRASS main directory
         --without-opengl \
         --without-openmp
 	make -j 2 && make install && ldconfig
-    # Create generic GRASS GIS binary name regardless of version number
+    # Create generic GRASS binary name regardless of version number
     ln -sf `find /usr/local/bin -name "grass??" | sort | tail -n 1` /usr/local/bin/grass
-    # Create generic GRASS GIS lib name regardless of version number
+    # Create generic GRASS lib name regardless of version number
     ln -sf `grass --config path` /usr/local/grass
     # Remove unused file
     apt-get autoremove -y

--- a/temporal/run_all_tests.sh
+++ b/temporal/run_all_tests.sh
@@ -3,7 +3,7 @@
 # Logs a written to "run.log"
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program." 1>&2
+    echo "You must be in GRASS to run this program." 1>&2
     exit 1
 fi
 

--- a/temporal/t.rast.extract/t.rast.extract.html
+++ b/temporal/t.rast.extract/t.rast.extract.html
@@ -12,7 +12,7 @@ sub-expression is defined, the base name of the resulting raster maps
 must be specified. The <em>r.mapcalc</em> expression can be used to
 select maps as well, since by default resulting empty maps are not
 registered in the output space time raster dataset and removed after
-processing. The number of parallel GRASS GIS processes can be specified
+processing. The number of parallel GRASS processes can be specified
 to speed up the processing.
 <p>
 If no <em>r.mapcalc</em> expression is defined, the selected maps are

--- a/temporal/t.rast.extract/t.rast.extract.md
+++ b/temporal/t.rast.extract/t.rast.extract.md
@@ -11,7 +11,7 @@ raster map. In case a *r.mapcalc* sub-expression is defined, the base
 name of the resulting raster maps must be specified. The *r.mapcalc*
 expression can be used to select maps as well, since by default
 resulting empty maps are not registered in the output space time raster
-dataset and removed after processing. The number of parallel GRASS GIS
+dataset and removed after processing. The number of parallel GRASS
 processes can be specified to speed up the processing.
 
 If no *r.mapcalc* expression is defined, the selected maps are simply

--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -28,7 +28,7 @@ To enable parallel processing, the user can specify the number of threads to be
 used with the <b>nprocs</b> parameter (default 1). The <b>memory</b> parameter
 (default 300 MB) can also be provided to determine the size of the buffer in MB for
 computation. Both parameters are passed to <a href="r.series.html">r.series</a>.
-To take advantage of the parallelization, GRASS GIS
+To take advantage of the parallelization, GRASS
 needs to be compiled with OpenMP enabled.
 
 

--- a/temporal/t.rast.series/t.rast.series.md
+++ b/temporal/t.rast.series/t.rast.series.md
@@ -30,7 +30,7 @@ threads to be used with the **nprocs** parameter (default 1). The
 **memory** parameter (default 300 MB) can also be provided to determine
 the size of the buffer in MB for computation. Both parameters are passed
 to [r.series](r.series.md). To take advantage of the parallelization,
-GRASS GIS needs to be compiled with OpenMP enabled.
+GRASS needs to be compiled with OpenMP enabled.
 
 ## EXAMPLES
 

--- a/temporal/t.register/t.register.html
+++ b/temporal/t.register/t.register.html
@@ -7,7 +7,7 @@ them within input space time datasets (stds). The existing timestamp modules
 <a href="r.timestamp.html">r.timestamp</a>,
 <a href="r3.timestamp.html">r3.timestamp</a> and
 <a href="v.timestamp.html">v.timestamp</a> do not register the maps in the
-temporal database of GRASS GIS. However, timestamps that have been created
+temporal database of GRASS. However, timestamps that have been created
 with these modules can be read and used by <em>t.register</em>. This
 works only for maps that are not already registered in the temporal
 database.

--- a/temporal/t.register/t.register.md
+++ b/temporal/t.register/t.register.md
@@ -6,7 +6,7 @@ timestamps to raster, 3D raster and vector maps in the temporal database
 registers them within input space time datasets (stds). The existing
 timestamp modules [r.timestamp](r.timestamp.md),
 [r3.timestamp](r3.timestamp.md) and [v.timestamp](v.timestamp.md) do not
-register the maps in the temporal database of GRASS GIS. However,
+register the maps in the temporal database of GRASS. However,
 timestamps that have been created with these modules can be read and
 used by *t.register*. This works only for maps that are not already
 registered in the temporal database.

--- a/temporal/t.vect.export/t.vect.export.py
+++ b/temporal/t.vect.export/t.vect.export.py
@@ -21,7 +21,7 @@
 #############################################################################
 
 # %module
-# % description: Exports a space time vector dataset as GRASS GIS specific archive file.
+# % description: Exports a space time vector dataset as GRASS specific archive file.
 # % keyword: temporal
 # % keyword: export
 # % keyword: vector

--- a/temporal/t.vect.import/t.vect.import.py
+++ b/temporal/t.vect.import/t.vect.import.py
@@ -21,7 +21,7 @@
 #############################################################################
 
 # %module
-# % description: Imports a space time vector dataset from a GRASS GIS specific archive file.
+# % description: Imports a space time vector dataset from a GRASS specific archive file.
 # % keyword: temporal
 # % keyword: import
 # % keyword: vector

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.html
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.html
@@ -15,7 +15,7 @@ The result is a new space time vector dataset that contains a single
 (new) vector map which links to as many time-stamped attribute tables
 as raster map layers are present in the input space time raster dataset.
 Hence, for each time step in the space time raster dataset a new
-attribute table is created. The GRASS GIS Temporal Framework allows
+attribute table is created. The GRASS Temporal Framework allows
 to time stamp attribute tables that can be linked to a single vector
 map layer.
 <p>

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.md
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.md
@@ -13,7 +13,7 @@ The result is a new space time vector dataset that contains a single
 (new) vector map which links to as many time-stamped attribute tables as
 raster map layers are present in the input space time raster dataset.
 Hence, for each time step in the space time raster dataset a new
-attribute table is created. The GRASS GIS Temporal Framework allows to
+attribute table is created. The GRASS Temporal Framework allows to
 time stamp attribute tables that can be linked to a single vector map
 layer.
 

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -5,12 +5,12 @@ This directory contains additional scripts and information to test functionality
 without a focus on a specific part of the code.
 
 There are two testing mechanism in place, _pytest_ which is the modern way of testing
-GRASS GIS. Tests using _pytest_ are written just as any other Python tests.
+GRASS. Tests using _pytest_ are written just as any other Python tests.
 
 In parallel, there is also custom unittest-based framework centered around
 _grass.gunittest_ package. These tests run in the NC sample datasets and can be
 executed using _pytest_ or directly. The unittest-based adds a number of custom
-assert methods to accommodate different data and outputs typical in GRASS GIS.
+assert methods to accommodate different data and outputs typical in GRASS.
 _grass.gunittest_ documentation:
 <https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html>
 

--- a/testsuite/raster_md5test.sh
+++ b/testsuite/raster_md5test.sh
@@ -9,7 +9,7 @@
 #   - compare with known results
 
 if [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program."
+    echo "You must be in GRASS to run this program."
     exit 1
 fi
 

--- a/utils/fix_typos.sh
+++ b/utils/fix_typos.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
-# Derived for GRASS GIS from
+# Derived for GRASS from
 # https://trac.osgeo.org/gdal/browser/trunk/gdal/scripts/fix_typos.sh
 #
-# Run in main source code directory of GRASS GIS:
+# Run in main source code directory of GRASS:
 # sh utils/fix_typos.sh
 #
 #
@@ -65,7 +65,7 @@ WORDS_WHITE_LIST="poSession,FIDN,TRAFIC,HTINK,repID,oCurr,INTREST,oPosition"
 WORDS_WHITE_LIST="$WORDS_WHITE_LIST,CPL_SUPRESS_CPLUSPLUS,SRP_NAM,ADRG_NAM,'SRP_NAM,AuxilaryTarget"
 # libtiff
 WORDS_WHITE_LIST="$WORDS_WHITE_LIST,THRESHHOLD_BILEVEL,THRESHHOLD_HALFTONE,THRESHHOLD_ERRORDIFFUSE"
-# GRASS GIS
+# GRASS
 WORDS_WHITE_LIST="$WORDS_WHITE_LIST,thru,parm,parms"
 
 MYPATH=$(pwd)

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -143,7 +143,7 @@ class Formatter:
             + os.path.basename(self.filename).replace(".html", "")
             + ' 1 "" "GRASS '
             + version
-            + '" "GRASS GIS User\'s Manual"'
+            + '" "GRASS User\'s Manual"'
         )
 
     def pp_tr(self, content):

--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -177,7 +177,7 @@ def print_notes(
     """
     num_changes = round_down_to_five(len(changes))
     print(
-        f"The GRASS GIS {end_tag} release provides more than "
+        f"The GRASS {end_tag} release provides more than "
         f"{num_changes} improvements and fixes "
         f"with respect to the release {start_tag}.\n"
     )

--- a/utils/grass_clang_format.sh
+++ b/utils/grass_clang_format.sh
@@ -2,7 +2,7 @@
 set -eu
 
 ###############################################################################
-# Format source code according to GRASS GIS submitting rules
+# Format source code according to GRASS submitting rules
 #
 # Dependencies:
 #    clang-format

--- a/utils/merge_sitemaps.py
+++ b/utils/merge_sitemaps.py
@@ -65,7 +65,7 @@ def import_nodes(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Merge XML sitemaps for GRASS GIS manual pages (MKDocs) and libpython (Sphinx)"
+        description="Merge XML sitemaps for GRASS manual pages (MKDocs) and libpython (Sphinx)"
     )
     parser.add_argument(
         "--mkdocs-sitemap",

--- a/utils/mkdocs.py
+++ b/utils/mkdocs.py
@@ -17,7 +17,7 @@ from urllib.error import HTTPError, URLError
 try:
     import grass.script as gs
 except ImportError:
-    # During compilation GRASS GIS
+    # During compilation GRASS
     gs = None
 
 from generate_last_commit_file import COMMIT_DATE_FORMAT
@@ -54,7 +54,7 @@ def get_version_branch(major_version, addons_git_repo_url):
     if not, take branch for the previous version
     For the official repo we assume that at least one version branch is present
 
-    :param major_version int: GRASS GIS major version
+    :param major_version int: GRASS major version
     :param addons_git_repo_url str: Addons Git repository URL
 
     :return version_branch str: version branch
@@ -140,7 +140,7 @@ def get_last_git_commit(src_dir, top_dir, pgm, addon_path, major_version):
         return get_git_commit_from_rest_api_for_addon_repo(
             addon_path=addon_path, src_dir=src_dir, pgm=pgm, major_version=major_version
         )
-    # During GRASS GIS compilation from source code without Git
+    # During GRASS compilation from source code without Git
     return get_git_commit_from_file(src_dir=src_dir, pgm=pgm)
 
 
@@ -224,7 +224,7 @@ def get_git_commit_from_rest_api_for_addon_repo(
     :param str addon_path: addon path
     :param str src_dir: addon source dir
     :param str pgm: program name
-    :param major_version int: GRASS GIS major version
+    :param major_version int: GRASS major version
     :param dict git_log: dict which store last commit and commnit date
 
     :return dict git_log: dict which store last commit and commnit date

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -30,7 +30,7 @@ import urllib.parse as urlparse
 try:
     import grass.script as gs
 except ImportError:
-    # During compilation GRASS GIS
+    # During compilation GRASS
     gs = None
 
 from mkdocs import (
@@ -93,7 +93,7 @@ header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
- <title>${PGM} - GRASS GIS Manual</title>
+ <title>${PGM} - GRASS Manual</title>
  <meta name="Author" content="GRASS Development Team">
  <meta name="description" content="${PGM}: ${PGM_DESC}">
  <link rel="stylesheet" href="grassdocs.css" type="text/css">
@@ -144,7 +144,7 @@ footer_index = string.Template(
 <p>
 &copy; 2003-${YEAR}
 <a href="https://grass.osgeo.org">GRASS Development Team</a>,
-GRASS GIS ${GRASS_VERSION} Reference Manual
+GRASS ${GRASS_VERSION} Reference Manual
 </p>
 
 </div>
@@ -165,7 +165,7 @@ footer_noindex = string.Template(
 <p>
 &copy; 2003-${YEAR}
 <a href="https://grass.osgeo.org">GRASS Development Team</a>,
-GRASS GIS ${GRASS_VERSION} Reference Manual
+GRASS ${GRASS_VERSION} Reference Manual
 </p>
 
 </div>
@@ -339,7 +339,7 @@ def update_toc(data):
 # process header
 src_data = read_file(src_file)
 name = re.search(r"(<!-- meta page name:)(.*)(-->)", src_data, re.IGNORECASE)
-pgm_desc = "GRASS GIS Reference Manual"
+pgm_desc = "GRASS Reference Manual"
 if name:
     pgm = name.group(2).strip().split("-", 1)[0].strip()
     name_desc = re.search(

--- a/utils/mkmarkdown.py
+++ b/utils/mkmarkdown.py
@@ -25,7 +25,7 @@ import urllib.parse as urlparse
 try:
     import grass.script as gs
 except ImportError:
-    # During compilation GRASS GIS
+    # During compilation GRASS
     gs = None
 
 from mkdocs import (

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -19,7 +19,7 @@
 #
 
 if  [ -z "$GISBASE" ] ; then
-    echo "You must be in GRASS GIS to run this program." 1>&2
+    echo "You must be in GRASS to run this program." 1>&2
     exit 1
 fi
 

--- a/utils/symbol_to_img.sh
+++ b/utils/symbol_to_img.sh
@@ -4,7 +4,7 @@
 #
 # MODULE:       symbol_to_img.sh
 # AUTHOR(S):    Anna Petrasova, Hamish Bowman, Vaclav Petras
-# PURPOSE:      Renders the GRASS GIS symbols from dir to a dir of PNGs
+# PURPOSE:      Renders the GRASS symbols from dir to a dir of PNGs
 # COPYRIGHT:    (C) 2012-2016 by Anna Petrasova
 #               and the GRASS Development Team
 #

--- a/utils/update_version.py
+++ b/utils/update_version.py
@@ -63,7 +63,7 @@ def suggest_commit(action, version, tag):
     print("use:")
     print(f"  commit_message: 'version: {action} {version}'")
     if tag:
-        print(f"  tag_message: 'GRASS GIS {version}'")
+        print(f"  tag_message: 'GRASS {version}'")
 
 
 def release_candidate(args):
@@ -86,7 +86,7 @@ def release_candidate(args):
         micro=micro,
         year=this_year(),
     )
-    suggest_commit_from_version_file("GRASS GIS", tag=True)
+    suggest_commit_from_version_file("GRASS", tag=True)
 
 
 def release(_unused):
@@ -106,7 +106,7 @@ def release(_unused):
         micro=micro,
         year=this_year(),
     )
-    suggest_commit_from_version_file("GRASS GIS", tag=True)
+    suggest_commit_from_version_file("GRASS", tag=True)
 
 
 def update_micro(_unused):
@@ -248,7 +248,7 @@ def suggest_message(args):
     version_info = read_version_file()
     if not version_info.micro.endswith("dev"):
         tag = construct_version(version_info)
-        action = "GRASS GIS"
+        action = "GRASS"
     else:
         tag = None
         action = "Start"

--- a/vector/v.build.polylines/tests/test_v_build_polylines.py
+++ b/vector/v.build.polylines/tests/test_v_build_polylines.py
@@ -6,7 +6,7 @@ import grass.script as gs
 @pytest.fixture
 def setup_polylines(tmp_path):
     """
-    Fixture to create a basic GRASS GIS project with a vector map 'lines' containing
+    Fixture to create a basic GRASS project with a vector map 'lines' containing
     connected and disconnected line features.
 
     The vector is created from ASCII standard format input defining three lines:

--- a/vector/v.build/v.build.html
+++ b/vector/v.build/v.build.html
@@ -10,7 +10,7 @@ cases the user has to (re)build them.
 
 <p>
 Refer to
-<a href="vectorintro.html">vector data processing in GRASS GIS</a> for
+<a href="vectorintro.html">vector data processing in GRASS</a> for
 more information on GRASS vector data model.
 
 <h2>NOTES</h2>
@@ -63,7 +63,7 @@ current mapset.
 Dump options print topology, spatial, category or feature index to
 standard output. Such information can also be printed for vector maps
 from other mapsets. A description of the vector topology is available in
-the <a href="https://grass.osgeo.org/programming8/vlibTopology.html">GRASS GIS 8 Programmer's Manual</a>,
+the <a href="https://grass.osgeo.org/programming8/vlibTopology.html">GRASS 8 Programmer's Manual</a>,
 section "Vector library topology management".
 
 <div class="code"><pre>

--- a/vector/v.build/v.build.md
+++ b/vector/v.build/v.build.md
@@ -7,7 +7,7 @@ that are needed by other GRASS modules.
 GRASS is generating these support files automatically, only in rare
 cases the user has to (re)build them.
 
-Refer to [vector data processing in GRASS GIS](vectorintro.md) for more
+Refer to [vector data processing in GRASS](vectorintro.md) for more
 information on GRASS vector data model.
 
 ## NOTES
@@ -51,7 +51,7 @@ mapset.
 Dump options print topology, spatial, category or feature index to
 standard output. Such information can also be printed for vector maps
 from other mapsets. A description of the vector topology is available in
-the [GRASS GIS 8 Programmer's
+the [GRASS 8 Programmer's
 Manual](https://grass.osgeo.org/programming8/vlibTopology.html), section
 "Vector library topology management".
 

--- a/vector/v.class/tests/test_v_class.py
+++ b/vector/v.class/tests/test_v_class.py
@@ -8,7 +8,7 @@ from grass.exceptions import CalledModuleError
 @pytest.fixture(scope="module")
 def setup_vector_with_values(tmp_path_factory):
     """
-    Pytest fixture to create a temporary GRASS GIS project with a vector map
+    Pytest fixture to create a temporary GRASS project with a vector map
     containing sample points and associated attribute data.
 
     This setup initializes the GRASS environment, sets the computational region,
@@ -16,7 +16,7 @@ def setup_vector_with_values(tmp_path_factory):
     and populates it with numeric values for testing classification.
 
     Yields:
-        session: active GRASS GIS session with the prepared project and vector map.
+        session: active GRASS session with the prepared project and vector map.
     """
     # Create a single temporary project directory once per module
     project = tmp_path_factory.mktemp("v_class_project")

--- a/vector/v.hull/testsuite/test_v_hull.py
+++ b/vector/v.hull/testsuite/test_v_hull.py
@@ -46,7 +46,7 @@ class TestVHull(TestCase):
         )
 
     def setUp(self):
-        """Creates temporary test point data and imports it into GRASS GIS as vector maps.s"""
+        """Creates temporary test point data and imports it into GRASS as vector maps.s"""
         self.temp_files = []
         self.temp_colinear = self.create_temp_file("0 0\n1 0\n2 0\n")
         self.temp_non_colinear = self.create_temp_file("0 0\n1 0\n0.5 1\n")

--- a/vector/v.in.db/v.in.db.html
+++ b/vector/v.in.db/v.in.db.html
@@ -140,7 +140,7 @@ v.in.db driver=sqlite database=/home/user/tables/mysqlite.db table=pointsfile x=
 </em>
 
 <p>
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.in.db/v.in.db.md
+++ b/vector/v.in.db/v.in.db.md
@@ -128,7 +128,7 @@ v.in.db driver=sqlite database=/home/user/tables/mysqlite.db table=pointsfile x=
 [v.info](v.info.md), [v.in.geonames](v.in.geonames.md),
 [v.in.ogr](v.in.ogr.md), [v.to.db](v.to.db.md)*
 
-[SQL support in GRASS GIS](sql.md)
+[SQL support in GRASS](sql.md)
 
 ## AUTHORS
 

--- a/vector/v.in.ogr/v.in.ogr.html
+++ b/vector/v.in.ogr/v.in.ogr.html
@@ -480,7 +480,7 @@ with <em><a href="v.proj.html">v.proj</a></em>.
 </em>
 
 <p>
-GRASS GIS Wiki page: Import of <a href="https://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
+GRASS Wiki page: Import of <a href="https://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.in.ogr/v.in.ogr.md
+++ b/vector/v.in.ogr/v.in.ogr.md
@@ -416,7 +416,7 @@ desired, you can then reproject it to another project with
 [v.import](v.import.md), [v.in.db](v.in.db.md), [v.in.e00](v.in.e00.md),
 [v.out.ogr](v.out.ogr.md)*
 
-GRASS GIS Wiki page: Import of [Global
+GRASS Wiki page: Import of [Global
 datasets](https://grasswiki.osgeo.org/wiki/Global_datasets)
 
 ## AUTHORS

--- a/vector/v.kernel/v.kernel.html
+++ b/vector/v.kernel/v.kernel.html
@@ -61,7 +61,7 @@ DOI: <a href="https://doi.org/10.1080/13658810802475491">10.1080/136588108024754
 <em><a href="v.surf.rst.html">v.surf.rst</a></em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.kernel/v.kernel.md
+++ b/vector/v.kernel/v.kernel.md
@@ -62,7 +62,7 @@ attribute values.
 *[v.surf.rst](v.surf.rst.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHORS
 

--- a/vector/v.mkgrid/v.mkgrid.html
+++ b/vector/v.mkgrid/v.mkgrid.html
@@ -66,7 +66,7 @@ Creating a 10x12 lat/lon grid, cells 2 arc-min a side, with lower left corner
 at 167deg 52min east, 47deg 6min south. For use with e.g. QGIS you can then
 pull this grid into a project with projected coordinate reference system (CRS)
 using <em>v.proj</em> before
-exporting as a vector file with <em>v.out.ogr</em> (within GRASS GIS you could
+exporting as a vector file with <em>v.out.ogr</em> (within GRASS you could
 just use <em>d.grid -w</em> from the project with projected CRS for the same effect):
 
 <div class="code"><pre>

--- a/vector/v.mkgrid/v.mkgrid.md
+++ b/vector/v.mkgrid/v.mkgrid.md
@@ -68,7 +68,7 @@ Creating a 10x12 lat/lon grid, cells 2 arc-min a side, with lower left
 corner at 167deg 52min east, 47deg 6min south. For use with e.g. QGIS
 you can then pull this grid into a project with projected coordinate
 reference system (CRS) using *v.proj* before exporting as a vector file
-with *v.out.ogr* (within GRASS GIS you could just use *d.grid -w* from
+with *v.out.ogr* (within GRASS you could just use *d.grid -w* from
 the project with projected CRS for the same effect):
 
 ```sh

--- a/vector/v.net.bridge/v.net.bridge.html
+++ b/vector/v.net.bridge/v.net.bridge.html
@@ -19,7 +19,7 @@ other hand, for <b>method=articulation</b>, points are created on
 the positions of articulation points.
 <p>
 
-<br>In GRASS GIS, <em>line</em> is not always a single line
+<br>In GRASS, <em>line</em> is not always a single line
 segment. It might be, and often is, a sequence of line segments
 between two intersections. Also, articulation point is a standard
 graph theoretic terminology which is slightly misleading in GRASS.

--- a/vector/v.net.bridge/v.net.bridge.md
+++ b/vector/v.net.bridge/v.net.bridge.md
@@ -17,7 +17,7 @@ input map to the output map. On the other hand, for
 **method=articulation**, points are created on the positions of
 articulation points.
 
-In GRASS GIS, *line* is not always a single line segment. It might be,
+In GRASS, *line* is not always a single line segment. It might be,
 and often is, a sequence of line segments between two intersections.
 Also, articulation point is a standard graph theoretic terminology which
 is slightly misleading in GRASS. An articulation point in graph theory

--- a/vector/v.net/v.net.html
+++ b/vector/v.net/v.net.html
@@ -11,7 +11,7 @@ operator), and by creating new lines between pairs of vector points
 <p>
 A GIS network consists of topologically correct lines (arcs). That is,
 the lines must be connected by shared vertices where real connections exist.
-In GRASS GIS you also can add nodes to the network. These are specially
+In GRASS you also can add nodes to the network. These are specially
 designated vertices used for analyzing network properties or computing
 cost/distance measures. That is, <b>not all vertices are treated as nodes by
 default</b>. Only <em><a href="v.net.path.html">v.net.path</a></em> can use a
@@ -150,7 +150,7 @@ If vector editing is required to modify the
 graph, <em><a href="g.gui.vdigit.html">g.gui.vdigit</a></em>
 or <em><a href="v.edit.html">v.edit</a></em> can be used.  See also
 the <a href="lrs.html">Linear Referencing System</a> available in
-GRASS GIS.
+GRASS.
 
 <h2>EXAMPLES</h2>
 

--- a/vector/v.net/v.net.md
+++ b/vector/v.net/v.net.md
@@ -9,7 +9,7 @@ points (*arcs* operator).
 
 A GIS network consists of topologically correct lines (arcs). That is,
 the lines must be connected by shared vertices where real connections
-exist. In GRASS GIS you also can add nodes to the network. These are
+exist. In GRASS you also can add nodes to the network. These are
 specially designated vertices used for analyzing network properties or
 computing cost/distance measures. That is, **not all vertices are
 treated as nodes by default**. Only *[v.net.path](v.net.path.md)* can
@@ -116,7 +116,7 @@ For a vector map prepared for network analysis in GRASS, nodes are
 represented by the grass-internal geometry type *node* and arcs by the
 geometry type *line*. If vector editing is required to modify the graph,
 *[g.gui.vdigit](g.gui.vdigit.md)* or *[v.edit](v.edit.md)* can be used.
-See also the [Linear Referencing System](lrs.md) available in GRASS GIS.
+See also the [Linear Referencing System](lrs.md) available in GRASS.
 
 ## EXAMPLES
 

--- a/vector/v.out.postgis/v.out.postgis.html
+++ b/vector/v.out.postgis/v.out.postgis.html
@@ -4,7 +4,7 @@
 PostGIS feature table. Features without category are skipped.
 
 <p>
-By default GRASS GIS topological features are converted into simple
+By default GRASS topological features are converted into simple
 features
 (see <a href="https://www.ogc.org/publications/standard/sfa/">OGC Simple
 Feature Access</a> specification for details). Flag <b>-l</b> allows

--- a/vector/v.out.postgis/v.out.postgis.md
+++ b/vector/v.out.postgis/v.out.postgis.md
@@ -3,7 +3,7 @@
 *v.out.postgis* exports an existing GRASS vector map layer to PostGIS
 feature table. Features without category are skipped.
 
-By default GRASS GIS topological features are converted into simple
+By default GRASS topological features are converted into simple
 features (see [OGC Simple Feature
 Access](https://www.ogc.org/publications/standard/sfa/) specification
 for details). Flag **-l** allows to export vector features as

--- a/vector/v.profile/main.c
+++ b/vector/v.profile/main.c
@@ -4,7 +4,7 @@
  *
  * AUTHOR(S):  Maris Nartiss <maris.gis@gmail.com>
  *             with hints from v.out.ascii, v.buffer, v.what
- *             and other GRASS GIS modules
+ *             and other GRASS modules
  *
  * PURPOSE:    Output vector point/line values along sampling line
  *

--- a/vector/v.profile/v.profile.html
+++ b/vector/v.profile/v.profile.html
@@ -77,7 +77,7 @@ the attribute table.
 <p>
 If sampled feature (point, line) contains multiple attribute entries
 (has multiple CAT values), only the first one is reported. If this is a
-limitation in some practical use case, a feature request in GRASS GIS
+limitation in some practical use case, a feature request in GRASS
 issue tracker should be opened.
 
 <h2>SEE ALSO</h2>

--- a/vector/v.profile/v.profile.md
+++ b/vector/v.profile/v.profile.md
@@ -75,7 +75,7 @@ is from the attribute table.
 
 If sampled feature (point, line) contains multiple attribute entries
 (has multiple CAT values), only the first one is reported. If this is a
-limitation in some practical use case, a feature request in GRASS GIS
+limitation in some practical use case, a feature request in GRASS
 issue tracker should be opened.
 
 ## SEE ALSO

--- a/vector/v.random/v.random.html
+++ b/vector/v.random/v.random.html
@@ -268,7 +268,7 @@ random sampling)
 <a href="v.what.vect.html">v.what.vect</a>
 </em>
 <p>
-<a href="sql.html">SQL support in GRASS GIS</a>
+<a href="sql.html">SQL support in GRASS</a>
 
 <h2>AUTHOR</h2>
 

--- a/vector/v.random/v.random.md
+++ b/vector/v.random/v.random.md
@@ -232,7 +232,7 @@ random sampling)*
 [v.sample](v.sample.md), [v.univar](v.univar.md),
 [v.what.rast](v.what.rast.md), [v.what.vect](v.what.vect.md)*
 
-[SQL support in GRASS GIS](sql.md)
+[SQL support in GRASS](sql.md)
 
 ## AUTHOR
 

--- a/vector/v.support/v.support.html
+++ b/vector/v.support/v.support.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 <em>v.support</em> is used to set/update vector map metadata. While GRASS
-GIS typically generates these metadata entries automatically, <em>v.support</em>
+typically generates these metadata entries automatically, <em>v.support</em>
 allows users to manually edit them when necessary.
 
 <h2>EXAMPLE</h2>

--- a/vector/v.support/v.support.md
+++ b/vector/v.support/v.support.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*v.support* is used to set/update vector map metadata. While GRASS GIS
+*v.support* is used to set/update vector map metadata. While GRASS
 typically generates these metadata entries automatically, *v.support*
 allows users to manually edit them when necessary.
 

--- a/vector/v.surf.bspline/v.surf.bspline.html
+++ b/vector/v.surf.bspline/v.surf.bspline.html
@@ -177,7 +177,7 @@ no problems with the raster map output from the DBF driver.
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.surf.bspline/v.surf.bspline.md
+++ b/vector/v.surf.bspline/v.surf.bspline.md
@@ -167,7 +167,7 @@ DBF driver.
 *[v.surf.idw](v.surf.idw.md), [v.surf.rst](v.surf.rst.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHORS
 

--- a/vector/v.surf.idw/v.surf.idw.html
+++ b/vector/v.surf.idw/v.surf.idw.html
@@ -89,7 +89,7 @@ raster Voronoi diagrams (Thiessen polygons).
 </em>
 
 <p>
-Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS GIS
+Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">Interpolation and Resampling</a> in GRASS
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.surf.idw/v.surf.idw.md
+++ b/vector/v.surf.idw/v.surf.idw.md
@@ -79,7 +79,7 @@ Voronoi diagrams (Thiessen polygons).
 [v.surf.rst](v.surf.rst.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 ## AUTHORS
 

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
     omp_set_num_threads(threads);
 #else
     if (threads > 1)
-        G_warning(_("GRASS GIS is not compiled with OpenMP support, parallel "
+        G_warning(_("GRASS is not compiled with OpenMP support, parallel "
                     "computation is disabled."));
 #endif
     if (threads > 1 && Rast_mask_is_present()) {

--- a/vector/v.surf.rst/v.surf.rst.html
+++ b/vector/v.surf.rst/v.surf.rst.html
@@ -412,7 +412,7 @@ d.vect elevrand where="value &gt; 94.9"
 
 <p>
 Overview: <a href="https://grasswiki.osgeo.org/wiki/Interpolation">
- Interpolation and Resampling</a> in GRASS GIS
+ Interpolation and Resampling</a> in GRASS
 
 <p>
 For examples of applications see

--- a/vector/v.surf.rst/v.surf.rst.md
+++ b/vector/v.surf.rst/v.surf.rst.md
@@ -345,7 +345,7 @@ d.vect elevrand where="value > 94.9"
 [g.region](g.region.md)*
 
 Overview: [Interpolation and
-Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS GIS
+Resampling](https://grasswiki.osgeo.org/wiki/Interpolation) in GRASS
 
 For examples of applications see [GRASS4
 implementation](http://fatra.cnr.ncsu.edu/~hmitaso/gmslab/) and [GRASS5

--- a/vector/v.type/v.type.html
+++ b/vector/v.type/v.type.html
@@ -3,7 +3,7 @@
 <em>v.type</em> changes the type of geometry primitives.
 
 <p>
-The following vector object types are defined in GRASS GIS:
+The following vector object types are defined in GRASS:
 
 <ul>
 <li> point: a point;</li>

--- a/vector/v.type/v.type.md
+++ b/vector/v.type/v.type.md
@@ -2,7 +2,7 @@
 
 *v.type* changes the type of geometry primitives.
 
-The following vector object types are defined in GRASS GIS:
+The following vector object types are defined in GRASS:
 
 - point: a point;
 - line: a directed sequence of connected vertices with two endpoints

--- a/vector/v.vol.rst/v.vol.rst.html
+++ b/vector/v.vol.rst/v.vol.rst.html
@@ -208,7 +208,7 @@ paraview --data=elevrand_3d.vtk
 # interpolate volume to "soilrange" voxel map
 v.vol.rst input=elevrand_3d wcol=soilrange elevation=soilrange zscale=100
 
-# visualize I: in GRASS GIS wxGUI
+# visualize I: in GRASS wxGUI
 g.gui
 # load: 2D raster map: elevation.10m
 #       3D raster map: soilrange

--- a/vector/v.vol.rst/v.vol.rst.md
+++ b/vector/v.vol.rst/v.vol.rst.md
@@ -204,7 +204,7 @@ paraview --data=elevrand_3d.vtk
 # interpolate volume to "soilrange" voxel map
 v.vol.rst input=elevrand_3d wcol=soilrange elevation=soilrange zscale=100
 
-# visualize I: in GRASS GIS wxGUI
+# visualize I: in GRASS wxGUI
 g.gui
 # load: 2D raster map: elevation.10m
 #       3D raster map: soilrange

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -1,4 +1,4 @@
-<!-- meta page description: Vector data processing in GRASS GIS -->
+<!-- meta page description: Vector data processing in GRASS -->
 <!-- meta page index: vector -->
 <h3>Vector maps in general</h3>
 
@@ -12,15 +12,15 @@ or 3D space and are independent of the GIS's computation region.
 
 <h3>Attribute management</h3>
 
-The default database driver used by GRASS GIS 8 is SQLite. GRASS GIS
+The default database driver used by GRASS 8 is SQLite. GRASS
 handles multiattribute vector data by default. The <em>db.*</em> set of
 commands  provides basic SQL support for attribute management, while the
 <em>v.db.*</em> set of commands operates on vector maps.
 
 <p>
 Note: The list of available database drivers can vary in various binary
-distributions of GRASS GIS, for details see
-<a href="sql.html">SQL support in GRASS GIS</a>.
+distributions of GRASS, for details see
+<a href="sql.html">SQL support in GRASS</a>.
 
 <h3>Vector data import and export</h3>
 
@@ -43,7 +43,7 @@ and export only attribute tables, use <a href="db.in.ogr.html">db.in.ogr</a>
 and <a href="db.out.ogr.html">db.out.ogr</a>.
 
 <p>
-GRASS GIS vector map exchange between different projects (same projection)
+GRASS vector map exchange between different projects (same projection)
 can be done in a lossless way using the <a href="v.pack.html">v.pack</a>
 and <a href="v.unpack.html">v.unpack</a> modules.
 

--- a/vector/vectorintro.md
+++ b/vector/vectorintro.md
@@ -17,14 +17,13 @@ space and are independent of the GIS's computation region.
 
 ## Attribute management
 
-The default database driver used by GRASS GIS 8 is SQLite. GRASS
+The default database driver used by GRASS 8 is SQLite. GRASS
 handles multiattribute vector data by default. The *db.\** set of
 commands provides basic SQL support for attribute management, while the
 *v.db.\** set of commands operates on vector maps.
 
 Note: The list of available database drivers can vary in various binary
-distributions of GRASS, for details see [SQL support in GRASS
-GIS](sql.md).
+distributions of GRASS, for details see [SQL support in GRASS](sql.md).
 
 ## Vector data import and export
 


### PR DESCRIPTION
Continuation of #6162

It should cover the remaining of the repo.
If really too big, I could try splitting it up, when I have access to a computer _with internet access_ at some point, but it’ll be the exact same contents. Use the checkboxes on the files reviewed. It’s about 570 lines changed.

The remaining would be to discuss
