### PR TITLE
gui: fix editing categories in vdigit

### DIFF
--- a/gui/wxpython/vdigit/dialogs.py
+++ b/gui/wxpython/vdigit/dialogs.py
@@ -401,7 +401,7 @@ class VDigitCategoryDialog(wx.Dialog, listmix.ColumnSorterMixin):
 
     def OnApply(self, event):
         """Apply button pressed"""
-        for fid in self.cats.keys():
+        for fid in list(self.cats.keys()):
             newfid = self.ApplyChanges(fid)
             if fid == self.fid and newfid > 0:
                 self.fid = newfid


### PR DESCRIPTION
Fixing the following issue when editing categories in GUI digitizer:
```
Traceback (most recent call last):
  File "/home/akratoc/dev/grass/grass_main/dist.x86_64-pc-
linux-gnu/gui/wxpython/vdigit/dialogs.py", line 461, in OnOK

self.OnApply(event)
  File "/home/akratoc/dev/grass/grass_main/dist.x86_64-pc-
linux-gnu/gui/wxpython/vdigit/dialogs.py", line 404, in
OnApply

for fid in self.cats.keys():
RuntimeError
:
dictionary keys changed during iteration
```