### PR TITLE
Fix openmp for init evaluate c

### DIFF
--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -459,8 +459,9 @@ void execute(expr_list *ee)
 
     verbose = isatty(2);
     for (current_depth = 0; current_depth < depths; current_depth++) {
+      int row;
 #pragma omp parallel for default(shared) schedule(static, 1) private(i) ordered
-        for (int row = 0; row < rows; row++) {
+        for (row = 0; row < rows; row++) {
             if (verbose)
                 G_percent(n, count, 2);
 


### PR DESCRIPTION
MSVC error C3015: initialization in OpenMP 'for' statement has improper form. Fixed by declaring 'int row;' before the OpenMP parallel for loop, ensuring compatibility with MSVC.

Please review @HuidaeCho