### PR TITLE
grass.gunittest: Solve ResourceWarning in gs.parser() coming from sys.stdout

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1095,8 +1095,11 @@ def parser() -> tuple[dict[str, str], dict[str, bool]]:
         s = p.communicate()[0]
         lines = s.split(b"\0")
         if not lines or lines[0] != b"@ARGS_PARSED@":
-            stdout = os.fdopen(sys.stdout.fileno(), "wb")
-            stdout.write(s)
+            if hasattr(sys.stdout, "buffer"):
+                sys.stdout.buffer.write(s)
+            else:
+                text = s.decode(sys.stdout.encoding, "strict")
+                sys.stdout.write(text)
             sys.exit(p.returncode)
         return _parse_opts(lines[1:])
 


### PR DESCRIPTION
The note at the end of [`sys.stdout`'s docs](https://docs.python.org/3/library/sys.html#sys.stdout) mentions that writing binary data to the standard streams should use the underlying binary buffer object. However, that file might be replaced by a file-like object that doesn't support the buffer attribute.

So, inspired by [the code example for `sys.displayhook`](https://docs.python.org/3.13/library/sys.html#sys.displayhook), use the binary buffer object if available or simply write the encoded text otherwise.

This solves multiple ResourceWarnings found in tests that could be traced back to this when enabling python tracemalloc as written in the warning messages. One of the ways is to set the env var `PYTHONTRACEMALLOC` to the number of frames to keep. So, `export PYTHONTRACEMALLOC=15` is enough.