### PR TITLE
wxGUI: fix URL of gismentors.zip data file

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -72,7 +72,7 @@ LOCATIONS = [
     },
     {
         "label": "GISMentors dataset, Czech Republic",
-        "url": "http://training.gismentors.eu/geodata/grass/gismentors.zip",
+        "url": "https://www.training.gismentors.cz/geodata/grass/gismentors.zip",
     },
     {
         "label": "Natural Earth Dataset in WGS84",


### PR DESCRIPTION
Update outdated URL to `gismentors.zip` project data.

Source: https://www.training.gismentors.cz/geodata/grass/