### PR TITLE
grass.tools: Return None with no stdout

### DIFF
--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -559,4 +559,18 @@ void G__md_print_python_long_version(FILE *file, const char *indent,
                            _("Very quiet module output"), indent);
     fprintf(file, MD_NEWLINE);
     fprintf(file, "\n");
+
+    if (!tools_api)
+        return;
+
+    fprintf(file, "\n%sReturns:\n\n", indent);
+    fprintf(file, "%s**result** : ", indent);
+    fprintf(file, "grass.tools.support.ToolResult");
+    fprintf(file, " | None");
+    fprintf(file, MD_NEWLINE);
+    fprintf(file, "\n%s", indent);
+    fprintf(file, "If the tool produces text as standard output, a "
+                  "*ToolResult* object will be returned. "
+                  "Otherwise, `None` will be returned.");
+    fprintf(file, "\n");
 }

--- a/python/grass/tools/session_tools.py
+++ b/python/grass/tools/session_tools.py
@@ -39,9 +39,7 @@ class Tools:
     >>> from grass.tools import Tools
     >>> tools = Tools(session=session)
     >>> tools.g_region(rows=100, cols=100)  # doctest: +ELLIPSIS
-    ToolResult(...)
     >>> tools.r_random_surface(output="surface", seed=42)
-    ToolResult(...)
 
     For tools outputting JSON, the results can be accessed directly:
 
@@ -59,13 +57,11 @@ class Tools:
     >>> tools.v_in_ascii(
     ...     input=StringIO("13.45,29.96,200"), output="point", separator=","
     ... )
-    ToolResult(...)
 
     The *Tools* object can be used as a context manager:
 
     >>> with Tools(session=session) as tools:
     ...     tools.g_region(rows=100, cols=100)
-    ToolResult(...)
 
     A tool can be accessed via a function with the same name as the tool.
     Alternatively, it can be called through one of the *run* or *call* functions.
@@ -89,6 +85,7 @@ class Tools:
         errors=None,
         capture_output=True,
         capture_stderr=None,
+        always_result=False,
     ):
         """
         If session is provided and has an env attribute, it is used to execute tools.
@@ -97,15 +94,15 @@ class Tools:
         However, session and env interaction may change in the future.
 
         If overwrite is provided, a an overwrite is set for all the tools.
-        When overwrite is set to False, individual tool calls can set overwrite
-        to True. If overwrite is set in the session or env, it is used.
-        Note that once overwrite is set to True globally, an individual tool call
-        cannot set it back to False.
+        When overwrite is set to `False`, individual tool calls can set overwrite
+        to `True`. If overwrite is set in the session or env, it is used.
+        Note that once overwrite is set to `True` globally, an individual tool call
+        cannot set it back to `False`.
 
-        If verbose, quiet, superquiet is set to True, the corresponding verbosity level
-        is set for all the tools. If one of them is set to False and the environment
+        If verbose, quiet, superquiet is set to `True`, the corresponding verbosity level
+        is set for all the tools. If one of them is set to `False` and the environment
         has the corresponding variable set, it is unset.
-        The values cannot be combined. If multiple ones are set to True, the most
+        The values cannot be combined. If multiple ones are set to `True`, the most
         verbose one wins.
 
         In case a tool run fails, indicating that by non-zero return code,
@@ -117,12 +114,17 @@ class Tools:
         Text outputs from the tool are captured by default, both standard output
         (stdout) and standard error output (stderr). Both will be part of the result
         object returned by each tool run. Additionally, the standard error output will
-        be included in the exception message. When *capture_output* is set to False,
+        be included in the exception message. When *capture_output* is set to `False`,
         outputs are not captured in Python as values and go where the Python process
         outputs go (this is usually clear in command line, but less clear in a Jupyter
-        notebook). When *capture_stderr* is set to True, the standard error output
+        notebook). When *capture_stderr* is set to `True`, the standard error output
         is captured and included in the exception message even if *capture_outputs*
-        is set to False.
+        is set to `False`.
+
+        A tool call will return a result object if the tool produces standard output
+        (stdout) and `None` otherwise. If *always_result* is set to `True`, a call
+        will return a result object even without standard output (stdout and text
+        attributes of the result object will evaluate to `False`).
 
         If *env* or other *Popen* arguments are provided to one of the tool running
         functions, the constructor parameters except *errors* are ignored.
@@ -145,6 +147,7 @@ class Tools:
         else:
             self._capture_stderr = capture_stderr
         self._name_resolver = None
+        self._always_result = always_result
 
     def _modified_env_if_needed(self):
         """Get the environment for subprocesses
