### PR TITLE
Windows: Add Jupyter dependencies to GRASS daily builds

### DIFF
--- a/mswindows/osgeo4w/setup.hint.tmpl
+++ b/mswindows/osgeo4w/setup.hint.tmpl
@@ -1,7 +1,7 @@
 sdesc: "GRASS - daily builds of development version"
 ldesc: "Geographic Resources Analysis Support System (GRASS) - daily builds of the main branch from Git"
 category: Desktop
-requires: liblas gdal303-runtime proj81-runtime avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2-binary zstd python3-pywin32
+requires: liblas gdal303-runtime proj81-runtime avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2-binary zstd python3-pywin32 python3-jupyterlab python3-jupyter-server python3-ipykernel python3-ipython python3-ipywidgets
 maintainer: MartinLanda
 curr: @GRASS_VERSION_NUMBER@-1
 prev: @GRASS_VERSION_NUMBER@-1

--- a/mswindows/osgeo4w/setup.hint.tmpl
+++ b/mswindows/osgeo4w/setup.hint.tmpl
@@ -1,7 +1,7 @@
 sdesc: "GRASS - daily builds of development version"
 ldesc: "Geographic Resources Analysis Support System (GRASS) - daily builds of the main branch from Git"
 category: Desktop
-requires: liblas gdal303-runtime proj81-runtime avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2-binary zstd python3-pywin32 python3-jupyterlab python3-jupyter-server python3-ipykernel python3-ipython python3-ipywidgets
+requires: liblas gdal303-runtime proj81-runtime avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2-binary zstd python3-pywin32 python3-jupyter
 maintainer: MartinLanda
 curr: @GRASS_VERSION_NUMBER@-1
 prev: @GRASS_VERSION_NUMBER@-1


### PR DESCRIPTION
This PR updates the GRASS setup.hint.tmpl template to include dependencies for running Jupyter notebooks inside GRASS.
It adds the following packages to requires: section:

- python3-jupyterlab – provides the JupyterLab interface.

- python3-jupyter-server – the backend server for Jupyter notebooks.

- python3-ipykernel – allows Python code execution in notebooks.

- python3-ipython – interactive Python shell for notebook execution.

- python3-ipywidgets – supports interactive widgets in notebooks.

**Next steps:**

Once tested in daily builds, these dependencies will also need to be added to the official OSGeo4W build: https://github.com/jef-n/OSGeo4W/blob/master/src/grass/osgeo4w/package.sh