### PR TITLE
v.class: Add more test cases and fix out-of-bounds bug

### DIFF
--- a/vector/v.class/main.c
+++ b/vector/v.class/main.c
@@ -81,6 +81,7 @@ int main(int argc, char *argv[])
     nbclass_opt->type = TYPE_INTEGER;
     nbclass_opt->required = YES;
     nbclass_opt->multiple = NO;
+    nbclass_opt->options = "2-";
     nbclass_opt->description = _("Number of classes to define");
 
     shell_flag = G_define_flag();

--- a/vector/v.class/tests/test_v_class.py
+++ b/vector/v.class/tests/test_v_class.py
@@ -96,6 +96,41 @@ def test_v_class_break_values(setup_vector_with_values, algorithm, expected):
     assert breaks == pytest.approx(expected, rel=1e-2)
 
 
+def test_v_class_required(setup_vector_with_values):
+    """
+    Test that v.class produces the expected output when only the required inputs are provided.
+    """
+    session = setup_vector_with_values
+    output = gs.read_command(
+        "v.class",
+        map="test_points",
+        column="value",
+        algorithm="qua",
+        nbclasses=5,
+        env=session.env,
+    )
+
+    result = output.splitlines()
+    expected = [
+        "",
+        "Classification of value into 5 classes",
+        "Using algorithm: *** qua ***",
+        "Mean: 5.500000\tStandard deviation = 2.872281",
+        "",
+        "   From (excl.)     To (incl.)      Frequency",
+        "",
+        "        1.00000        3.00000              3",
+        "        3.00000        5.00000              2",
+        "        5.00000        7.00000              2",
+        "        7.00000        9.00000              2",
+        "        9.00000       10.00000              1",
+        "",
+        "Note: Minimum of first class is including",
+        "",
+    ]
+    assert result == expected
+
+
 def test_v_class_expression_breaks(setup_vector_with_values):
     """
     Test break values when passing a column expression (value/2).
@@ -156,7 +191,7 @@ def test_v_class_invalid_column(setup_vector_with_values):
 
 @pytest.mark.parametrize(
     ("nbclasses", "expected_breaks"),
-    [(1, [0.0]), (2, [6.0]), (10, [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])],
+    [(2, [6.0]), (10, [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])],
 )
 def test_v_class_varied_nbclasses(setup_vector_with_values, nbclasses, expected_breaks):
     """

--- a/vector/v.class/v.class.md
+++ b/vector/v.class/v.class.md
@@ -68,7 +68,7 @@ and to determine the density classes:
 v.class map=communes column=pop/area algo=std nbclasses=5
 ```
 
-The following example uses the output of d.class and feeds it directly
+The following example uses the output of v.class and feeds it directly
 into *d.vect.thematic*:
 
 ```sh


### PR DESCRIPTION
ref: #6136

This PR adds one more test case for the `v.class` module to cover all scenarios, ensuring that future changes, particularly the upcoming addition of JSON support, do not break existing behavior.

It also includes a fix for an out-of-bounds bug mentioned here: https://github.com/OSGeo/grass/issues/6136#issuecomment-3148203451
The fix sets the range for `nbclasses` to a minimum of 2 using a parser option.

Additionally, it contains a minor typo fix in the documentation.