### PR TITLE
g.list: Print empty list for JSON

### DIFF
--- a/general/g.list/list.c
+++ b/general/g.list/list.c
@@ -80,7 +80,7 @@ void print_list(FILE *fp, struct elist *el, int count, const char *separator,
     JSON_Object *map_object = NULL;
     JSON_Value *map_value = NULL;
 
-    if (!count)
+    if (!count && format != JSON)
         return;
 
     if (format == JSON) {
@@ -91,7 +91,8 @@ void print_list(FILE *fp, struct elist *el, int count, const char *separator,
         root_array = G_json_array(root_value);
     }
 
-    qsort(el, count, sizeof(struct elist), compare_elist);
+    if (count > 1)
+        qsort(el, count, sizeof(struct elist), compare_elist);
 
     for (i = 0; i < count; i++) {
         int need_mapset = 0;

--- a/general/g.list/tests/g_list_test.py
+++ b/general/g.list/tests/g_list_test.py
@@ -1,6 +1,9 @@
-import grass.script as gs
-import pytest
 import sys
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
 
 
 def test_default_output(simple_dataset):
@@ -290,3 +293,15 @@ def test_json_output(simple_dataset):
         },
     ]
     assert actual == expected
+
+
+def test_no_json_output(simple_dataset):
+    """Test g.list returning an empty JSON list"""
+    tools = Tools(env=simple_dataset.env)
+    result = tools.g_list(
+        type="raster",
+        pattern="does_not_exist",
+        format="json",
+    )
+    assert not result
+    assert list(result) == []


### PR DESCRIPTION
If nothing is found, still print an empty JSON list with format=json (but still nothing with other formats). Additionally, sort only with list with two or more items. While calling qsort on zero items should work, there is no reason to call it on zero items or one item.
