### PR TITLE
grass.script.core: Use context manager for Popen call in call() function

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -144,7 +144,8 @@ _capture_stderr = False  # capture stderr of subprocesses if possible
 
 
 def call(*args, **kwargs):
-    return Popen(*args, **kwargs).wait()
+    with Popen(*args, **kwargs) as p:
+        return p.wait()
 
 
 # GRASS-oriented interface to subprocess module


### PR DESCRIPTION
Similar to #6198 and #6197, add a context manager for a very simple `call()` wrapper. The `Popen` instance was already not available for use anywhere else.