### PR TITLE
v.what: Fix label for -j with deprecated

### DIFF
--- a/vector/v.what/main.c
+++ b/vector/v.what/main.c
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 
     flag.json = G_define_flag();
     flag.json->key = 'j';
-    flag.json->description = _("Print the stats in JSON [deprecated]");
+    flag.json->label = _("Print the stats in JSON [deprecated]");
     flag.json->description = _(
         "This flag is deprecated and will be removed in a future release. Use "
         "format=json instead.");


### PR DESCRIPTION
The description attribute was repeated, but it was supposed to be label. Introduced in #6252. Found by Coverity Scan.
