### PR TITLE
grass.jupyter: fix setting region interactively in latlon projects

### DIFF
--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -554,7 +554,7 @@ class InteractiveRegionController:
             self.bottom_output_widget.clear_output()
             print(
                 _(
-                    "Region changed to: n={n}, s={s}, e={e}, w={w} "
+                    "Region changed to: n={north}, s={south}, e={east}, w={west} "
                     "nsres={nsres} ewres={ewres}"
                 ).format(**region)
             )

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -475,13 +475,14 @@ def update_region(region):
     current = gs.region()
     return gs.parse_command(
         "g.region",
-        flags="ga",
+        flags="p" if gs.locn_is_latlong() else "pa",
         n=region["north"],
         s=region["south"],
         e=region["east"],
         w=region["west"],
         nsres=current["nsres"],
         ewres=current["ewres"],
+        format="json",
     )
 
 


### PR DESCRIPTION
This PR fixes interactive region setting in jupyter by avoiding using -a flag which doesn't work well with units degrees. Also updates g.region to use json instead of -g flag.