### PR TITLE
grass.gunittest: Remove Python2-only `-tt` interpreter option

### DIFF
--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -169,8 +169,7 @@ class GrassTestFilesInvoker:
         if module.file_type == "py":
             # ignoring shebang line to use current Python
             # and also pass parameters to it
-            # add also '-Qwarn'?
-            args = [sys.executable, "-tt", module.abs_file_path]
+            args = [sys.executable, module.abs_file_path]
         elif module.file_type == "sh":
             # ignoring shebang line to pass parameters to shell
             # expecting system to have sh or something compatible

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -152,7 +152,6 @@ def main():
         with subprocess.Popen(
             [
                 sys.executable,
-                "-tt",
                 "-m",
                 "grass.gunittest.main",
                 "--grassdata",


### PR DESCRIPTION
The option `-t`, documented here: https://docs.python.org/2.7/using/cmdline.html#cmdoption-t, was used to issue a warning when spaces and tabs were used in a same file, in a way that makes it depend on the worth of a tab expressed in spaces. With `-tt`, it was an error instead.

This doesn't exist since Python 3, as it was always an error.

The comment also mentioned a Python 2-only `-Qwarn`, documented here: https://docs.python.org/2.7/using/cmdline.html#cmdoption-q, that was used to choose the type of division:
"warn: old division semantics with a warning for int/int and long/long"

This also doesn't make sense since Python 3 and that interpreter option doesn't exist in Python 3.