### PR TITLE
docs: fix testing default value in parser

### DIFF
--- a/lib/gis/parser_md_cli.c
+++ b/lib/gis/parser_md_cli.c
@@ -105,14 +105,12 @@ void print_cli_option(FILE *file, const struct Option *opt, const char *indent)
         fprintf(file, "*");
     }
 
-    if (opt->def) {
+    if (opt->def && opt->def[0] != '\0') {
         fprintf(file, MD_NEWLINE);
         fprintf(file, "\n");
         fprintf(file, "%s", indent);
         G__md_print_escaped(file, "\t");
         fprintf(file, "%s:", _("Default"));
-        /* TODO check if value is empty
-           if (!opt->def.empty()){ */
         fprintf(file, " *");
         G__md_print_escaped(file, opt->def);
         fprintf(file, "*");

--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -248,7 +248,7 @@ void print_python_option(FILE *file, const struct Option *opt,
         }
     }
 
-    if (opt->def) {
+    if (opt->def && opt->def[0] != '\0') {
         fprintf(file, MD_NEWLINE);
         fprintf(file, "\n");
         fprintf(file, "%s", indent);


### PR DESCRIPTION
Some tools explicitly declare no default value (here v.out.ogr), messing up markdown:

Before:

<img width="696" height="574" alt="image" src="https://github.com/user-attachments/assets/8b48d8c6-32dd-4a51-898d-57f4c8e050ac" />

After:

<img width="696" height="574" alt="Screenshot from 2025-09-03 16-48-38" src="https://github.com/user-attachments/assets/f9ba5792-b063-46e5-a25b-840e737ce34f" />

Now the "Default:" is not shown at all.