### PR TITLE
lib/vector: remove writing trailing spaces in ASCII format

### DIFF
--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -829,11 +829,11 @@ int Vect_write_ascii(FILE *ascii, FILE *att, struct Map_info *Map, int ver,
                     if (Map->head.with_z) {
                         G_rasprintf(&zstring, &zsize, "%.*f", dp, *zptr++);
                         G_trim_decimal(zstring);
-                        fprintf(ascii, " %-12s %-12s %-12s%s", xstring, ystring,
+                        fprintf(ascii, " %-12s %-12s %s%s", xstring, ystring,
                                 zstring, HOST_NEWLINE);
                     }
                     else {
-                        fprintf(ascii, " %-12s %-12s%s", xstring, ystring,
+                        fprintf(ascii, " %-12s %s%s", xstring, ystring,
                                 HOST_NEWLINE);
                     }
                 } /*Version 4 */
@@ -845,8 +845,8 @@ int Vect_write_ascii(FILE *ascii, FILE *att, struct Map_info *Map, int ver,
 
             if (ver == 5) {
                 for (i = 0; i < Cats->n_cats; i++) {
-                    fprintf(ascii, " %-5d %-10d%s", Cats->field[i],
-                            Cats->cat[i], HOST_NEWLINE);
+                    fprintf(ascii, " %-5d %d%s", Cats->field[i], Cats->cat[i],
+                            HOST_NEWLINE);
                 }
             }
             else {

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1243,8 +1243,8 @@ class TestCase(unittest.TestCase):
         # workaround for missing -h (do not print header) flag in v.out.ascii
         num_lines_of_header = 10
         diff = difflib.unified_diff(
-            fromlines[num_lines_of_header:],
-            tolines[num_lines_of_header:],
+            [line.strip() for line in fromlines[num_lines_of_header:]],
+            [line.strip() for line in tolines[num_lines_of_header:]],
             "reference",
             "actual",
             n=context_lines,

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1245,8 +1245,8 @@ class TestCase(unittest.TestCase):
         diff = difflib.unified_diff(
             [line.strip() for line in fromlines[num_lines_of_header:]],
             [line.strip() for line in tolines[num_lines_of_header:]],
-            "actual",
             "reference",
+            "actual",
             n=context_lines,
         )
         # TODO: this should be solved according to cleanup policy
@@ -1289,8 +1289,8 @@ class TestCase(unittest.TestCase):
                 htmldiff = difflib.HtmlDiff().make_file(
                     fromlines,
                     tolines,
-                    "actual",
                     "reference",
+                    "actual",
                     context=True,
                     numlines=context_lines,
                     charset="utf-8",

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1243,10 +1243,10 @@ class TestCase(unittest.TestCase):
         # workaround for missing -h (do not print header) flag in v.out.ascii
         num_lines_of_header = 10
         diff = difflib.unified_diff(
-            fromlines[num_lines_of_header:],
-            tolines[num_lines_of_header:],
-            "reference",
+            [line.strip() for line in fromlines[num_lines_of_header:]],
+            [line.strip() for line in tolines[num_lines_of_header:]],
             "actual",
+            "reference",
             n=context_lines,
         )
         # TODO: this should be solved according to cleanup policy
@@ -1289,8 +1289,8 @@ class TestCase(unittest.TestCase):
                 htmldiff = difflib.HtmlDiff().make_file(
                     fromlines,
                     tolines,
-                    "reference",
                     "actual",
+                    "reference",
                     context=True,
                     numlines=context_lines,
                     charset="utf-8",

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1243,8 +1243,8 @@ class TestCase(unittest.TestCase):
         # workaround for missing -h (do not print header) flag in v.out.ascii
         num_lines_of_header = 10
         diff = difflib.unified_diff(
-            [line.strip() for line in fromlines[num_lines_of_header:]],
-            [line.strip() for line in tolines[num_lines_of_header:]],
+            fromlines[num_lines_of_header:],
+            tolines[num_lines_of_header:],
             "reference",
             "actual",
             n=context_lines,

--- a/python/grass/gunittest/testsuite/test_assertions_vect.py
+++ b/python/grass/gunittest/testsuite/test_assertions_vect.py
@@ -2,7 +2,6 @@
 Tests assertion methods for vectors.
 """
 
-import unittest
 from grass.exceptions import CalledModuleError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -282,7 +281,6 @@ class TestVectorGeometryAssertions(TestCase):
         self.assertFileExists(self.simple_base_file)
         self.assertFileExists(self.simple_modified_file)
 
-    @unittest.expectedFailure
     def test_assertVectorEqualsAscii_by_import(self):
         amap = "simple_vector_map_imported_base"
         self.runModule(


### PR DESCRIPTION
This attempts to fix comparison of vector ascii files in testing. Currently r.centroids has been failing with:
```
FAIL: test_output (__main__.TestCentroids.test_output)
2025-08-25T17:20:36.8321804Z Test that centroids are expected output
2025-08-25T17:20:36.8322918Z ----------------------------------------------------------------------
2025-08-25T17:20:36.8323842Z Traceback (most recent call last):
2025-08-25T17:20:36.8324992Z   File "raster/r.centroids/testsuite/test_r_centroids.py", line 57, in test_output
2025-08-25T17:20:36.8325959Z     self.assertVectorEqualsAscii(
2025-08-25T17:20:36.8327064Z   File "etc/python/grass/gunittest/case.py", line 1208, in assertVectorEqualsAscii
2025-08-25T17:20:36.8328352Z     self.assertVectorAsciiEqualsVectorAscii(
2025-08-25T17:20:36.8329835Z   File "etc/python/grass/gunittest/case.py", line 1300, in assertVectorAsciiEqualsVectorAscii
2025-08-25T17:20:36.8330905Z     self.fail(self._formatMessage(msg, stdmsg))
2025-08-25T17:20:36.8331954Z AssertionError: There is a difference between vectors when compared as ASCII files.
2025-08-25T17:20:36.8332810Z --- reference
2025-08-25T17:20:36.8333156Z +++ actual
2025-08-25T17:20:36.8333503Z @@ -1,45 +1,45 @@
2025-08-25T17:20:36.8333834Z  P  1 1
2025-08-25T17:20:36.8334213Z - 642375       226865      
2025-08-25T17:20:36.8334625Z - 1     2         
2025-08-25T17:20:36.8335013Z + 642375       226865
2025-08-25T17:20:36.8335373Z + 1     2
2025-08-25T17:20:36.8335666Z  P  1 1
2025-08-25T17:20:36.8336042Z - 643425       223335      
2025-08-25T17:20:36.8336532Z - 1     4         
2025-08-25T17:20:36.8337137Z + 643425       223335
2025-08-25T17:20:36.8337487Z + 1     4
2025-08-25T17:20:36.8337991Z  P  1 1
2025-08-25T17:20:36.8338338Z - 642175       222595      
2025-08-25T17:20:36.8338737Z - 1     6         
2025-08-25T17:20:36.8339105Z + 642175       222595
2025-08-25T17:20:36.8339455Z + 1     6
```
v.out.ascii for some reason adds extra spaces after the coordinates, so this strips them in the comparison functions. 