### PR TITLE
grass.gunittest: Use context manager for Popen calls in gunittest

### DIFF
--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -9,6 +9,8 @@ for details.
 :authors: Vaclav Petras, Soeren Gebbert
 """
 
+from __future__ import annotations
+
 import subprocess
 from grass.script.core import start_command
 from grass.script.utils import decode
@@ -58,11 +60,11 @@ class SimpleModule(Module):
 def call_module(
     module,
     stdin=None,
-    merge_stderr=False,
-    capture_stdout=True,
-    capture_stderr=True,
+    merge_stderr: bool = False,
+    capture_stdout: bool = True,
+    capture_stderr: bool = True,
     **kwargs,
-):
+) -> str | None:
     r"""Run module with parameters given in `kwargs` and return its output.
 
     >>> print(call_module("g.region", flags="pg"))  # doctest: +ELLIPSIS
@@ -129,13 +131,13 @@ def call_module(
             kwargs["stderr"] = subprocess.STDOUT
         else:
             kwargs["stderr"] = subprocess.PIPE
-    process = start_command(module, **kwargs)
-    # input=None means no stdin (our default)
-    # for no stdout, output is None which is out interface
-    # for stderr=STDOUT or no stderr, errors is None
-    # which is fine for CalledModuleError
-    output, errors = process.communicate(input=decode(stdin) if stdin else None)
-    returncode = process.poll()
+    with start_command(module, **kwargs) as process:
+        # input=None means no stdin (our default)
+        # for no stdout, output is None which is out interface
+        # for stderr=STDOUT or no stderr, errors is None
+        # which is fine for CalledModuleError
+        output, errors = process.communicate(input=decode(stdin) if stdin else None)
+        returncode = process.poll()
     if returncode:
         raise CalledModuleError(module, kwargs, returncode, errors)
     return decode(output) if output else None

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -186,13 +186,13 @@ def get_svn_info():
     """
     try:
         # TODO: introduce directory, not only current
-        p = subprocess.Popen(
+        with subprocess.Popen(
             ["svn", "info", ".", "--xml"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-        )
-        stdout, stderr = p.communicate()
-        rc = p.poll()
+        ) as p:
+            stdout, stderr = p.communicate()
+            rc = p.poll()
         info = {}
         if not rc:
             root = ET.fromstring(stdout)
@@ -241,13 +241,13 @@ def get_svn_path_authors(path, from_date=None):
     revision_range = "BASE:1" if from_date is None else "BASE:{%s}" % from_date
     try:
         # TODO: allow also usage of --limit
-        p = subprocess.Popen(
+        with subprocess.Popen(
             ["svn", "log", "--xml", "--revision", revision_range, path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-        )
-        stdout, stderr = p.communicate()
-        rc = p.poll()
+        ) as p:
+            stdout, stderr = p.communicate()
+            rc = p.poll()
         if not rc:
             root = ET.fromstring(stdout)
             # TODO: get also date if this make sense

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -505,7 +505,7 @@ def start_command(
     verbose=False,
     superquiet=False,
     **kwargs,
-):
+) -> Popen:
     """Returns a :class:`~grass.script.core.Popen` object with the command created by
     :py:func:`~grass.script.core.make_command`.
     Accepts any of the arguments which :py:class:`Popen()` accepts apart from "args"


### PR DESCRIPTION
Similar to #6197, and another yet-to-file PR, context managers can, _and should_, be used with Popen.

This PR addresses the similar instances in gunittest code, the code I was working on closely today.
Maybe in the near future, we would get rid of the svn calls when doing tests, but I'm not finished investigating the impacts of it.