### PR TITLE
grass.gunittest: Inherit more from unittest classes

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -16,6 +16,7 @@ import subprocess
 import hashlib
 import uuid
 import unittest
+from itertools import starmap
 from unittest.util import safe_repr
 
 from grass.pygrass.modules import Module
@@ -1502,16 +1503,15 @@ class _SubTest(TestCase):
         self.failureException = test_case.failureException
 
     def runTest(self):
-        raise NotImplementedError("subtests cannot be run directly")
+        msg = "subtests cannot be run directly"
+        raise NotImplementedError(msg)
 
     def _subDescription(self):
         parts = []
         if self._message is not _subtest_msg_sentinel:
             parts.append("[{}]".format(self._message))
         if self.params:
-            params_desc = ", ".join(
-                "{}={!r}".format(k, v) for (k, v) in self.params.items()
-            )
+            params_desc = ", ".join(starmap("{}={!r}".format, self.params.items()))
             parts.append("({})".format(params_desc))
         return " ".join(parts) or "(<subtest>)"
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -16,7 +16,6 @@ import subprocess
 import hashlib
 import uuid
 import unittest
-from itertools import starmap
 from unittest.util import safe_repr
 
 from grass.pygrass.modules import Module
@@ -36,8 +35,6 @@ from .checkers import (
 from .gutils import is_map_in_mapset
 
 from io import StringIO
-
-_subtest_msg_sentinel = object()
 
 
 class TestCase(unittest.TestCase):
@@ -1487,42 +1484,3 @@ def _check_module_run_parameters(module):
         msg = "stderr_ can be only PIPE or None"
         raise ValueError(msg)
         # because we want to capture it
-
-
-class _SubTest(TestCase):
-    """
-    Private class _SubTest copied over from Python unittest to be available
-    when subclassing
-    """
-
-    def __init__(self, test_case, message, params):
-        super().__init__()
-        self._message = message
-        self.test_case = test_case
-        self.params = params
-        self.failureException = test_case.failureException
-
-    def runTest(self):
-        msg = "subtests cannot be run directly"
-        raise NotImplementedError(msg)
-
-    def _subDescription(self):
-        parts = []
-        if self._message is not _subtest_msg_sentinel:
-            parts.append("[{}]".format(self._message))
-        if self.params:
-            params_desc = ", ".join(starmap("{}={!r}".format, self.params.items()))
-            parts.append("({})".format(params_desc))
-        return " ".join(parts) or "(<subtest>)"
-
-    def id(self):
-        return "{} {}".format(self.test_case.id(), self._subDescription())
-
-    def shortDescription(self):
-        """Returns a one-line description of the subtest, or None if no
-        description has been provided.
-        """
-        return self.test_case.shortDescription()
-
-    def __str__(self):
-        return "{} {}".format(self.test_case, self._subDescription())

--- a/python/grass/gunittest/result.py
+++ b/python/grass/gunittest/result.py
@@ -21,6 +21,10 @@ class TestResult(unittest.TestResult):
     formatted traceback of the error that occurred.
     """
 
+    start_time: float | None = None
+    end_time: float | None = None
+    time_taken: float | None = None
+
     # descriptions and verbosity unused
     # included for compatibility with unittest's TestResult
     # where are also unused, so perhaps we can remove them
@@ -35,6 +39,9 @@ class TestResult(unittest.TestResult):
         self.successes: list[
             grass.gunittest.case.TestCase | unittest.case.TestCase
         ] = []
+        self.start_time = None
+        self.end_time = None
+        self.time_taken = None
 
     def addSuccess(
         self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
@@ -55,4 +62,6 @@ class TestResult(unittest.TestResult):
         :param end_time: The end time of the test, as returned by time.time()
         :param time_taken: The time taken for the test, usually end_time-start_time
         """
-        # TODO: implement this
+        self.start_time = start_time
+        self.end_time = end_time
+        self.time_taken = time_taken

--- a/python/grass/gunittest/result.py
+++ b/python/grass/gunittest/result.py
@@ -55,5 +55,4 @@ class TestResult(unittest.TestResult):
         :param end_time: The end time of the test, as returned by time.time()
         :param time_taken: The time taken for the test, usually end_time-start_time
         """
-        pass
         # TODO: implement this

--- a/python/grass/gunittest/result.py
+++ b/python/grass/gunittest/result.py
@@ -1,6 +1,12 @@
 """Test result object"""
 
+from __future__ import annotations
+
 import unittest
+from typing import TYPE_CHECKING, TextIO
+
+if TYPE_CHECKING:
+    import grass.gunittest.case
 
 
 class TestResult(unittest.TestResult):
@@ -19,18 +25,35 @@ class TestResult(unittest.TestResult):
     # included for compatibility with unittest's TestResult
     # where are also unused, so perhaps we can remove them
     # stream set to None and not included in interface, it would not make sense
-    def __init__(self, stream=None, descriptions=None, verbosity=None):
+    def __init__(
+        self,
+        stream: TextIO | None = None,
+        descriptions: bool | None = None,
+        verbosity: int | None = None,
+    ) -> None:
         super().__init__(stream=stream, descriptions=descriptions, verbosity=verbosity)
-        self.successes = []
+        self.successes: list[
+            grass.gunittest.case.TestCase | unittest.case.TestCase
+        ] = []
 
-    def addSuccess(self, test):
+    def addSuccess(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         super().addSuccess(test)
         self.successes.append(test)
 
     # TODO: better would be to pass start at the beginning
     # alternative is to leave counting time on class
-    # TODO: document: we expect all grass classes to have setTimes
     # TODO: alternatively, be more forgiving for non-unittest methods
-    def setTimes(self, start_time, end_time, time_taken):
+    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
+        """
+        Store the start time, end time and time taken for a test.
+
+        We expect all grass classes to have setTimes.
+
+        :param start_time: The start time of the test, as returned by time.time()
+        :param end_time: The end time of the test, as returned by time.time()
+        :param time_taken: The time taken for the test, usually end_time-start_time
+        """
         pass
         # TODO: implement this

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -17,7 +17,6 @@ import time
 
 import unittest
 import grass.gunittest.result
-from grass.gunittest.case import _SubTest
 
 __unittest = True
 
@@ -60,34 +59,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         self.start_time = None
         self.end_time = None
         self.time_taken = None
-
-    def _write_status(self, test, status):
-        is_subtest = isinstance(test, _SubTest)
-        if is_subtest or self._newline:
-            if not self._newline:
-                self.stream.writeln()
-            if is_subtest:
-                self.stream.write("  ")
-            self.stream.write(self.getDescription(test))
-            self.stream.write(" ... ")
-        self.stream.writeln(status)
-        self.stream.flush()
-        self._newline = True
-
-    def addSubTest(self, test, subtest, err):
-        if err is not None:
-            if self.showAll:
-                if issubclass(err[0], subtest.failureException):
-                    self._write_status(subtest, "FAIL")
-                else:
-                    self._write_status(subtest, "ERROR")
-            elif self.dots:
-                if issubclass(err[0], subtest.failureException):
-                    self.stream.write("F")
-                else:
-                    self.stream.write("E")
-                self.stream.flush()
-        super().addSubTest(test, subtest, err)
 
     def setTimes(self, start_time, end_time, time_taken):
         self.start_time = start_time

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import time
 import unittest
 from typing import TextIO
-import warnings
 
 import grass.gunittest.case
 import grass.gunittest.result
@@ -404,82 +403,11 @@ class GrassTestRunner(unittest.TextTestRunner):
 
     def run(self, test):
         """Run the given test case or test suite."""
-        result = self._makeResult()
-        unittest.registerResult(result)
-        result.failfast = self.failfast
-        result.buffer = self.buffer
-        result.tb_locals = self.tb_locals
-        with warnings.catch_warnings():
-            if self.warnings:
-                # if self.warnings is set, use it to filter all the warnings
-                warnings.simplefilter(self.warnings)
-                # if the filter is 'default' or 'always', special-case the
-                # warnings from the deprecated unittest methods to show them
-                # no more than once per module, because they can be fairly
-                # noisy.  The -Wd and -Wa flags can be used to bypass this
-                # only when self.warnings is None.
-                if self.warnings in ["default", "always"]:
-                    warnings.filterwarnings(
-                        "module",
-                        category=DeprecationWarning,
-                        message=r"Please use assert\w+ instead.",
-                    )
-            startTime = time.perf_counter()
-            startTestRun = getattr(result, "startTestRun", None)
-            if startTestRun is not None:
-                startTestRun()
-            try:
-                test(result)
-            finally:
-                stopTime = time.perf_counter()
-                timeTaken = stopTime - startTime
-                setTimes = getattr(result, "setTimes", None)
-                if setTimes is not None:
-                    setTimes(startTime, stopTime, timeTaken)
-                stopTestRun = getattr(result, "stopTestRun", None)
-                if stopTestRun is not None:
-                    stopTestRun()
-            stopTime = time.perf_counter()
+        startTime = time.perf_counter()
+        result = super().run(test)
+        stopTime = time.perf_counter()
         timeTaken = stopTime - startTime
-        result.printErrors()
-        if hasattr(result, "separator2"):
-            self.stream.writeln(result.separator2)
-        run = result.testsRun
-        self.stream.writeln(
-            "Ran %d test%s in %.3fs" % (run, (run != 1 and "s") or "", timeTaken)
-        )
-        self.stream.writeln()
-
-        expectedFails = unexpectedSuccesses = skipped = 0
-        try:
-            results = map(
-                len,
-                (result.expectedFailures, result.unexpectedSuccesses, result.skipped),
-            )
-        except AttributeError:
-            pass
-        else:
-            expectedFails, unexpectedSuccesses, skipped = results
-
-        infos = []
-        if not result.wasSuccessful():
-            self.stream.write("FAILED")
-            failed, errored = len(result.failures), len(result.errors)
-            if failed:
-                infos.append("failures=%d" % failed)
-            if errored:
-                infos.append("errors=%d" % errored)
-        else:
-            self.stream.write("OK")
-        if skipped:
-            infos.append("skipped=%d" % skipped)
-        if expectedFails:
-            infos.append("expected failures=%d" % expectedFails)
-        if unexpectedSuccesses:
-            infos.append("unexpected successes=%d" % unexpectedSuccesses)
-        if infos:
-            self.stream.writeln(" (%s)" % (", ".join(infos),))
-        else:
-            self.stream.write("\n")
-        self.stream.flush()
+        setTimes = getattr(result, "setTimes", None)
+        if setTimes is not None:
+            setTimes(startTime, stopTime, timeTaken)
         return result

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -70,7 +70,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         self.end_time: float | None = None
         self.time_taken: float | None = None
 
-
     def stopTestRun(self) -> None:
         super().stopTestRun()
         self.printErrors()
@@ -133,7 +132,6 @@ class KeyValueTestResult(grass.gunittest.result.TestResult):
 
         self._grass_modules = []
         self._supplementary_files: list[str] = []
-
 
     def stopTest(
         self, test: grass.gunittest.case.TestCase | unittest.case.TestCase

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -71,9 +71,9 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         self.time_taken: float | None = None
 
     def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
-        self.start_time = start_time
-        self.end_time = end_time
-        self.time_taken = time_taken
+        super().setTimes(
+            start_time=start_time, end_time=end_time, time_taken=time_taken
+        )
 
     def stopTestRun(self) -> None:
         super().stopTestRun()
@@ -139,9 +139,9 @@ class KeyValueTestResult(grass.gunittest.result.TestResult):
         self._supplementary_files: list[str] = []
 
     def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
-        self.start_time = start_time
-        self.end_time = end_time
-        self.time_taken = time_taken
+        super().setTimes(
+            start_time=start_time, end_time=end_time, time_taken=time_taken
+        )
 
     def stopTest(
         self, test: grass.gunittest.case.TestCase | unittest.case.TestCase

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -446,7 +446,7 @@ class GrassTestRunner(unittest.TextTestRunner):
             self.stream.writeln(result.separator2)
         run = result.testsRun
         self.stream.writeln(
-            "Ran %d test%s in %.3fs" % (run, run != 1 and "s" or "", timeTaken)
+            "Ran %d test%s in %.3fs" % (run, (run != 1 and "s") or "", timeTaken)
         )
         self.stream.writeln()
 

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -53,7 +53,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         super().__init__(
             stream=stream, descriptions=descriptions, verbosity=verbosity, **kwargs
         )
-        self._newline = True
         self.durations = durations
 
         self.start_time = None

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -65,20 +65,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         self.end_time = None
         self.time_taken = None
 
-    def getDescription(self, test):
-        doc_first_line = test.shortDescription()
-        if self.descriptions and doc_first_line:
-            return "\n".join((str(test), doc_first_line))
-        return str(test)
-
-    def startTest(self, test):
-        super().startTest(test)
-        if self.showAll:
-            self.stream.write(self.getDescription(test))
-            self.stream.write(" ... ")
-            self.stream.flush()
-            self._newline = False
-
     def _write_status(self, test, status):
         is_subtest = isinstance(test, _SubTest)
         if is_subtest or self._newline:
@@ -106,77 +92,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
                     self.stream.write("E")
                 self.stream.flush()
         super().addSubTest(test, subtest, err)
-
-    def addSuccess(self, test):
-        super().addSuccess(test)
-        if self.showAll:
-            self._write_status(test, "ok")
-        elif self.dots:
-            self.stream.write(".")
-            self.stream.flush()
-
-    def addError(self, test, err):
-        super().addError(test, err)
-        if self.showAll:
-            self._write_status(test, "ERROR")
-        elif self.dots:
-            self.stream.write("E")
-            self.stream.flush()
-
-    def addFailure(self, test, err):
-        super().addFailure(test, err)
-        if self.showAll:
-            self._write_status(test, "FAIL")
-        elif self.dots:
-            self.stream.write("F")
-            self.stream.flush()
-
-    def addSkip(self, test, reason):
-        super().addSkip(test, reason)
-        if self.showAll:
-            self._write_status(test, "skipped {0!r}".format(reason))
-        elif self.dots:
-            self.stream.write("s")
-            self.stream.flush()
-
-    def addExpectedFailure(self, test, err):
-        super().addExpectedFailure(test, err)
-        if self.showAll:
-            self.stream.writeln("expected failure")
-            self.stream.flush()
-        elif self.dots:
-            self.stream.write("x")
-            self.stream.flush()
-
-    def addUnexpectedSuccess(self, test):
-        super().addUnexpectedSuccess(test)
-        if self.showAll:
-            self.stream.writeln("unexpected success")
-            self.stream.flush()
-        elif self.dots:
-            self.stream.write("u")
-            self.stream.flush()
-
-    def printErrors(self):
-        if self.dots or self.showAll:
-            self.stream.writeln()
-            self.stream.flush()
-        self.printErrorList("ERROR", self.errors)
-        self.printErrorList("FAIL", self.failures)
-        unexpectedSuccesses = getattr(self, "unexpectedSuccesses", ())
-        if unexpectedSuccesses:
-            self.stream.writeln(self.separator1)
-            for test in unexpectedSuccesses:
-                self.stream.writeln(f"UNEXPECTED SUCCESS: {self.getDescription(test)}")
-            self.stream.flush()
-
-    def printErrorList(self, flavour, errors):
-        for test, err in errors:
-            self.stream.writeln(self.separator1)
-            self.stream.writeln("%s: %s" % (flavour, self.getDescription(test)))
-            self.stream.writeln(self.separator2)
-            self.stream.writeln("%s" % err)
-            self.stream.flush()
 
     def setTimes(self, start_time, end_time, time_taken):
         self.start_time = start_time

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -12,10 +12,14 @@ File content taken from Python's  ``unittest.runner``, it will be used as
 a template. It is not expected that something will left.
 """
 
+from __future__ import annotations
+
 import sys
 import time
-
 import unittest
+from typing import TextIO
+
+import grass.gunittest.case
 import grass.gunittest.result
 
 __unittest = True
@@ -24,7 +28,7 @@ __unittest = True
 class _WritelnDecorator:
     """Used to decorate file-like objects with a handy 'writeln' method"""
 
-    def __init__(self, stream):
+    def __init__(self, stream) -> None:
         self.stream = stream
 
     def __getattr__(self, attr: str):
@@ -32,7 +36,7 @@ class _WritelnDecorator:
             raise AttributeError(attr)
         return getattr(self.stream, attr)
 
-    def writeln(self, arg=None):
+    def writeln(self, arg=None) -> None:
         if arg:
             self.write(arg)
         self.write("\n")  # text-mode streams translate to \r\n if needed
@@ -47,24 +51,32 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
     separator1 = "=" * 70
     separator2 = "-" * 70
 
-    def __init__(self, stream, descriptions, verbosity, *, durations=None, **kwargs):
+    def __init__(
+        self,
+        stream: TextIO | None,
+        descriptions: bool | None,
+        verbosity: int | None,
+        *,
+        durations: int | None = None,
+        **kwargs,
+    ) -> None:
         """Construct a TextTestResult. Subclasses should accept **kwargs
         to ensure compatibility as the interface changes."""
         super().__init__(
             stream=stream, descriptions=descriptions, verbosity=verbosity, **kwargs
         )
-        self.durations = durations
+        self.durations: int | None = durations
 
-        self.start_time = None
-        self.end_time = None
-        self.time_taken = None
+        self.start_time: float | None = None
+        self.end_time: float | None = None
+        self.time_taken: float | None = None
 
-    def setTimes(self, start_time, end_time, time_taken):
+    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
         self.start_time = start_time
         self.end_time = end_time
         self.time_taken = time_taken
 
-    def stopTestRun(self):
+    def stopTestRun(self) -> None:
         super().stopTestRun()
         self.printErrors()
         self.stream.writeln(self.separator2)
@@ -111,13 +123,13 @@ class KeyValueTestResult(grass.gunittest.result.TestResult):
     separator1 = "=" * 70
     separator2 = "-" * 70
 
-    def __init__(self, stream, test_type=None):
+    def __init__(self, stream, test_type=None) -> None:
         super().__init__(stream=stream, descriptions=None, verbosity=None)
         self._stream = _WritelnDecorator(stream)
 
-        self.start_time = None
-        self.end_time = None
-        self.time_taken = None
+        self.start_time: float | None = None
+        self.end_time: float | None = None
+        self.time_taken: float | None = None
 
         if test_type:
             self.test_type = test_type
@@ -127,19 +139,21 @@ class KeyValueTestResult(grass.gunittest.result.TestResult):
         self._grass_modules = []
         self._supplementary_files: list[str] = []
 
-    def setTimes(self, start_time, end_time, time_taken):
+    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
         self.start_time = start_time
         self.end_time = end_time
         self.time_taken = time_taken
 
-    def stopTest(self, test):
+    def stopTest(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         super().stopTest(test)
         if hasattr(test, "grass_modules"):
             self._grass_modules.extend(test.grass_modules)
         if hasattr(test, "supplementary_files"):
             self._supplementary_files.extend(test.supplementary_files)
 
-    def stopTestRun(self):
+    def stopTestRun(self) -> None:
         super().stopTestRun()
         infos = []
 
@@ -207,12 +221,16 @@ class MultiTestResult(grass.gunittest.result.TestResult):
     # included for compatibility with unittest's TestResult
     # where are also unused, so perhaps we can remove them
     # stream set to None and not included in interface, it would not make sense
-    def __init__(self, results, forgiving=False, descriptions=None, verbosity=None):
+    def __init__(
+        self, results, forgiving=False, descriptions=None, verbosity=None
+    ) -> None:
         super().__init__(stream=None, descriptions=descriptions, verbosity=verbosity)
         self._results = results
         self._forgiving = forgiving
 
-    def startTest(self, test):
+    def startTest(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         super().startTest(test)
         for result in self._results:
             try:
@@ -223,7 +241,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def stopTest(self, test):
+    def stopTest(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         """Called when the given test has been run"""
         super().stopTest(test)
         for result in self._results:
@@ -235,7 +255,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addSuccess(self, test):
+    def addSuccess(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         super().addSuccess(test)
         for result in self._results:
             try:
@@ -246,7 +268,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addError(self, test, err):
+    def addError(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase, err
+    ) -> None:
         super().addError(test, err)
         for result in self._results:
             try:
@@ -257,7 +281,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addFailure(self, test, err):
+    def addFailure(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase, err
+    ) -> None:
         super().addFailure(test, err)
         for result in self._results:
             try:
@@ -268,7 +294,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addSkip(self, test, reason):
+    def addSkip(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase, reason: str
+    ) -> None:
         super().addSkip(test, reason)
         for result in self._results:
             try:
@@ -279,7 +307,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addExpectedFailure(self, test, err):
+    def addExpectedFailure(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase, err
+    ) -> None:
         super().addExpectedFailure(test, err)
         for result in self._results:
             try:
@@ -290,7 +320,9 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def addUnexpectedSuccess(self, test):
+    def addUnexpectedSuccess(
+        self, test: grass.gunittest.case.TestCase | unittest.case.TestCase
+    ) -> None:
         super().addUnexpectedSuccess(test)
         for result in self._results:
             try:
@@ -301,7 +333,7 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def printErrors(self):
+    def printErrors(self) -> None:
         """Called by TestRunner after test run"""
         super().printErrors()
         for result in self._results:
@@ -313,7 +345,7 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def startTestRun(self):
+    def startTestRun(self) -> None:
         """Called once before any tests are executed.
 
         See startTest for a method called before each test.
@@ -328,7 +360,7 @@ class MultiTestResult(grass.gunittest.result.TestResult):
                 else:
                     raise
 
-    def stopTestRun(self):
+    def stopTestRun(self) -> None:
         """Called once after all tests are executed.
 
         See stopTest for a method called after each test.
@@ -345,9 +377,8 @@ class MultiTestResult(grass.gunittest.result.TestResult):
 
     # TODO: better would be to pass start at the beginning
     # alternative is to leave counting time on class
-    # TODO: document: we expect all grass classes to have setTimes
     # TODO: alternatively, be more forgiving for non-unittest methods
-    def setTimes(self, start_time, end_time, time_taken):
+    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
         for result in self._results:
             try:
                 result.setTimes(start_time, end_time, time_taken)
@@ -372,7 +403,7 @@ class GrassTestRunner:
         *,
         tb_locals=False,
         **kwargs,
-    ):
+    ) -> None:
         if stream is None:
             stream = sys.stderr
         self.stream = _WritelnDecorator(stream)

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -39,7 +39,7 @@ class _WritelnDecorator:
         self.write("\n")  # text-mode streams translate to \r\n if needed
 
 
-class TextTestResult(grass.gunittest.result.TestResult):
+class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult):
     """A test result class that can print formatted text results to a stream.
 
     Used by TextTestRunner.

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -70,10 +70,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         self.end_time: float | None = None
         self.time_taken: float | None = None
 
-    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
-        super().setTimes(
-            start_time=start_time, end_time=end_time, time_taken=time_taken
-        )
 
     def stopTestRun(self) -> None:
         super().stopTestRun()
@@ -138,10 +134,6 @@ class KeyValueTestResult(grass.gunittest.result.TestResult):
         self._grass_modules = []
         self._supplementary_files: list[str] = []
 
-    def setTimes(self, start_time: float, end_time: float, time_taken: float) -> None:
-        super().setTimes(
-            start_time=start_time, end_time=end_time, time_taken=time_taken
-        )
 
     def stopTest(
         self, test: grass.gunittest.case.TestCase | unittest.case.TestCase

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -17,6 +17,7 @@ import time
 
 import unittest
 import grass.gunittest.result
+from grass.gunittest.case import _SubTest
 
 __unittest = True
 
@@ -47,7 +48,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
     separator1 = "=" * 70
     separator2 = "-" * 70
 
-    def __init__(self, stream, descriptions, verbosity, **kwargs):
+    def __init__(self, stream, descriptions, verbosity, *, durations=None, **kwargs):
         """Construct a TextTestResult. Subclasses should accept **kwargs
         to ensure compatibility as the interface changes."""
         super().__init__(
@@ -57,6 +58,8 @@ class TextTestResult(grass.gunittest.result.TestResult):
         self.showAll = verbosity > 1
         self.dots = verbosity == 1
         self.descriptions = descriptions
+        self._newline = True
+        self.durations = durations
 
         self.start_time = None
         self.end_time = None
@@ -74,12 +77,40 @@ class TextTestResult(grass.gunittest.result.TestResult):
             self.stream.write(self.getDescription(test))
             self.stream.write(" ... ")
             self.stream.flush()
+            self._newline = False
+
+    def _write_status(self, test, status):
+        is_subtest = isinstance(test, _SubTest)
+        if is_subtest or self._newline:
+            if not self._newline:
+                self.stream.writeln()
+            if is_subtest:
+                self.stream.write("  ")
+            self.stream.write(self.getDescription(test))
+            self.stream.write(" ... ")
+        self.stream.writeln(status)
+        self.stream.flush()
+        self._newline = True
+
+    def addSubTest(self, test, subtest, err):
+        if err is not None:
+            if self.showAll:
+                if issubclass(err[0], subtest.failureException):
+                    self._write_status(subtest, "FAIL")
+                else:
+                    self._write_status(subtest, "ERROR")
+            elif self.dots:
+                if issubclass(err[0], subtest.failureException):
+                    self.stream.write("F")
+                else:
+                    self.stream.write("E")
+                self.stream.flush()
+        super().addSubTest(test, subtest, err)
 
     def addSuccess(self, test):
         super().addSuccess(test)
         if self.showAll:
-            self.stream.writeln("ok")
-            self.stream.flush()
+            self._write_status(test, "ok")
         elif self.dots:
             self.stream.write(".")
             self.stream.flush()
@@ -87,8 +118,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
     def addError(self, test, err):
         super().addError(test, err)
         if self.showAll:
-            self.stream.writeln("ERROR")
-            self.stream.flush()
+            self._write_status(test, "ERROR")
         elif self.dots:
             self.stream.write("E")
             self.stream.flush()
@@ -96,8 +126,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
     def addFailure(self, test, err):
         super().addFailure(test, err)
         if self.showAll:
-            self.stream.writeln("FAIL")
-            self.stream.flush()
+            self._write_status(test, "FAIL")
         elif self.dots:
             self.stream.write("F")
             self.stream.flush()
@@ -105,8 +134,7 @@ class TextTestResult(grass.gunittest.result.TestResult):
     def addSkip(self, test, reason):
         super().addSkip(test, reason)
         if self.showAll:
-            self.stream.writeln("skipped {0!r}".format(reason))
-            self.stream.flush()
+            self._write_status(test, "skipped {0!r}".format(reason))
         elif self.dots:
             self.stream.write("s")
             self.stream.flush()
@@ -135,6 +163,12 @@ class TextTestResult(grass.gunittest.result.TestResult):
             self.stream.flush()
         self.printErrorList("ERROR", self.errors)
         self.printErrorList("FAIL", self.failures)
+        unexpectedSuccesses = getattr(self, "unexpectedSuccesses", ())
+        if unexpectedSuccesses:
+            self.stream.writeln(self.separator1)
+            for test in unexpectedSuccesses:
+                self.stream.writeln(f"UNEXPECTED SUCCESS: {self.getDescription(test)}")
+            self.stream.flush()
 
     def printErrorList(self, flavour, errors):
         for test, err in errors:

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -53,7 +53,7 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
 
     def __init__(
         self,
-        stream: TextIO | None,
+        stream: _WritelnDecorator | TextIO | None,
         descriptions: bool | None,
         verbosity: int | None,
         *,

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -208,7 +208,7 @@ class MultiTestResult(grass.gunittest.result.TestResult):
     # where are also unused, so perhaps we can remove them
     # stream set to None and not included in interface, it would not make sense
     def __init__(self, results, forgiving=False, descriptions=None, verbosity=None):
-        super().__init__(descriptions=descriptions, verbosity=verbosity, stream=None)
+        super().__init__(stream=None, descriptions=descriptions, verbosity=verbosity)
         self._results = results
         self._forgiving = forgiving
 

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -54,10 +54,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
         super().__init__(
             stream=stream, descriptions=descriptions, verbosity=verbosity, **kwargs
         )
-        self.stream = stream
-        self.showAll = verbosity > 1
-        self.dots = verbosity == 1
-        self.descriptions = descriptions
         self._newline = True
         self.durations = durations
 


### PR DESCRIPTION
Python is one of the few languages that allows multiple inheritance. That means that even we override two classes, one of which is is the base class of another, and we want the second class to use both our overridden class and overridden base class: it is possible. That is the case in our gunittest code.

Python uses a MRO (method resolution order) to know from which class call the function in this case. This order ignores duplicate classes if it happens. Python will handle at runtime an error when instantiating the class if there is a cycle in the base classes that can’t exist (this isn’t our case here). The `super()` call is where it makes the sense the most in Python, in multiple inheritance situations.


This PR is a follow up of some of my previous PRs (like #6200) that synced some gunittest code from unittest code so that the contents of the functions are exactly the same or similar.
Starting from there, classes, like the TextTestResult, were made subclasses of our overridden base class, AND unittest’s class. Then, replace all function implementations that are exactly the same as the unittest classe with a super() call. If there’s nothing else that remains apart from a super() call, it is useless to keep it, so remove the function.

With these removed, assignments to attributes that are used only by the unittest class can be simplified out, as done by the base class.

I simplified the GrassTestRunner class, in particular the only method run(), to use a call to the base classes instead of merging our code into the upstream code. That means our timing call is done before and after the base class call (that already does some timing calls, especially since 3.12 added durations natively. This means that our whole test call might be a little less precise (as it includes some time taken by the unittest call), but we don’t have to keep the implementation updated for each Python version.


Finished off with some typing annotations to make type checkers understand that our overridden classes are accepted as inputs. I also made a base implementation of the setTimes method, and called it with super() where appropriate in our classes (instead of defining it multiple times).

When developing, I stepped through function calls in the debugger to make sure the correct method resolution order was used, and to see which base implementations of functions were called and in which order.


