### PR TITLE
grass.pygrass: Remove Vector.write() 2nd positional argument deprecated in 7.2

### DIFF
--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -190,18 +190,6 @@ class Vector(Info):
 
         """
         self.n_lines += 1
-        if not isinstance(cat, int) and not isinstance(cat, str):
-            # likely the case of using 7.0 API
-            import warnings
-
-            warnings.warn(
-                "Vector.write(geo_obj, attrs=(...)) is"
-                " deprecated, specify cat explicitly",
-                DeprecationWarning,
-            )
-            # try to accommodate
-            attrs = cat
-            cat = None
         if attrs and cat is None:
             # TODO: this does not work as expected when there are
             # already features in the map when we opened it

--- a/scripts/v.rast.stats/testsuite/test_v_rast_stats.py
+++ b/scripts/v.rast.stats/testsuite/test_v_rast_stats.py
@@ -52,8 +52,8 @@ class TestRastStats(TestCase):
         vt.open("w", tab_cols=cols)
         line1 = Line([(1, 1), (2, 1), (2, 2)])
         line2 = Line([(10, 20), (15, 22), (20, 32), (30, 40)])
-        vt.write(line1, ("first",))
-        vt.write(line2, ("second",))
+        vt.write(line1, attrs=("first",))
+        vt.write(line2, attrs=("second",))
         vt.table.conn.commit()
         vt.close()
 
@@ -67,8 +67,8 @@ class TestRastStats(TestCase):
         cent2 = Centroid(x=2.75, y=2.75)
         vt.write(area1)
         vt.write(area2)
-        vt.write(cent1, ("first",))
-        vt.write(cent2, ("second",))
+        vt.write(cent1, attrs=("first",))
+        vt.write(cent2, attrs=("second",))
         vt.table.conn.commit()
         vt.close()
 


### PR DESCRIPTION
I was tired of seeing the deprecation warning in the gunittest logs, distracting the analysis of changes. So I went and tried to address our usages of it.

I started by removing the compatibility code for accepting the API before GRASS 7.2. It has already been a decade since that workaround to keep the calling syntax of GRASS 7.0 and before valid. Then, once removed, I fixed the tests that failed.

I’ll let this run to have CI here without the compatibility code, then revert the commit to keep only the test changes.