### PR TITLE
grass.exceptions: make CalledModuleError pickleable for multiprocessing

### DIFF
--- a/python/grass/exceptions/__init__.py
+++ b/python/grass/exceptions/__init__.py
@@ -92,6 +92,15 @@ class CalledModuleError(subprocess.CalledProcessError):
             returncode=returncode,
             see_errors=err,
         )
+        self.module = module
+        self.code = code
+        self.errors = errors
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.module, self.code, self.returncode, self.errors),
+        )
 
     def __str__(self):
         return self.msg


### PR DESCRIPTION
Add a __reduce__ method to CalledModuleError so that instances can be pickled and unpickled correctly. Without this, multiprocessing fails when trying to reconstruct the exception, raising:

```
 TypeError: CalledModuleError.__init__() missing 3 required positional arguments
```