### PR TITLE
i.in.spotvgt: bug fixes

### DIFF
--- a/scripts/i.in.spotvgt/i.in.spotvgt.py
+++ b/scripts/i.in.spotvgt/i.in.spotvgt.py
@@ -179,7 +179,7 @@ def main():
 
     # clone current region
     # switch to a temporary region
-    # gs.use_temp_region()
+    gs.use_temp_region()
 
     gs.run_command("g.region", raster=name, quiet=True)
 


### PR DESCRIPTION
This PR addresses the four issues in the `i.in.spotvgt` module that previously led to incorrect imports or completely null raster outputs as highlighted in https://github.com/OSGeo/grass/issues/6175.

## Summary of Changes:
- Line `if f < 2:` caused type error due to comparison of list directly, it has been correctly fixed as `if len(f) < 2:`
- Previously, `qname = spotname.replace("NDV", "SM")` resulted in missing file error due to missing extension. This has been fixed by changing it to `qname = spotname.replace("NDV", "SM") + ".HDF"`
- In the old version,
```python
rules = [
    r + "\n"
    for r in [
        "8 50 50 50",
        ...
    ]
]
gs.write_command("r.colors", map=smfile, rules="-", stdin=rules)
```
raised `TypeError` as `stdin` can only accept string or bytes. This has been fixed by modifying it to:
```python
rules = """8 50 50 50
11 70 70 70
...
252 green
"""
```
- Line `gs.use_temp_region()` caused the output map to be null, since the temporary region prevented g.rename and r.mapcalc results from being preserved in main mapset. This line has been commented out.

This PR closes #6175.