### PR TITLE
grass.gunittest: Sync with unittest from Python 3.9

### DIFF
--- a/python/grass/gunittest/Makefile
+++ b/python/grass/gunittest/Makefile
@@ -8,7 +8,7 @@ GDIR = $(PYDIR)/grass
 DSTDIR = $(GDIR)/gunittest
 
 # TODO: add multireport multirunner
-MODULES = case gmodules loader runner checkers gutils invoker main reporters utils
+MODULES = case gmodules loader runner checkers gutils invoker main reporters result utils
 
 PYFILES := $(patsubst %,$(DSTDIR)/%.py,$(MODULES) __init__)
 PYCFILES := $(patsubst %,$(DSTDIR)/%.pyc,$(MODULES) __init__)

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -65,19 +65,14 @@ class TestCase(unittest.TestCase):
         self.addTypeEqualityFunc(str, "assertMultiLineEqual")
 
     def _formatMessage(self, msg, standardMsg):
-        """Honor the longMessage attribute when generating failure messages.
-
+        """Honour the longMessage attribute when generating failure messages.
         If longMessage is False this means:
-
         * Use only an explicit message if it is provided
         * Otherwise use the standard message for the assert
 
         If longMessage is True:
-
         * Use the standard message
-        * If an explicit message is provided, return string with both messages
-
-        Based on Python unittest _formatMessage, formatting changed.
+        * If an explicit message is provided, plus ' : ' and the explicit message
         """
         if not self.longMessage:
             return msg or standardMsg
@@ -86,9 +81,9 @@ class TestCase(unittest.TestCase):
         try:
             # don't switch to '{}' formatting in Python 2.X
             # it changes the way unicode input is handled
-            return "%s \n%s" % (msg, standardMsg)
+            return "%s : %s" % (standardMsg, msg)
         except UnicodeDecodeError:
-            return "%s \n%s" % (safe_repr(msg), safe_repr(standardMsg))
+            return "%s : %s" % (safe_repr(standardMsg), safe_repr(msg))
 
     @classmethod
     def use_temp_region(cls):

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -16,6 +16,7 @@ import subprocess
 import hashlib
 import uuid
 import unittest
+from unittest.util import safe_repr
 
 from grass.pygrass.modules import Module
 from grass.exceptions import CalledModuleError
@@ -31,7 +32,6 @@ from .checkers import (
     text_file_md5,
     files_equal_md5,
 )
-from .utils import safe_repr
 from .gutils import is_map_in_mapset
 
 from io import StringIO

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -40,7 +40,7 @@ from io import StringIO
 class TestCase(unittest.TestCase):
     # we disable R0904 for all TestCase classes because their purpose is to
     # provide a lot of assert methods
-    # pylint: disable=R0904
+    # pylint: disable=R0904,C0103
     """
 
     Always use keyword arguments for all parameters other than first two. For

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -147,7 +147,7 @@ class TestCase(unittest.TestCase):
         call_module("g.remove", quiet=True, flags="f", type="region", name=name)
         # TODO: we don't know if user calls this
         # so perhaps some decorator which would use with statement
-        # but we have zero chance of infuencing another test class
+        # but we have zero chance of influencing another test class
         # since we use class-specific name for temporary region
 
     def assertMultiLineEqual(self, first, second, msg=None):

--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -45,6 +45,9 @@ class GrassTestProgram(TestProgram):
         verbosity=1,
         failfast=None,
         catchbreak=None,
