### PR TITLE
doc: Use CRS instead of SRS

### DIFF
--- a/raster/r.external/proj.c
+++ b/raster/r.external/proj.c
@@ -48,7 +48,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
             GPJ_osr_to_grass(cellhd, &proj_info, &proj_units, hSRS, 0);
 
         if (!hSRS || (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS))) {
-            G_important_message(_("Input contains an invalid SRS. "
+            G_important_message(_("Input contains an invalid CRS. "
                                   "WKT definition:\n%s"),
                                 wkt);
 
@@ -90,7 +90,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
             GPJ_osr_to_grass(cellhd, &proj_info, &proj_units, hSRS, 0);
 
         if (!hSRS || (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS))) {
-            G_important_message(_("Input contains an invalid SRS. "
+            G_important_message(_("Input contains an invalid CRS. "
                                   "WKT definition:\n%s"),
                                 wkt);
 

--- a/raster/r.in.gdal/proj.c
+++ b/raster/r.in.gdal/proj.c
@@ -48,7 +48,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
             GPJ_osr_to_grass(cellhd, &proj_info, &proj_units, hSRS, 0);
 
         if (!hSRS || (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS))) {
-            G_important_message(_("Input contains an invalid SRS. "
+            G_important_message(_("Input contains an invalid CRS. "
                                   "WKT definition:\n%s"),
                                 wkt);
 
@@ -90,7 +90,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
             GPJ_osr_to_grass(cellhd, &proj_info, &proj_units, hSRS, 0);
 
         if (!hSRS || (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS))) {
-            G_important_message(_("Input contains an invalid SRS. "
+            G_important_message(_("Input contains an invalid CRS. "
                                   "WKT definition:\n%s"),
                                 wkt);
 

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -135,8 +135,9 @@ class WMSBase:
             if self.source_epsg != self.target_epsg:
                 gs.warning(
                     _(
-                        "SRS differences: WMS source EPSG %s != location EPSG %s (use "
-                        "srs=%s to adjust)"
+                        "CRS (SRS) differences:"
+                        " WMS source EPSG %s != location EPSG %s (use"
+                        " srs=%s to adjust)"
                     )
                     % (self.source_epsg, self.target_epsg, self.target_epsg)
                 )

--- a/vector/v.external/proj.c
+++ b/vector/v.external/proj.c
@@ -75,7 +75,7 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
 
     if (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS)) {
         G_important_message(
-            _("Projection for layer <%s> does not contain a valid SRS"),
+            _("Projection for layer <%s> does not contain a valid CRS"),
             OGR_L_GetName(Ogr_layer));
 
         if (verbose) {

--- a/vector/v.in.ogr/proj.c
+++ b/vector/v.in.ogr/proj.c
@@ -76,7 +76,7 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
 
     if (!OSRIsProjected(hSRS) && !OSRIsGeographic(hSRS)) {
         G_important_message(
-            _("Projection for layer <%s> does not contain a valid SRS"),
+            _("Projection for layer <%s> does not contain a valid CRS"),
             OGR_L_GetName(Ogr_layer));
 
         if (verbose) {


### PR DESCRIPTION
We use both CRS and SRS in the documentation. There is more CRS than SRS, so this replaces the few occurences of SRS with CRS. In case of WMS, also mention SRS because the SRS/srs parameter is explicitly mentioned. In general, we can't avoid SRS because it is used a lot in the code, in GDAL, and at this point in tool parameters as well. This does not touch the cases where 'projection' is used to refer to CRS.