@@ -313,6 +316,8 @@ class Tools:
                 stderr=stderr,
                 handler=self._errors,
             )
+        if not self._always_result and not result.stdout:
+            return None
         return result
 
     def __getattr__(self, name):

--- a/python/grass/tools/support.py
+++ b/python/grass/tools/support.py
@@ -151,7 +151,7 @@ class ToolResult:
 
     @property
     def text(self) -> str | None:
-        """Text output as decoded string"""
+        """Text output as decoded string without leading and trailing whitespace"""
         if self._text is not None:
             return self._text
         if self._stdout is None:
@@ -209,7 +209,7 @@ class ToolResult:
         Empty or no output results in an empty list.
         """
         if not self.text:
-            # This provides consitent behavior with explicit separator including
+            # This provides consistent behavior with explicit separator including
             # a single space and no separator which triggers general whitespace
             # splitting which results in an empty list for an empty string.
             return []
@@ -219,10 +219,12 @@ class ToolResult:
 
     @property
     def stdout(self) -> str | bytes | None:
+        """Standard output (text output) without modifications"""
         return self._stdout
 
     @property
     def stderr(self) -> str | bytes | None:
+        """Standard error output (messages and errors) without modifications"""
         return self._stderr
 
     def _json_or_error(self) -> dict:

--- a/python/grass/tools/tests/grass_tools_session_tools_test.py
+++ b/python/grass/tools/tests/grass_tools_session_tools_test.py
@@ -11,6 +11,70 @@ from grass.experimental.mapset import TemporaryMapsetSession
 from grass.tools import Tools
 
 
+def test_no_stdout_returns_none(xy_dataset_session):
+    """Check that no stdout results in returning None"""
+    tools = Tools(session=xy_dataset_session)
+    assert tools.g_region(res=10) is None
+    assert tools.run("g.region", res=10) is None
+    # Same should apply also to the function accepting a command.
+    assert tools.run_cmd(["g.region", "res=10"]) is None
+    # And to the low-level functions.
+    assert tools.call("g.region", res=10) is None
+    assert tools.call_cmd(["g.region", "res=10"]) is None
+
+
+def test_no_stdout_is_falsy_in_result(xy_dataset_session):
+    """Check that no stdout needs to be at least falsy when stored in the result"""
+    tools = Tools(session=xy_dataset_session, always_result=True)
+    result = tools.g_region(res=10)
+    assert not result.stdout
+    assert not result.text
+    result = tools.run("g.region", res=10)
+    assert not result.stdout
+    assert not result.text
+    result = tools.run_cmd(["g.region", "res=10"])
+    assert not result.stdout
+    assert not result.text
+    result = tools.call("g.region", res=10)
+    assert not result.stdout
+    assert not result.text
+    result = tools.call_cmd(["g.region", "res=10"])
+    assert not result.stdout
+    assert not result.text
+
+
+def test_no_stdout_is_empty_string_in_result(xy_dataset_session):
+    """Check that no stdout results in an empty string (not None).
+
+    Intentionally, this is not properly specified in the doc.
+    Improve this before version 8.6.
+    """
+    tools = Tools(session=xy_dataset_session, always_result=True)
+    result = tools.g_region(res=10)
+    assert result.stdout == ""
+    assert result.text == ""
+    result = tools.run("g.region", res=10)
+    assert result.stdout == ""
+    assert result.text == ""
+    result = tools.run_cmd(["g.region", "res=10"])
+    assert result.stdout == ""
+    assert result.text == ""
+    result = tools.call("g.region", res=10)
+    assert result.stdout == ""
+    assert result.text == ""
+    result = tools.call_cmd(["g.region", "res=10"])
+    assert result.stdout == ""
+    assert result.text == ""
+
+
+def test_stdout_vs_text(xy_dataset_session):
+    """Check that stdout is raw while text is stripped"""
+    tools = Tools(session=xy_dataset_session, always_result=True)
+    result = tools.g_mapset(flags="p")
+    assert result.stdout == "PERMANENT\n"
+    assert result.text == "PERMANENT"
+
+
 def test_key_value_parser_number(xy_dataset_session):
     """Check that numbers are parsed as numbers from key-value (shell) output"""
     tools = Tools(session=xy_dataset_session)
@@ -72,13 +136,13 @@ def test_json_as_list(xy_dataset_session):
 
 def test_help_call_no_parameters(xy_dataset_session):
     """Check that help text is generated without any one parameters provided"""
-    tools = Tools(session=xy_dataset_session)
+    tools = Tools(session=xy_dataset_session, always_result=True)
     assert "r.slope.aspect" in tools.call_cmd(["r.slope.aspect", "--help"]).stderr
 
 
 def test_help_call_with_parameters(xy_dataset_session):
     """Check that help text is generated with parameters provided"""
-    tools = Tools(session=xy_dataset_session)
+    tools = Tools(session=xy_dataset_session, always_result=True)
     assert (
         "r.slope.aspect"
         in tools.call_cmd(
@@ -177,7 +241,7 @@ def test_stdout_comma_items(xy_dataset_session):
 
 def test_stdout_without_capturing(xy_dataset_session):
     """Check that stdout and stderr are not present when not capturing it"""
-    tools = Tools(session=xy_dataset_session, capture_output=False)
+    tools = Tools(session=xy_dataset_session, capture_output=False, always_result=True)
     result = tools.g_mapset(flags="p")
     assert not result.stdout
     assert result.stdout is None
@@ -187,7 +251,7 @@ def test_stdout_without_capturing(xy_dataset_session):
 
 def test_attributes_without_stdout(xy_dataset_session):
     """Check that attributes behave as expected when not capturing stdout"""
-    tools = Tools(session=xy_dataset_session, capture_output=False)
+    tools = Tools(session=xy_dataset_session, capture_output=False, always_result=True)
     result = tools.run_cmd(["g.region", "format=json", "-p"])
     assert not result.text
     assert result.text is None
@@ -206,7 +270,12 @@ def test_attributes_without_stdout(xy_dataset_session):
 
 def test_capturing_stdout_and_stderr(xy_dataset_session):
     """Check that both stdout and stdin are present when capturing them"""
-    tools = Tools(session=xy_dataset_session, capture_output=True, errors="ignore")
+    tools = Tools(
+        session=xy_dataset_session,
+        capture_output=True,
+        errors="ignore",
+        always_result=True,
+    )
     result = tools.g_mapset(flags="l")
     assert result.stdout
     assert result.stdout is not None
@@ -224,6 +293,7 @@ def test_capturing_stdout_without_stderr(xy_dataset_session):
         capture_output=True,
         capture_stderr=False,
         errors="ignore",
+        always_result=True,
     )
     result = tools.g_mapset(flags="l")
     assert result.stdout
@@ -241,6 +311,7 @@ def test_capturing_stderr_without_stdout(xy_dataset_session):
         capture_output=False,
         capture_stderr=True,
         errors="ignore",
+        always_result=True,
     )
     result = tools.g_mapset(flags="p")
     assert not result.stdout
@@ -309,7 +380,7 @@ def test_error_handler_ignore(xy_dataset_session):
 
 def test_error_handler_check_returncode(xy_dataset_session):
     """Check that ignore error handler allows to check return code"""
-    tools = Tools(session=xy_dataset_session, errors="ignore")
+    tools = Tools(session=xy_dataset_session, errors="ignore", always_result=True)
     assert tools.g_mapset(mapset="does_not_exist").returncode == 1
     assert tools.g_region(raster="does_not_exist").returncode == 1
     # Works after errors as usual with return code.
@@ -332,7 +403,7 @@ def test_error_handler_exit(xy_dataset_session):
 
 def test_verbose(xy_dataset_session):
     """Check that verbose message is generated"""
-    tools = Tools(session=xy_dataset_session, verbose=True)
+    tools = Tools(session=xy_dataset_session, verbose=True, always_result=True)
     tools.g_mapset(mapset="test1", flags="c")
     tools.g_mapset(mapset="test2", flags="c")
     result = tools.g_mapsets(mapset="test1")
@@ -343,7 +414,7 @@ def test_verbose(xy_dataset_session):
 
 def test_quiet(xy_dataset_session):
     """Check that quiet configuration works"""
-    tools = Tools(session=xy_dataset_session, quiet=True)
+    tools = Tools(session=xy_dataset_session, quiet=True, always_result=True)
     result = tools.g_mapsets(mapset="PERMANENT")
     # Expecting an important message about no modification.
     assert result.stderr
@@ -351,21 +422,21 @@ def test_quiet(xy_dataset_session):
 
 def test_superquiet(xy_dataset_session):
     """Check that superquiet configuration does not generate any messages"""
-    tools = Tools(session=xy_dataset_session, superquiet=True)
+    tools = Tools(session=xy_dataset_session, superquiet=True, always_result=True)
     result = tools.g_mapsets(mapset="PERMANENT")
     assert not result.stderr
 
 
 def test_superquiet_verbose(xy_dataset_session):
     """Check that text function-level verbose overrides object-level superquiet"""
-    tools = Tools(session=xy_dataset_session, superquiet=True)
+    tools = Tools(session=xy_dataset_session, superquiet=True, always_result=True)
     result = tools.g_mapsets(mapset="PERMANENT", verbose=True)
     assert result.stderr
 
 
 def test_verbose_superquiet(xy_dataset_session):
     """Check that text function-level superquiet overrides object-level verbose"""
-    tools = Tools(session=xy_dataset_session, verbose=True)
+    tools = Tools(session=xy_dataset_session, verbose=True, always_result=True)
     result = tools.g_mapsets(mapset="PERMANENT", superquiet=True)
     assert not result.stderr
 
@@ -373,7 +444,7 @@ def test_verbose_superquiet(xy_dataset_session):
 def test_superquiet_false(xy_dataset_session):
     """Check that text object-level superquiet False overrides global superquiet"""
     xy_dataset_session.env["GRASS_VERBOSE"] = "0"
-    tools = Tools(session=xy_dataset_session, superquiet=False)
+    tools = Tools(session=xy_dataset_session, superquiet=False, always_result=True)
     result = tools.g_mapsets(mapset="PERMANENT")
     assert result.stderr
     assert "GRASS_VERBOSE" in xy_dataset_session.env
@@ -386,7 +457,7 @@ def test_superquiet_false(xy_dataset_session):
 def test_verbose_false(xy_dataset_session):
     """Check that text object-level verbose False overrides global verbose"""
     xy_dataset_session.env["GRASS_VERBOSE"] = "3"
-    tools = Tools(session=xy_dataset_session, verbose=False)
+    tools = Tools(session=xy_dataset_session, verbose=False, always_result=True)
     tools.g_mapset(mapset="test1", flags="c")
     tools.g_mapset(mapset="test2", flags="c")
     result = tools.g_mapsets(mapset="test1")
@@ -502,6 +573,33 @@ def test_parent_overwrite_after_call(xy_dataset_session):
     tools.r_random_surface(output="surface", seed=42)
     xy_dataset_session.env["GRASS_OVERWRITE"] = "1"
     tools.r_random_surface(output="surface", seed=42)
+
+
+@pytest.mark.parametrize("always_result", [None, False])
+def test_return_object_or_none(xy_dataset_session, always_result):
+    tools = Tools(session=xy_dataset_session, always_result=False)
+    # Tool call without standard output
+    result = tools.g_region(res=10)
+    assert result is None
+    # Tool call with standard output
+    result = tools.g_region(flags="p")
+    assert result is not None
+    assert result.stdout
+    assert result.text
+
+
+def test_always_result_true(xy_dataset_session):
+    tools = Tools(session=xy_dataset_session, always_result=True)
+    # Tool call without standard output
+    result = tools.g_region(res=10)
+    assert result is not None
+    assert not result.stdout
+    assert not result.text
+    # Tool call with standard output
+    result = tools.g_region(flags="p")
+    assert result is not None
+    assert result.stdout
+    assert result.text
 
 
 def test_migration_from_run_command_family(xy_dataset_session):
@@ -646,7 +744,9 @@ def test_migration_from_run_command_family(xy_dataset_session):
         == 1
     )
     # replacement:
-    tools_with_returncode = Tools(errors="ignore", env=xy_dataset_session.env)
+    tools_with_returncode = Tools(
+        errors="ignore", always_result=True, env=xy_dataset_session.env
+    )
     assert tools_with_returncode.run("r.mask.status", flags="t").returncode == 1
     assert tools_with_returncode.r_mask_status(flags="t").returncode == 1
 


### PR DESCRIPTION
When there is no standard output (stdout), return None, instead of returning the ToolResult object.
This creates expected result in interactive console and similar cases (notebooks and doctest-tested documentation),
i.e., no result for tools which produce no text output (all tools which create spatial data such as r.slope.aspect or r.grow).

Closes #6272.

This also adds description of the returned value to the generated documentation of each tool. We don't have a 'returns' section which would apply to all interfaces, so I went with imperfect soltion of adding 'Returns:' block at the end of Parameters section. This mimics how the block looks like in other Python doc, copying the 'Parameters:' block, but our block does completely fit with our Parameters section and breaks the hiearchy as it is nested under Parameters (but it is not a section heading, so not visible as heading or in toc). It also leave out the indent for the description because we can do this indent only for the first line, so a multiline paragraph would not create a consistent look.

It also fixes couple spelling and syntax issues in the doc and adds missing tests related to no stdout.

While this makes even more sense with #5878 (returning NumPy arrays), it would make sense even without it.
