### PR TITLE
r.mapcalc: Fix OpenMP C3015 error in evaluate.c on MSVC

### DIFF
--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -459,8 +459,9 @@ void execute(expr_list *ee)
 
     verbose = isatty(2);
     for (current_depth = 0; current_depth < depths; current_depth++) {
+      int row;
 #pragma omp parallel for default(shared) schedule(static, 1) private(i) ordered
-        for (int row = 0; row < rows; row++) {
+        for (row = 0; row < rows; row++) {
             if (verbose)
                 G_percent(n, count, 2);
 

--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -459,7 +459,7 @@ void execute(expr_list *ee)
 
     verbose = isatty(2);
     for (current_depth = 0; current_depth < depths; current_depth++) {
-      int row;
+        int row;
 #pragma omp parallel for default(shared) schedule(static, 1) private(i) ordered
         for (row = 0; row < rows; row++) {
             if (verbose)


### PR DESCRIPTION
# Fix OpenMP C3015 compilation error in r.mapcalc

## Problem
MSVC build fails with OpenMP error:

```
"C:\opt\grass\build\grass.sln" (default target) (1) ->
"C:\opt\grass\build\ALL_BUILD.vcxproj.metaproj" (default target) (2) ->
"C:\opt\grass\build\raster\ALL_RASTER_MODULES.vcxproj.metaproj" (default target) (306) ->
"C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj.metaproj" (default target) (391) ->
"C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj" (default target) (394) ->
(ClCompile target) -> 
  C:\opt\grass\raster\r.mapcalc\evaluate.c(463,18): error C3015: initialization in OpenMP 'for' statement has improper form [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
```

## Solution
Moved variable declaration outside the OpenMP pragma directive to comply with OpenMP standards.

## Changes
- Declared `int row;` before the `#pragma omp parallel for` directive
- Modified for loop initialization to use pre-declared variable

Fixes Windows MSVC compilation while maintaining OpenMP functionality.

## Reviewers

@HuidaeCho 