### PR TITLE
init: Fix SyntaxWarning: invalid escape sequence in grass.py

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2092,7 +2092,7 @@ def find_grass_python_package() -> None:
     if "GRASS_PYDIR" in os.environ and len(os.getenv("GRASS_PYDIR")) > 0:
         GRASS_PYDIR = os.path.normpath(os.environ["GRASS_PYDIR"])
     else:
-        GRASS_PYDIR = os.path.normpath("@GRASS_PYDIR@")
+        GRASS_PYDIR = os.path.normpath(r"@GRASS_PYDIR@")
 
     if os.path.exists(GRASS_PYDIR):
         sys.path.append(GRASS_PYDIR)


### PR DESCRIPTION
# Fix SyntaxWarning: invalid escape sequence in grass.py

## Problem
Python script generates SyntaxWarning and RuntimeError on Windows:

```
C:\opt\grass\build\output\bin\[grass85.py:2095](http://grass85.py:2095/): SyntaxWarning: invalid escape sequence '\o'
  GRASS_PYDIR = os.path.normpath("C:\opt\grass\build\output\lib\grass85\etc\python")
Traceback (most recent call last):
  File "C:\opt\grass\build\output\bin\[grass85.py](http://grass85.py/)", line 2473, in <module>
    main()
    ~~~~^^
  File "C:\opt\grass\build\output\bin\[grass85.py](http://grass85.py/)", line 2118, in main
    find_grass_python_package()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\opt\grass\build\output\bin\[grass85.py](http://grass85.py/)", line 2106, in find_grass_python_package
    raise RuntimeError(msg)
RuntimeError: The grass Python package is missing. Is the installation of GRASS complete?
```


## Solution
Convert string literal to raw string to properly handle backslashes in Windows paths.

## Changes
- Changed `"@GRASS_PYDIR@"` to `r"@GRASS_PYDIR@"` in the `find_grass_python_package()` function

This eliminates the SyntaxWarning about invalid escape sequence `\o` and ensures proper path handling on Windows systems.

Fixes Python syntax warning that occurs during GRASS GIS initialization on Windows.

## Reviewers

@HuidaeCho 
