### PR TITLE
r.distance: Add JSON and CSV support

### DIFF
--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -209,7 +209,7 @@ build_program_in_subdir(r.cross DEPENDS grass_gis grass_raster grass_btree
 
 build_program_in_subdir(r.describe DEPENDS grass_gis grass_raster grass_parson)
 
-build_program_in_subdir(r.distance DEPENDS grass_gis grass_raster)
+build_program_in_subdir(r.distance DEPENDS grass_gis grass_raster grass_parson)
 
 build_program_in_subdir(
   r.external

--- a/raster/r.distance/Makefile
+++ b/raster/r.distance/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.distance
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.distance/defs.h
+++ b/raster/r.distance/defs.h
@@ -20,7 +20,10 @@
 #define __R_DIST_DEFS_H__
 
 #include <grass/gis.h>
+#include <grass/gjson.h>
 #include <grass/raster.h>
+
+enum OutputFormat { PLAIN, CSV, JSON };
 
 struct EdgeList /* keep track of edge cells */
 {
@@ -52,6 +55,8 @@ struct Parms {
     int sort;              /* 0: sort by cat1,cat2 (default)
                               1: sort by distance in ascending order
                               2: sort by distance in descending order */
+    enum OutputFormat
+        format; /* output format for results: PLAIN, CSV, or JSON */
 };
 
 /* distance.c */

--- a/raster/r.distance/r.distance.md
+++ b/raster/r.distance/r.distance.md
@@ -10,23 +10,23 @@ The output is an ascii list, one line per pair of objects, in the
 following form:
 
 ```sh
-cat1:cat2:distance:east1:north1:east2:north2
+from_category:to_category:distance:from_easting:from_northing:to_easting:to_northing
 ```
 
-**cat1**  
+**from_category**  
 Category number from map1
 
-**cat2**  
+**to_category**  
 Category number from map2
 
 **distance**  
-The distance in meters between "cat1" and "cat2"
+The distance in meters between "from_category" and "to_category"
 
-**east1,north1**  
-The coordinates of the grid cell "cat1" which is closest to "cat2"
+**from_easting,from_northing**  
+The coordinates of the grid cell "from_category" which is closest to "to_category"
 
-**east2,north2**  
-The coordinates of the grid cell "cat2" which is closest to "cat1"
+**to_easting,to_northing**  
+The coordinates of the grid cell "to_category" which is closest to "from_category"
 
 ### Flags
 
@@ -53,6 +53,34 @@ into awk and then into *v.in.ascii*:
 ```sh
 r.distance map=map1,map2 | \
   awk -F: '{print $4,$5}' | v.in.ascii format=point output=name separator=space
+```
+
+## EXAMPLES
+
+### Using JSON output with Pandas to locate closest points
+
+```python
+import pandas as pd
+import grass.script as gs
+
+result = gs.parse_command(
+    "r.distance", map=["zipcodes", "lakes"], flags="l", format="json"
+)
+df = pd.json_normalize(result)
+print(df)
+```
+
+Possible output:
+
+```text
+        distance  from_cell.category  from_cell.easting  from_cell.northing from_cell.label  to_cell.category  to_cell.easting  to_cell.northing to_cell.label
+0   11158.870911               27511             632605              223295            CARY             34300           640585            215495      Dam/Weir
+1    1037.304198               27511             631735              222695            CARY             39000           632315            221835     Lake/Pond
+2    2277.059507               27511             630015              221605            CARY             43600           630765            219455     Reservoir
+..           ...                 ...                ...                 ...             ...               ...              ...               ...           ...
+36   4922.600939               27610             642975              219815         RALEIGH             34300           640615            215495      Dam/Weir
+37     50.000000               27610             642655              222765         RALEIGH             39000           642705            222765     Lake/Pond
+38  11368.069317               27610             642305              220945         RALEIGH             43600           631035            219455     Reservoir
 ```
 
 ## SEE ALSO

--- a/raster/r.distance/report.c
+++ b/raster/r.distance/report.c
@@ -33,7 +33,7 @@ struct ReportLine {
     double distance;
 };
 
-static void print(struct ReportLine *, struct Parms *);
+static void print(struct ReportLine *, struct Parms *, JSON_Array *);
 static int compare(const void *, const void *);
 static int revcompare(const void *, const void *);
 
@@ -46,6 +46,8 @@ void report(struct Parms *parms)
     struct CatEdgeList *list1, *list2;
     struct ReportLine *lines;
     int nlines;
+    JSON_Value *root_value = NULL;
+    JSON_Array *root_array = NULL;
 
     G_get_set_window(&region);
     G_begin_distance_calculations();
@@ -54,6 +56,27 @@ void report(struct Parms *parms)
     map2 = &parms->map2;
 
     G_message(_("Processing..."));
+
+    if (parms->format == JSON) {
+        root_value = G_json_value_init_array();
+        if (root_value == NULL) {
+            G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+        }
+        root_array = G_json_array(root_value);
+    }
+    else if (parms->format == CSV) {
+        fprintf(stdout, "%s%s%s%s%s%s%s%s%s%s%s%s%s", "from_category",
+                parms->fs, "to_category", parms->fs, "distance", parms->fs,
+                "from_easting", parms->fs, "from_northing", parms->fs,
+                "to_easting", parms->fs, "to_northing");
+
+        if (parms->labels) {
+            fprintf(stdout, "%s%s%s%s", parms->fs, "from_label", parms->fs,
+                    "to_label");
+        }
+
+        fprintf(stdout, "\n");
+    }
 
     if (parms->sort > 0)
         lines = (struct ReportLine *)G_malloc(
@@ -92,7 +115,7 @@ void report(struct Parms *parms)
             if (parms->sort > 0)
                 lines[nlines++] = line;
             else
-                print(&line, parms);
+                print(&line, parms, root_array);
         }
     }
 
@@ -105,57 +128,144 @@ void report(struct Parms *parms)
             qsort(lines, nlines, sizeof(struct ReportLine), revcompare);
 
         for (i = 0; i < nlines; i++)
-            print(&lines[i], parms);
+            print(&lines[i], parms, root_array);
+    }
+
+    if (parms->format == JSON) {
+        char *json_string = G_json_serialize_to_string_pretty(root_value);
+        if (!json_string) {
+            G_json_value_free(root_value);
+            G_fatal_error(_("Failed to serialize JSON to pretty format."));
+        }
+
+        puts(json_string);
+
+        G_json_free_serialized_string(json_string);
+        G_json_value_free(root_value);
     }
 }
 