+        *,
+        tb_locals=False,
+        **kwargs,
     ):
         """Prepares the tests in GRASS way and then runs the tests.
 
@@ -74,13 +77,15 @@ class GrassTestProgram(TestProgram):
             super().__init__(
                 module=module,
                 argv=unittest_argv,
-                testLoader=grass_loader,
                 testRunner=grass_runner,
+                testLoader=grass_loader,
                 exit=exit_at_end,
                 verbosity=verbosity,
                 failfast=failfast,
                 catchbreak=catchbreak,
                 buffer=buffer_stdout_stderr,
+                tb_locals=tb_locals,
+                **kwargs,
             )
 
 

--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -20,7 +20,13 @@ from unittest.main import TestProgram
 import grass.script.core as gs
 
 from .loader import GrassTestLoader
-from .runner import GrassTestRunner, MultiTestResult, TextTestResult, KeyValueTestResult
+from .runner import (
+    GrassTestRunner,
+    KeyValueTestResult,
+    MultiTestResult,
+    TextTestResult,
+    _WritelnDecorator,
+)
 from .invoker import GrassTestFilesInvoker
 from .utils import silent_rmtree
 from .reporters import FileAnonymizer
@@ -53,7 +59,7 @@ class GrassTestProgram(TestProgram):
         grass_loader = GrassTestLoader(grass_location=self.grass_location)
 
         text_result = TextTestResult(
-            stream=sys.stderr, descriptions=True, verbosity=verbosity
+            stream=_WritelnDecorator(sys.stderr), descriptions=True, verbosity=verbosity
         )
         with open("test_keyvalue_result.txt", "w") as keyval_file:
             keyval_result = KeyValueTestResult(stream=keyval_file)

--- a/python/grass/gunittest/result.py
+++ b/python/grass/gunittest/result.py
@@ -1,0 +1,36 @@
+"""Test result object"""
+
+import unittest
+
+
+class TestResult(unittest.TestResult):
+    """Holder for test result information.
+
+    Test results are automatically managed by the TestCase and TestSuite
+    classes, and do not need to be explicitly manipulated by writers of tests.
+
+    Each instance holds the total number of tests run, and collections of
+    failures and errors that occurred among those test runs. The collections
+    contain tuples of (testcase, exceptioninfo), where exceptioninfo is the
+    formatted traceback of the error that occurred.
+    """
+
+    # descriptions and verbosity unused
+    # included for compatibility with unittest's TestResult
+    # where are also unused, so perhaps we can remove them
+    # stream set to None and not included in interface, it would not make sense
+    def __init__(self, stream=None, descriptions=None, verbosity=None):
+        super().__init__(stream=stream, descriptions=descriptions, verbosity=verbosity)
+        self.successes = []
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        self.successes.append(test)
+
+    # TODO: better would be to pass start at the beginning
+    # alternative is to leave counting time on class
+    # TODO: document: we expect all grass classes to have setTimes
+    # TODO: alternatively, be more forgiving for non-unittest methods
+    def setTimes(self, start_time, end_time, time_taken):
+        pass
+        # TODO: implement this

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -452,6 +452,8 @@ class GrassTestRunner:
         failfast=False,
         buffer=False,
         result=None,
+        *,
+        **kwargs,
     ):
         if stream is None:
             stream = sys.stderr

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -16,6 +16,7 @@ import sys
 import time
 
 import unittest
+from grass.gunittest.result import TestResult
 
 __unittest = True
 
@@ -35,28 +36,6 @@ class _WritelnDecorator:
         if arg:
             self.write(arg)
         self.write("\n")  # text-mode streams translate to \r\n if needed
-
-
-class TestResult(unittest.TestResult):
-    # descriptions and verbosity unused
-    # included for compatibility with unittest's TestResult
-    # where are also unused, so perhaps we can remove them
-    # stream set to None and not included in interface, it would not make sense
-    def __init__(self, stream=None, descriptions=None, verbosity=None):
-        super().__init__(stream=stream, descriptions=descriptions, verbosity=verbosity)
-        self.successes = []
-
-    def addSuccess(self, test):
-        super().addSuccess(test)
-        self.successes.append(test)
-
-    # TODO: better would be to pass start at the beginning
-    # alternative is to leave counting time on class
-    # TODO: document: we expect all grass classes to have setTimes
-    # TODO: alternatively, be more forgiving for non-unittest methods
-    def setTimes(self, start_time, end_time, time_taken):
-        pass
-        # TODO: implement this
 
 
 class TextTestResult(TestResult):

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -446,13 +446,15 @@ class MultiTestResult(grass.gunittest.result.TestResult):
 class GrassTestRunner:
     def __init__(
         self,
-        stream=sys.stderr,
+        stream=None,
         descriptions=True,
         verbosity=1,
         failfast=False,
         buffer=False,
         result=None,
     ):
+        if stream is None:
+            stream = sys.stderr
         self.stream = _WritelnDecorator(stream)
         self.descriptions = descriptions
         self.verbosity = verbosity

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -16,7 +16,7 @@ import sys
 import time
 
 import unittest
-from grass.gunittest.result import TestResult
+import grass.gunittest.result
 
 __unittest = True
 
@@ -38,7 +38,7 @@ class _WritelnDecorator:
         self.write("\n")  # text-mode streams translate to \r\n if needed
 
 
-class TextTestResult(TestResult):
+class TextTestResult(grass.gunittest.result.TestResult):
     """A test result class that can print formatted text results to a stream.
 
     Used by TextTestRunner.
@@ -175,7 +175,7 @@ class TextTestResult(TestResult):
             self.stream.write("\n")
 
 
