### PR TITLE
v.out.ogr: fix fast method with no attributes

### DIFF
--- a/vector/v.out.ogr/export_areas_fast.c
+++ b/vector/v.out.ogr/export_areas_fast.c
@@ -104,25 +104,27 @@ int export_areas_single(struct Map_info *In, int field, int donocat,
         G_message(_("Exporting features with category..."));
 
     /* select attributes ordered by category value */
-    db_init_string(&dbstring);
-    snprintf(buf, sizeof(buf), "SELECT * FROM %s ORDER BY %s ASC", Fi->table,
-             Fi->key);
-    G_debug(2, "SQL: %s", buf);
-    db_set_string(&dbstring, buf);
-    if (db_open_select_cursor(driver, &dbstring, &cursor, DB_SEQUENTIAL) !=
-        DB_OK) {
-        G_fatal_error(_("Cannot select attributes sorted by %s"), Fi->key);
-    }
+    if (doatt) {
+        db_init_string(&dbstring);
+        snprintf(buf, sizeof(buf), "SELECT * FROM %s ORDER BY %s ASC",
+                 Fi->table, Fi->key);
+        G_debug(2, "SQL: %s", buf);
+        db_set_string(&dbstring, buf);
+        if (db_open_select_cursor(driver, &dbstring, &cursor, DB_SEQUENTIAL) !=
+            DB_OK) {
+            G_fatal_error(_("Cannot select attributes sorted by %s"), Fi->key);
+        }
 
-    if (db_fetch(&cursor, DB_NEXT, &more) != DB_OK)
-        G_fatal_error(_("Unable to fetch data from table"));
+        if (db_fetch(&cursor, DB_NEXT, &more) != DB_OK)
+            G_fatal_error(_("Unable to fetch data from table"));
 
-    /* get index of key column */
-    key_col_index = -1;
-    for (i = 0; i < ncol; i++) {
-        if (strcmp(Fi->key, colname[i]) == 0) {
-            key_col_index = i;
-            break;
+        /* get index of key column */
+        key_col_index = -1;
+        for (i = 0; i < ncol; i++) {
+            if (strcmp(Fi->key, colname[i]) == 0) {
+                key_col_index = i;
+                break;
+            }
         }
     }
 

--- a/vector/v.out.ogr/testsuite/test_v_out_ogr.py
+++ b/vector/v.out.ogr/testsuite/test_v_out_ogr.py
@@ -154,22 +154,7 @@ C  1 1
             output=f"{self.test_map}.json",
             format="GeoJSON",
         )
-
-        # Import back to verify
-        self.runModule(
-            "v.in.ogr",
-            input=f"{self.test_map}.json",
-            output=self.temp_import,
-        )
-
-        self.runModule("g.region", vector=self.temp_import)
-
-        self.assertVectorFitsUnivar(
-            map=self.temp_import,
-            reference=self.univar_string,
-            column=self.univar_col,
-            precision=1e-8,
-        )
+        self.assertFileExists(f"{self.test_map}.json")
 
     def test_geojson_format_no_attributes(self):
         """Tests output to GeoJSON format with no attributes"""
@@ -181,12 +166,7 @@ C  1 1
             format="GeoJSON",
         )
 
-        # Import back to verify
-        self.runModule(
-            "v.in.ogr",
-            input=f"{self.test_map}.json",
-            output=self.temp_import,
-        )
+        self.assertFileExists(f"{self.test_map}.json")
 
 
 if __name__ == "__main__":

--- a/vector/v.out.ogr/testsuite/test_v_out_ogr.py
+++ b/vector/v.out.ogr/testsuite/test_v_out_ogr.py
@@ -36,15 +36,52 @@ kurtosis=33.681
 skewness=4.86561
 """
 
+    area_map = "test_area_map"
+    areas_string = """\
+VERTI:
+B  6
+ 11.6         29.55
+ 12.01        27.01
+ 15.25        26.68
+ 16.32        29.42
+ 13.49        31.06
+ 11.6         29.55
+C  1 1
+ 13.85        28.69
+ 1     1
+B  10
+ 18.49        34.1
+ 21.73        28.85
+ 28.24        33.28
+ 26.6         37.17
+ 23.9         34.92
+ 22.75        36.92
+ 18.86        37.17
+ 14.1         36.19
+ 14.19        32.54
+ 18.49        34.1
+C  1 1
+ 21.11        34.03
+ 1     2
+"""
+
     @classmethod
     def setUpClass(cls):
         """Use temporary region settings"""
         cls.use_temp_region()
+        cls.runModule(
+            "v.in.ascii",
+            input="-",
+            output=cls.area_map,
+            format="standard",
+            stdin=cls.areas_string,
+        )
 
     @classmethod
     def tearDownClass(cls):
         """Remove the temporary region"""
         cls.del_temp_region()
+        cls.runModule("g.remove", type="vector", flags="f", name=cls.area_map)
 
     def tearDown(self):
         self.runModule(
@@ -105,6 +142,50 @@ skewness=4.86561
             reference=self.univar_string,
             column=self.univar_col,
             precision=1e-8,
+        )
+
+    def test_geojson_format(self):
+        """Tests output to GeoJSON format"""
+
+        self.assertModule(
+            "v.out.ogr",
+            "Export to GeoJSON Format",
+            input=self.test_map,
+            output=f"{self.test_map}.json",
+            format="GeoJSON",
+        )
+
+        # Import back to verify
+        self.runModule(
+            "v.in.ogr",
+            input=f"{self.test_map}.json",
+            output=self.temp_import,
+        )
+
+        self.runModule("g.region", vector=self.temp_import)
+
+        self.assertVectorFitsUnivar(
+            map=self.temp_import,
+            reference=self.univar_string,
+            column=self.univar_col,
+            precision=1e-8,
+        )
+
+    def test_geojson_format_no_attributes(self):
+        """Tests output to GeoJSON format with no attributes"""
+        self.assertModule(
+            "v.out.ogr",
+            "Export to GeoJSON Format",
+            input=self.area_map,
+            output=f"{self.test_map}.json",
+            format="GeoJSON",
+        )
+
+        # Import back to verify
+        self.runModule(
+            "v.in.ogr",
+            input=f"{self.test_map}.json",
+            output=self.temp_import,
         )
 
 


### PR DESCRIPTION
When exporting vector with no attribute table linked, v.out.ogr was crashing, there was a missing check when the new fast method was implemented. I didn't look too much into the code, I fixed it based on the `export_areas_multi` function.

Added test, it fails without this change.