### PR TITLE
lib/vector/neta: Fix Resource Leak Issue in timetables.c

### DIFF
--- a/lib/vector/neta/timetables.c
+++ b/lib/vector/neta/timetables.c
@@ -88,6 +88,7 @@ int NetA_init_distinct(dbDriver *driver, dbString *sql, int **lengths,
         last = cur;
         count++;
     }
+    db_close_cursor(&cursor);
     return result;
 }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1588974)
Used db_close_cursor() to fix this issue.