-static void print(struct ReportLine *line, struct Parms *parms)
+static void print(struct ReportLine *line, struct Parms *parms,
+                  JSON_Array *root_array)
 {
     char *fs;
     char temp[100];
+    JSON_Value *cell_value = NULL, *from_cell_value = NULL,
+               *to_cell_value = NULL;
+    JSON_Object *cell_object = NULL, *from_cell_object = NULL,
+                *to_cell_object = NULL;
 
     fs = parms->fs;
 
-    /* print cat numbers */
-    if (line->isnull1 && line->isnull2)
-        fprintf(stdout, "*%s*", fs);
-    else if (line->isnull1)
-        fprintf(stdout, "*%s%ld", fs, (long)line->cat2);
-    else if (line->isnull2)
-        fprintf(stdout, "%ld%s*", (long)line->cat1, fs);
-    else
-        fprintf(stdout, "%ld%s%ld", (long)line->cat1, fs, (long)line->cat2);
+    switch (parms->format) {
+    case CSV:
+    case PLAIN:
+        /* print cat numbers */
+        if (line->isnull1 && line->isnull2)
+            fprintf(stdout, "*%s*", fs);
+        else if (line->isnull1)
+            fprintf(stdout, "*%s%ld", fs, (long)line->cat2);
+        else if (line->isnull2)
+            fprintf(stdout, "%ld%s*", (long)line->cat1, fs);
+        else
+            fprintf(stdout, "%ld%s%ld", (long)line->cat1, fs, (long)line->cat2);
 
-    /* print distance */
-    snprintf(temp, sizeof(temp), "%.10f", line->distance);
-    G_trim_decimal(temp);
-    fprintf(stdout, "%s%s", fs, temp);
+        /* print distance */
+        snprintf(temp, sizeof(temp), "%.10f", line->distance);
+        G_trim_decimal(temp);
+        fprintf(stdout, "%s%s", fs, temp);
 
-    /* print coordinates of the closest pair */
-    G_format_easting(line->east1, temp,
-                     G_projection() == PROJECTION_LL ? -1 : 0);
-    fprintf(stdout, "%s%s", fs, temp);
-    G_format_northing(line->north1, temp,
-                      G_projection() == PROJECTION_LL ? -1 : 0);
-    fprintf(stdout, "%s%s", fs, temp);
-    G_format_easting(line->east2, temp,
-                     G_projection() == PROJECTION_LL ? -1 : 0);
-    fprintf(stdout, "%s%s", fs, temp);
-    G_format_northing(line->north2, temp,
-                      G_projection() == PROJECTION_LL ? -1 : 0);
-    fprintf(stdout, "%s%s", fs, temp);
+        /* print coordinates of the closest pair */
+        G_format_easting(line->east1, temp,
+                         G_projection() == PROJECTION_LL ? -1 : 0);
+        fprintf(stdout, "%s%s", fs, temp);
+        G_format_northing(line->north1, temp,
+                          G_projection() == PROJECTION_LL ? -1 : 0);
+        fprintf(stdout, "%s%s", fs, temp);
+        G_format_easting(line->east2, temp,
+                         G_projection() == PROJECTION_LL ? -1 : 0);
+        fprintf(stdout, "%s%s", fs, temp);
+        G_format_northing(line->north2, temp,
+                          G_projection() == PROJECTION_LL ? -1 : 0);
+        fprintf(stdout, "%s%s", fs, temp);
 
-    /* print category labels */
-    if (parms->labels) {
-        struct Map *map1, *map2;
+        /* print category labels */
+        if (parms->labels) {
+            struct Map *map1, *map2;
 
-        map1 = &parms->map1;
-        map2 = &parms->map2;
+            map1 = &parms->map1;
+            map2 = &parms->map2;
 
-        fprintf(stdout, "%s%s", fs, get_label(map1, line->cat1));
-        fprintf(stdout, "%s%s", fs, get_label(map2, line->cat2));
+            fprintf(stdout, "%s%s", fs, get_label(map1, line->cat1));
+            fprintf(stdout, "%s%s", fs, get_label(map2, line->cat2));
+        }
+        fprintf(stdout, "\n");
+        break;
+
+    case JSON:
+        /* initialize JSON objects */
+        cell_value = G_json_value_init_object();
+        if (cell_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        cell_object = G_json_object(cell_value);
+
+        from_cell_value = G_json_value_init_object();
+        if (from_cell_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        from_cell_object = G_json_object(from_cell_value);
+
+        to_cell_value = G_json_value_init_object();
+        if (to_cell_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        to_cell_object = G_json_object(to_cell_value);
+
+        /* print cat numbers */
+        if (line->isnull1)
+            G_json_object_set_null(from_cell_object, "category");
+        else
+            G_json_object_set_number(from_cell_object, "category",
+                                     (long)line->cat1);
+
+        if (line->isnull2)
+            G_json_object_set_null(to_cell_object, "category");
+        else
+            G_json_object_set_number(to_cell_object, "category",
+                                     (long)line->cat2);
+
+        /* print coordinates of the closest pair */
+        G_json_object_set_number(from_cell_object, "easting", line->east1);
+        G_json_object_set_number(from_cell_object, "northing", line->north1);
+        G_json_object_set_number(to_cell_object, "easting", line->east2);
+        G_json_object_set_number(to_cell_object, "northing", line->north2);
+
+        /* print category labels */
+        if (parms->labels) {
+            struct Map *map1, *map2;
+
+            map1 = &parms->map1;
+            map2 = &parms->map2;
+
+            G_json_object_set_string(from_cell_object, "label",
+                                     get_label(map1, line->cat1));
+            G_json_object_set_string(to_cell_object, "label",
+                                     get_label(map2, line->cat2));
+        }
+
+        /* print distance */
+        G_json_object_set_value(cell_object, "from_cell", from_cell_value);
+        G_json_object_set_value(cell_object, "to_cell", to_cell_value);
+        G_json_object_set_number(cell_object, "distance", line->distance);
+
+        /* add the cell object to the root array */
+        G_json_array_append_value(root_array, cell_value);
+        break;
     }
-    fprintf(stdout, "\n");
 }
 
 static int compare(const void *p1, const void *p2)

--- a/raster/r.distance/testsuite/test_distance.py
+++ b/raster/r.distance/testsuite/test_distance.py
@@ -1,3 +1,4 @@
+import json
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
@@ -65,6 +66,13 @@ class TestRDistance(TestCase):
                 component, expected_results[i], f"Mismatch at line {i + 1}"
             )
 
+        # Test with explicit 'plain' format
+        module = SimpleModule("r.distance", map=("map1", "map2"), format="plain")
+        self.assertModule(module)
+
+        result_plain = module.outputs.stdout.strip().splitlines()
+        self.assertEqual(result_plain, result)
+
     def test_overlap_distance(self):
         """Test r.distance when comparing a map to itself with overlapping features."""
         module = SimpleModule("r.distance", map=("map1", "map1"), flags="o")
@@ -84,6 +92,15 @@ class TestRDistance(TestCase):
                 component, expected_results[i], f"Mismatch at line {i + 1}"
             )
 
+        # Test with explicit 'plain' format
+        module = SimpleModule(
+            "r.distance", map=("map1", "map1"), flags="o", format="plain"
+        )
+        self.assertModule(module)
+
+        result_plain = module.outputs.stdout.strip().splitlines()
+        self.assertEqual(result_plain, result)
+
     def test_null_distance(self):
         """Test r.distance when reporting null values with -n flag."""
         module = SimpleModule("r.distance", map=("map3", "map2"), flags="n")
@@ -97,6 +114,15 @@ class TestRDistance(TestCase):
             self.assertEqual(
                 component, expected_results[i], f"Mismatch at line {i + 1}"
             )
+
+        # Test with explicit 'plain' format
+        module = SimpleModule(
+            "r.distance", map=("map3", "map2"), flags="n", format="plain"
+        )
+        self.assertModule(module)
+
+        result_plain = module.outputs.stdout.strip().splitlines()
+        self.assertEqual(result_plain, result)
 
     def test_cat_labels(self):
         """Test r.distance when reporting category labels."""
@@ -114,6 +140,231 @@ class TestRDistance(TestCase):
             self.assertEqual(
                 component, expected_results[i], f"Mismatch at line {i + 1}"
             )
+
+        # Test with explicit 'plain' format
+        module = SimpleModule(
+            "r.distance", map=("map1", "map2"), flags="l", format="plain"
+        )
+        self.assertModule(module)
+
+        result_plain = module.outputs.stdout.strip().splitlines()
+        self.assertEqual(result_plain, result)
+
+    def test_distance_csv(self):
+        """Test distance calculation between map1 and map2 with CSV format."""
+        module = SimpleModule("r.distance", map=("map1", "map2"), format="csv")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "from_category,to_category,distance,from_easting,from_northing,to_easting,to_northing",
+            "1,1,2.8284271247,1.5,8.5,3.5,6.5",
+            "2,1,2.8284271247,7.5,2.5,5.5,4.5",
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+
+    def test_overlap_distance_csv(self):
+        """Test r.distance when comparing a map to itself with overlapping features with CSV format."""
+        module = SimpleModule(
+            "r.distance", map=("map1", "map1"), flags="o", format="csv"
+        )
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "from_category,to_category,distance,from_easting,from_northing,to_easting,to_northing",
+            "1,1,0,0.5,9.5,0.5,9.5",
+            "1,2,0,0.5,9.5,0.5,9.5",
+            "2,1,0,0.5,9.5,0.5,9.5",
+            "2,2,0,0.5,9.5,0.5,9.5",
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+
+    def test_null_distance_csv(self):
+        """Test r.distance when reporting null values with -n flag with CSV format."""
+        module = SimpleModule(
+            "r.distance", map=("map3", "map2"), flags="n", format="csv"
+        )
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "from_category,to_category,distance,from_easting,from_northing,to_easting,to_northing",
+            "*,*,0,0.5,9.5,0.5,9.5",
+            "*,1,2,3.5,8.5,3.5,6.5",
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+
+    def test_cat_labels_csv(self):
+        """Test r.distance when reporting category labels with CSV format."""
+        module = SimpleModule(
+            "r.distance", map=("map1", "map2"), flags="l", format="csv"
+        )
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "from_category,to_category,distance,from_easting,from_northing,to_easting,to_northing,from_label,to_label",
+            "1,1,2.8284271247,1.5,8.5,3.5,6.5,top left block,center block",
+            "2,1,2.8284271247,7.5,2.5,5.5,4.5,bottom right block,center block",
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+
+    def assert_json_equal(self, expected, actual):
+        if isinstance(expected, dict):
+            self.assertIsInstance(actual, dict)
+            self.assertCountEqual(expected.keys(), actual.keys())
+            for key in expected:
+                self.assert_json_equal(expected[key], actual[key])
+        elif isinstance(expected, list):
+            self.assertIsInstance(actual, list)
+            self.assertEqual(len(expected), len(actual))
+            for exp_item, act_item in zip(expected, actual):
+                self.assert_json_equal(exp_item, act_item)
+        elif isinstance(expected, float):
+            self.assertAlmostEqual(expected, actual, places=6)
+        else:
+            self.assertEqual(expected, actual)
+
+    def test_distance_json(self):
+        """Test distance calculation between map1 and map2 with JSON format."""
+        module = SimpleModule("r.distance", map=("map1", "map2"), format="json")
+        self.assertModule(module)
+
+        expected_results = [
+            {
+                "from_cell": {"category": 1, "easting": 1.5, "northing": 8.5},
+                "to_cell": {"category": 1, "easting": 3.5, "northing": 6.5},
+                "distance": 2.8284271247461903,
+            },
+            {
+                "from_cell": {"category": 2, "easting": 7.5, "northing": 2.5},
+                "to_cell": {"category": 1, "easting": 5.5, "northing": 4.5},
+                "distance": 2.8284271247461903,
+            },
+        ]
+
+        result = json.loads(module.outputs.stdout)
+        self.assert_json_equal(expected_results, result)
+
+    def test_overlap_distance_json(self):
+        """Test r.distance when comparing a map to itself with overlapping features with JSON format."""
+        module = SimpleModule(
+            "r.distance", map=("map1", "map1"), flags="o", format="json"
+        )
+        self.assertModule(module)
+
+        expected_results = [
+            {
+                "from_cell": {"category": 1, "easting": 0.5, "northing": 9.5},
+                "to_cell": {"category": 1, "easting": 0.5, "northing": 9.5},
+                "distance": 0,
+            },
+            {
+                "from_cell": {"category": 1, "easting": 0.5, "northing": 9.5},
+                "to_cell": {"category": 2, "easting": 0.5, "northing": 9.5},
+                "distance": 0,
+            },
+            {
+                "from_cell": {"category": 2, "easting": 0.5, "northing": 9.5},
+                "to_cell": {"category": 1, "easting": 0.5, "northing": 9.5},
+                "distance": 0,
+            },
+            {
+                "from_cell": {"category": 2, "easting": 0.5, "northing": 9.5},
+                "to_cell": {"category": 2, "easting": 0.5, "northing": 9.5},
+                "distance": 0,
+            },
+        ]
+
+        result = json.loads(module.outputs.stdout)
+        self.assert_json_equal(expected_results, result)
+
+    def test_null_distance_json(self):
+        """Test r.distance when reporting null values with -n flag with JSON format."""
+        module = SimpleModule(
+            "r.distance", map=("map3", "map2"), flags="n", format="json"
+        )
+        self.assertModule(module)
+
+        expected_results = [
+            {
+                "from_cell": {"category": None, "easting": 0.5, "northing": 9.5},
+                "to_cell": {"category": None, "easting": 0.5, "northing": 9.5},
+                "distance": 0,
+            },
+            {
+                "from_cell": {"category": None, "easting": 3.5, "northing": 8.5},
+                "to_cell": {"category": 1, "easting": 3.5, "northing": 6.5},
+                "distance": 2,
+            },
+        ]
+
+        result = json.loads(module.outputs.stdout)
+        self.assert_json_equal(expected_results, result)
+
+    def test_cat_labels_json(self):
+        """Test r.distance when reporting category labels with JSON format."""
+        module = SimpleModule(
+            "r.distance", map=("map1", "map2"), flags="l", format="json"
+        )
+        self.assertModule(module)
+
+        expected_results = [
+            {
+                "from_cell": {
+                    "category": 1,
+                    "easting": 1.5,
+                    "northing": 8.5,
+                    "label": "top left block",
+                },
+                "to_cell": {
+                    "category": 1,
+                    "easting": 3.5,
+                    "northing": 6.5,
+                    "label": "center block",
+                },
+                "distance": 2.8284271247461903,
+            },
+            {
+                "from_cell": {
+                    "category": 2,
+                    "easting": 7.5,
+                    "northing": 2.5,
+                    "label": "bottom right block",
+                },
+                "to_cell": {
+                    "category": 1,
+                    "easting": 5.5,
+                    "northing": 4.5,
+                    "label": "center block",
+                },
+                "distance": 2.8284271247461903,
+            },
+        ]
+
+        result = json.loads(module.outputs.stdout)
+        self.assert_json_equal(expected_results, result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: #6135

This PR adds JSON and CSV support to the `r.distance` module.

The JSON output looks like:
```json
[
            {
                "from_cell": {
                    "category": 1,
                    "easting": 1.5,
                    "northing": 8.5,
                    "label": "top left block",
                },
                "to_cell": {
                    "category": 1,
                    "easting": 3.5,
                    "northing": 6.5,
                    "label": "center block",
                },
                "distance": 2.8284271247461903,
            },
            {
                "from_cell": {
                    "category": 2,
                    "easting": 7.5,
                    "northing": 2.5,
                    "label": "bottom right block",
                },
                "to_cell": {
                    "category": 1,
                    "easting": 5.5,
                    "northing": 4.5,
                    "label": "center block",
                },
                "distance": 2.8284271247461903,
            },
]
```

The CSV output looks like:
```text
from_category,to_category,distance,from_easting,from_northing,to_easting,to_northing,from_label,to_label
1,1,2.8284271247,1.5,8.5,3.5,6.5,top left block,center block
2,1,2.8284271247,7.5,2.5,5.5,4.5,bottom right block,center block
```

This PR includes the following changes:

1. Adds a `format` option with `plain`, `csv`, and `json` modes for output formatting.
2. Adds tests covering each of the new formats.
3. Adds a Pandas example to the documentation for parsing JSON output.