### PR TITLE
r.mapcalc: Fix LNK2019/LNK2001 unresolved symbol 'columns'

### DIFF
--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -18,7 +18,7 @@
 
 int current_depth;
 int *current_row;
-int depths, rows, columns;
+int depths, rows;
 
 /* Local variables for map management */
 static expression **map_list = NULL;

--- a/raster/r.mapcalc/globals.h
+++ b/raster/r.mapcalc/globals.h
@@ -8,6 +8,6 @@ extern int region_approach;
 
 extern int current_depth;
 extern int *current_row;
-extern int depths, rows, columns;
+extern int depths, rows;
 
 #endif /* __GLOBALS_H_ */


### PR DESCRIPTION
# Fix LNK2019/LNK2001 unresolved symbol 'columns' in r.mapcalc

## Problem
MSVC build fails with multiple linker errors related to unresolved 'columns' symbol:

```
"C:\opt\grass\build\grass.sln" (default target) (1) ->
"C:\opt\grass\build\ALL_BUILD.vcxproj.metaproj" (default target) (2) ->
"C:\opt\grass\build\raster\ALL_RASTER_MODULES.vcxproj.metaproj" (default target) (306) ->
"C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj.metaproj" (default target) (391) ->
"C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj" (default target) (394) ->
(Link target) -> 
  xarea.obj : error LNK2019: unresolved external symbol columns referenced in function f_area [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  xcoor.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  xres.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  column_shift.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  evaluate.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  xrowcol.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  map.obj : error LNK2001: unresolved external symbol columns [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
  C:\opt\grass\build\output\lib\grass85\bin\r.mapcalc.exe : fatal error LNK1120: 1 unresolved externals [C:\opt\grass\build\raster\r.mapcalc\r.mapcalc.vcxproj]
```

## Root Cause Analysis

The issue stems from differences in how **GCC (Linux)** and **MSVC (Windows)** handle **DLL symbol visibility** for shared variables across modules.

### The Architecture
The `columns` variable is **properly defined in `lib/calc/calc.c`** and is intended to be **shared between the calc library and r.mapcalc module**. The r.mapcalc module correctly **depends on the calc library** as specified in its CMakeLists.txt.

### Why it works on Linux (GCC):
- **Simple variable definitions like `int columns;` automatically export** symbols from shared libraries
- **`extern` declarations in r.mapcalc/globals.h automatically import** these symbols in dependent modules
- **No special export/import annotations** are required
- This follows traditional Unix shared library conventions

### Why it fails on Windows (MSVC):
- **Windows DLLs require explicit symbol visibility**: `__declspec(dllexport)` to export and `__declspec(dllimport)` to import
- **MSVC does not automatically export/import** simple variable definitions across DLL boundaries
- Unlike on Linux, **`extern` declarations in r.mapcalc/globals.h** are not enough to import symbols from shared libraries
- **Without proper export/import declarations**, the linker cannot resolve cross-DLL symbol references
- This stricter behavior is part of Windows PE (Portable Executable) format requirements

### The Missing Link
The `columns` variable was defined in `lib/calc/calc.c` but **lacked the proper `GRASS_CALC_EXPORT` annotation** needed for Windows DLL export/import, while other variables in the same library (`floating_point_exception`, `floating_point_exception_occurred`) were properly annotated.

## Solution

Applied the **proper DLL export/import mechanism** using GRASS's existing `GRASS_CALC_EXPORT` system to enable cross-DLL variable sharing on Windows while maintaining Linux compatibility.

## Changes Made

### 1. **include/grass/calc.h**
```c
// BEFORE:
extern int columns;

// AFTER:  
extern GRASS_CALC_EXPORT int columns;
```

Added `GRASS_CALC_EXPORT`  annotation to the `columns` declaration, making it consistent with other exported variables in the same header.

### 2. **raster\r.mapcalc\globals.h**

```c
// BEFORE:
extern int depths, rows, columns;

// AFTER:
extern int depths, rows;
```
to import `columns` from the calc library

How `GRASS_CALC_EXPORT` Works

- On Windows: Expands to `__declspec(dllexport)` when building the calc library, `__declspec(dllimport)` when using it
- On Linux: Expands to nothing (empty), preserving traditional behavior
- Automatic detection: Based on build context (whether building the library or using it)

## Reviewers

@HuidaeCho 