### PR TITLE
v.what: Expand doc to describe outputs, JSON, flags

### DIFF
--- a/vector/v.what/main.c
+++ b/vector/v.what/main.c
@@ -88,15 +88,17 @@ int main(int argc, char **argv)
     opt.cols->label = _("Name of attribute column(s)");
     opt.cols->description = _("Default: all columns");
 
-    flag.topo = G_define_flag();
-    flag.topo->key = 'd';
-    flag.topo->description = _("Print topological information (debugging)");
-    flag.topo->guisection = _("Print");
-
     flag.print = G_define_flag();
     flag.print->key = 'a';
     flag.print->description = _("Print attribute information");
     flag.print->guisection = _("Print");
+
+    flag.topo = G_define_flag();
+    flag.topo->key = 'd';
+    flag.topo->label = _("Print topological information (debugging)");
+    flag.topo->description =
+        _("Prints internal information for topology debugging");
+    flag.topo->guisection = _("Print");
 
     flag.shell = G_define_flag();
     flag.shell->key = 'g';
@@ -110,11 +112,14 @@ int main(int argc, char **argv)
 
     flag.multiple = G_define_flag();
     flag.multiple->key = 'm';
+    flag.multiple->label =
+        _("Print multiple features for each map if they meet the criteria");
     flag.multiple->description =
-        _("Print multiple features if overlapping features are found");
+        _("For JSON, this places features under a \"features\" key");
     flag.multiple->guisection = _("Print");
 
     G_option_exclusive(flag.shell, flag.json, NULL);
+    G_option_requires(opt.cols, flag.print, NULL);
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);

--- a/vector/v.what/v.what.md
+++ b/vector/v.what/v.what.md
@@ -1,10 +1,62 @@
 ## DESCRIPTION
 
-*v.what* outputs the category number value(s) associated with
-user-specified location(s) in user-specified vector map layer(s). This
-module was derived from the *d.what.vect* module by removing all
-interactive code and modification of the output for easy parsing. Using
-the *-g* flag generates script-style output which is easily parsable.
+*v.what* outputs the features associated with
+user-specified location(s) in user-specified vector map(s).
+The tool operates on features which are vector geometry objects,
+such as point or area. The result is a list of these features
+along with their associated categories for the layer specified by *layer*.
+If there are no categories for the specified layer, the feature
+is not included in the result. With `layer=-1` (all layers), all features
+are included in the result regardless of their categories.
+
+### Output content
+
+By default, the closest feature is returned for each coordinate and each
+vector map if the feature fulfills the geometry query and layer selection
+criteria. With the *-m* flag, all matching features are returned, not just
+the closest one.
+
+If an attribute database connection is defined for a given layer
+and the *-a* flag is specified, attributes from the associated attribute table
+will be returned for each category associated with the feature.
+
+The tool operates on features defined as vector geometry objects as opposed
+to features defined by categories. Consequently, the output is organized
+by geometry IDs, to which possible categories and attributes are attached.
+If multiple geometries have the same category, the same set of attributes
+is repeated for each geometry.
+
+The output also includes the coordinates used in the query,
+the vector map name, and the mapset. For vector lines,
+the length is returned. The *-d* flag returns internal topological
+information.
+
+### JSON output
+
+With `format="json"`, a list of matching features is returned.
+Each feature includes the geometry ID (`id`), geometry type (`type`),
+vector map name (`map` and `mapset`), and the relevant part of the spatial
+query (`coordinates`).
+If the feature has associated categories for the given *layer*,
+they are included under `data` in a list of items with `layer` and `category` values.
+With *-a*, `data` will also include `attributes` for each `category`.
+
+A feature is not included in the result if there are no categories
+for the specified layer. For `layer=-1`, all features
+are included in the result and each feature's `data` will contain all
+associated categories in all layers.
+
+With the *-m* flag, each list item contains coordinates, a vector map name,
+and a list of matching features under the `features` key.
+In other words, rather than being organized by feature, the list now contains
+lists of features nested under each combination of coordinate pair and vector map.
+
+## NOTES
+
+The *-g* and *-j* flags are deprecated and will be removed in a future release.
+Please, use `format="json"` instead.
+
+The behavior of the *-d* flag for internal topology information is not guaranteed.
 
 ## EXAMPLE
 
@@ -28,7 +80,7 @@ v.what hospitals coordinates=542690.4,204802.7 distance=2000000
 *[d.what.rast](d.what.rast.md), [d.what.vect](d.what.vect.md),
 [v.rast.stats](v.rast.stats.md), [v.vect.stats](v.vect.stats.md),
 [v.what.rast](v.what.rast.md), [v.what.rast3](v.what.rast3.md),
-[v.what.vect](v.what.vect.md)*
+[v.what.vect](v.what.vect.md), [r.what](r.what.md)*
 
 ## AUTHOR
 


### PR DESCRIPTION
This expands documentation in light of the new JSON addition (not merged at the time of writing), but also generally describing how the tool behaves. Additionally, this improves how -a and -m flags are described and presented. columns now requires -a because it doesn't do anything otherwise. r.what is linked from doc.

## New Description and Notes sections

<img width="845" height="1477" alt="image" src="https://github.com/user-attachments/assets/269c7d25-1aca-4eda-9e2f-e9163b617f9a" />

## New flags section

<img width="847" height="554" alt="image" src="https://github.com/user-attachments/assets/2528426e-dd55-4b1e-9bde-9de592ec4754" />

## New error message

```bash
grass --tmp-mapset ... --exec v.what map=bridges coordinates=915044,317756 columns=YEAR_BUILT
```

```
ERROR: Option <columns> requires <-a>
```
