### PR TITLE
v.univar: Fix Resource Leak Issue in main.c

### DIFF
--- a/vector/v.univar/main.c
+++ b/vector/v.univar/main.c
@@ -579,6 +579,7 @@ void select_from_database(void)
     }
 
     G_debug(2, "sum = %f total_size = %f", sum, total_size);
+    Vect_destroy_line_struct(Points);
 }
 
 void summary(void)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan ( CID : 1207789)
Used Vect_destroy_line_struct()