### PR TITLE
GUI: fix hiding input/output fields from import dialogs on Windows

### DIFF
--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -347,9 +347,9 @@ class processTask:
 
             hidden: bool = bool(
                 self.task.blackList["enabled"]
-                and self.task.name in self.task.blackList["items"]
+                and self.task.get_name() in self.task.blackList["items"]
                 and p.get("name")
-                in self.task.blackList["items"][self.task.name].get("params", [])
+                in self.task.blackList["items"][self.task.get_name()].get("params", [])
             )
 
             self.task.params.append(


### PR DESCRIPTION
The dialog for importing included input and output fields, even though they are explicitely blacklisted in the code. It was working on linux, but on windows the name included .py extension so it never passed the test:

<img width="704" height="646" alt="image" src="https://github.com/user-attachments/assets/0e18495c-2437-40fd-9b4f-75bc692346dc" />

Thanks @latb for bringing this to my attention.