### PR TITLE
docs: put tool description in quotes in yaml header

### DIFF
--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -32,14 +32,14 @@ void G__usage_markdown(void)
     /* print metadata used by man/build*.py */
     fprintf(stdout, "---\n");
     fprintf(stdout, "name: %s\n", st->pgm_name);
-    fprintf(stdout, "description: ");
+    fprintf(stdout, "description: \"");
     if (st->module_info.label)
         fprintf(stdout, "%s", st->module_info.label);
     if (st->module_info.label && st->module_info.description)
         fprintf(stdout, " ");
     if (st->module_info.description)
         fprintf(stdout, "%s", st->module_info.description);
-    fprintf(stdout, "\n");
+    fprintf(stdout, "\"\n");
     fprintf(stdout, "keywords: [ ");
     G__print_keywords(stdout, NULL, FALSE);
     fprintf(stdout, " ]");


### PR DESCRIPTION
Currently, there are cases of tools with ":" in the tool description. That causes problems in the generated yaml header resulting in:
<img width="1021" height="674" alt="image" src="https://github.com/user-attachments/assets/23121a82-8bf9-4b82-bf4e-b3431f81c632" />

This add quotes to fix that. I tested locally and seems to work.