### PR TITLE
CI: Do not persist credentials on checkout when not needed

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 31
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout GRASS
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Install CMake
         run: |
           cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,6 +18,8 @@ jobs:
     if: github.repository == 'OSGeo/grass'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
       - name: Get the latest tag and release branches
         id: tag-branch
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           path: grass
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get dependencies
         run: |
@@ -66,6 +67,7 @@ jobs:
           ref: grass${{ env.MAJOR }}
           path: grass-addons
           fetch-depth: 0
+          persist-credentials: false
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Get dependencies
         run: |
           sudo apt-get update -y

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,6 +48,8 @@ jobs:
           # Rehash to forget about the deleted files
           hash -r
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Get current date cache key segment
         id: date
         # Year and week of year so cache key changes weekly

--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -69,6 +69,8 @@ jobs:
           # Rehash to forget about the deleted files
           hash -r
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Environment info
         shell: bash -el {0}
         run: |

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -35,6 +35,8 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         id: msys2
         with:

--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -33,6 +33,8 @@ jobs:
         id: vars
         run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: "Check that autoconf scripts are up-to-date:"
         run: |
           rm -f config.guess config.sub
@@ -74,6 +76,8 @@ jobs:
         id: vars
         run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -54,6 +54,8 @@ jobs:
           echo Ruff: ${{ env.RUFF_VERSION }}
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -32,6 +32,7 @@ jobs:
           # super-linter needs the full git history to get the
           # list of files that changed across commits
           fetch-depth: 0
+          persist-credentials: false
       - name: Lint code base
         uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
         env:

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install nix
         uses: DeterminateSystems/determinate-nix-action@fd3eb131b9b46cc1dd978a7c0ba3fce79dd7d3eb # v3.9.1

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout base repository (doesn't include the PR changes)
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Call PR title validation function
         run: python utils/generate_release_notes.py check "${PR_TITLE}" "" ""
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -63,6 +63,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Invert inclusion list to an exclusion list
         id: get-exclude
         run: |


### PR DESCRIPTION
Analogous to https://github.com/OSGeo/grass-addons/pull/1473

Fixes zizmor warnings that are now included by default in super-linter (but not enabled here yet).

Persisting credentials is not needed, as we don't need to push commits made inside any of the workflows.
The only places where we actually do a commit and push, we do it though an action which seems to use the GITHUB_TOKEN instead.