-class KeyValueTestResult(TestResult):
+class KeyValueTestResult(grass.gunittest.result.TestResult):
     """A test result class that can print formatted text results to a stream.
 
     Used by TextTestRunner.
@@ -275,7 +275,7 @@ class KeyValueTestResult(TestResult):
         self._stream.flush()
 
 
-class MultiTestResult(TestResult):
+class MultiTestResult(grass.gunittest.result.TestResult):
     # descriptions and verbosity unused
     # included for compatibility with unittest's TestResult
     # where are also unused, so perhaps we can remove them

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -452,7 +452,10 @@ class GrassTestRunner:
         failfast=False,
         buffer=False,
         result=None,
+        resultclass=None,
+        warnings=None,
         *,
+        tb_locals=False,
         **kwargs,
     ):
         if stream is None:
@@ -462,6 +465,11 @@ class GrassTestRunner:
         self.verbosity = verbosity
         self.failfast = failfast
         self.buffer = buffer
+        self.tb_locals = tb_locals
+        self.warnings = warnings
+        if resultclass is not None:
+            self.resultclass = resultclass
+
         self._result = result
 
     def run(self, test):

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -47,9 +47,13 @@ class TextTestResult(grass.gunittest.result.TestResult):
     separator1 = "=" * 70
     separator2 = "-" * 70
 
-    def __init__(self, stream, descriptions, verbosity):
-        super().__init__(stream=stream, descriptions=descriptions, verbosity=verbosity)
-        self.stream = _WritelnDecorator(stream)
+    def __init__(self, stream, descriptions, verbosity, **kwargs):
+        """Construct a TextTestResult. Subclasses should accept **kwargs
+        to ensure compatibility as the interface changes."""
+        super().__init__(
+            stream=stream, descriptions=descriptions, verbosity=verbosity, **kwargs
+        )
+        self.stream = stream
         self.showAll = verbosity > 1
         self.dots = verbosity == 1
         self.descriptions = descriptions
@@ -75,6 +79,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addSuccess(test)
         if self.showAll:
             self.stream.writeln("ok")
+            self.stream.flush()
         elif self.dots:
             self.stream.write(".")
             self.stream.flush()
@@ -83,6 +88,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addError(test, err)
         if self.showAll:
             self.stream.writeln("ERROR")
+            self.stream.flush()
         elif self.dots:
             self.stream.write("E")
             self.stream.flush()
@@ -91,6 +97,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addFailure(test, err)
         if self.showAll:
             self.stream.writeln("FAIL")
+            self.stream.flush()
         elif self.dots:
             self.stream.write("F")
             self.stream.flush()
@@ -99,6 +106,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addSkip(test, reason)
         if self.showAll:
             self.stream.writeln("skipped {0!r}".format(reason))
+            self.stream.flush()
         elif self.dots:
             self.stream.write("s")
             self.stream.flush()
@@ -107,6 +115,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addExpectedFailure(test, err)
         if self.showAll:
             self.stream.writeln("expected failure")
+            self.stream.flush()
         elif self.dots:
             self.stream.write("x")
             self.stream.flush()
@@ -115,6 +124,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
         super().addUnexpectedSuccess(test)
         if self.showAll:
             self.stream.writeln("unexpected success")
+            self.stream.flush()
         elif self.dots:
             self.stream.write("u")
             self.stream.flush()
@@ -122,6 +132,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
     def printErrors(self):
         if self.dots or self.showAll:
             self.stream.writeln()
+            self.stream.flush()
         self.printErrorList("ERROR", self.errors)
         self.printErrorList("FAIL", self.failures)
 
@@ -131,6 +142,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
             self.stream.writeln("%s: %s" % (flavour, self.getDescription(test)))
             self.stream.writeln(self.separator2)
             self.stream.writeln("%s" % err)
+            self.stream.flush()
 
     def setTimes(self, start_time, end_time, time_taken):
         self.start_time = start_time

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -72,18 +72,6 @@ def do_doctest_gettext_workaround():
 _MAX_LENGTH = 80
 
 
-# taken from unittest.util (Python 2.7) since it is not part of API
-# but we need it for the same reason as it is used un unittest's TestCase
-def safe_repr(obj, short=False):
-    try:
-        result = repr(obj)
-    except Exception:
-        result = object.__repr__(obj)  # noqa: PLC2801
-    if not short or len(result) < _MAX_LENGTH:
-        return result
-    return result[:_MAX_LENGTH] + " [truncated]..."
-
-
 def xfail_windows(test_item):
     """Marks a test as an expected failure or error only on Windows
     Equivalent to applying @unittest.expectedFailure only when running


### PR DESCRIPTION
Prepare classes from gunittest to use multiple inheritance and be able to subclass from unittest, that would allow removing any code that we don't override. But before this, sync the code with Python 3.9's unittest implementation's, so the code is more similar and easier to compare. There will be less diff to review, and allows us to see that some newer unittest code effectively still works well with our codebase.

So, apart from copying over code that was copied some time ago, some code that is in a file named "result.py" was moved there, to follow the unittest implementation:
https://github.com/python/cpython/blob/06fc882eac0e59220a7b8b127a1e7babe0055d45/Lib/unittest/result.py#L24-L39

Other useful code to see is:
https://github.com/python/cpython/blob/06fc882eac0e59220a7b8b127a1e7babe0055d45/Lib/unittest/runner.py#L13-L125