### PR TITLE
v.category: return json array for layers option

### DIFF
--- a/vector/v.category/main.c
+++ b/vector/v.category/main.c
@@ -92,7 +92,6 @@ int main(int argc, char *argv[])
     enum OutputFormat format;
     JSON_Array *root_array = NULL;
     JSON_Value *root_value = NULL;
-    JSON_Object *root_object = NULL;
     int skip_header = 0;
 
     module = G_define_module();

--- a/vector/v.category/main.c
+++ b/vector/v.category/main.c
@@ -259,13 +259,6 @@ int main(int argc, char *argv[])
         JSON_Array *layers_array = NULL;
         JSON_Value *layers_value = NULL;
         if (format == JSON) {
-            root_value = json_value_init_object();
-            if (root_value == NULL) {
-                G_fatal_error(
-                    _("Failed to initialize JSON object. Out of memory?"));
-            }
-            root_object = json_object(root_value);
-
             layers_value = json_value_init_array();
             if (layers_value == NULL) {
                 G_fatal_error(
@@ -321,16 +314,15 @@ int main(int argc, char *argv[])
         }
 
         if (format == JSON) {
-            json_object_set_value(root_object, "layers", layers_value);
 
             char *serialized_string = NULL;
-            serialized_string = json_serialize_to_string_pretty(root_value);
+            serialized_string = json_serialize_to_string_pretty(layers_value);
             if (serialized_string == NULL) {
                 G_fatal_error(_("Failed to initialize pretty JSON string."));
             }
             puts(serialized_string);
             json_free_serialized_string(serialized_string);
-            json_value_free(root_value);
+            json_value_free(layers_value);
         }
         Vect_close(&In);
         exit(EXIT_SUCCESS);

--- a/vector/v.category/testsuite/test_v_category.py
+++ b/vector/v.category/testsuite/test_v_category.py
@@ -105,7 +105,7 @@ class TestVCategory(TestCase):
 
         result = json.loads(module.outputs.stdout)
 
-        expected = {"layers": [1, 2]}
+        expected = [1, 2]
 
         self.assertDictEqual(expected, result)
 

--- a/vector/v.category/testsuite/test_v_category.py
+++ b/vector/v.category/testsuite/test_v_category.py
@@ -107,7 +107,7 @@ class TestVCategory(TestCase):
 
         expected = [1, 2]
 
-        self.assertDictEqual(expected, result)
+        self.assertListEqual(expected, result)
 
     def test_report_option_plain(self):
         """Test v.category with the plain output format, and report option."""


### PR DESCRIPTION
This simplifies v.category format=json option=layers from:
```json
{
    "layers": [
        1
    ]
}
```
to
```json
[
    1
]
```

which is more consistent with the other options.
