### PR TITLE
CMake: Support fixed ctypesgen on Windows

### DIFF
--- a/cmake/ctypesgen.cmake
+++ b/cmake/ctypesgen.cmake
@@ -31,7 +31,7 @@ if(NOT MSVC)
 endif()
 set(ENV{LC_ALL} C)
 
-set(CTYPESFLAGS "${COMPILER} -E ${C_FLAGS}")
+set(CTYPESFLAGS "\"${COMPILER}\" -E ${C_FLAGS}")
 
 set(LIBRARIES)
 foreach(LIB ${LIBS})


### PR DESCRIPTION
This PR works with https://github.com/OSGeo/grass/pull/6276 to support MSVC. It double-quotes PATHs for `cl.exe`, includes, and libs. It might also fix similar but rare cases on Linux and macOS.