### PR TITLE
grass.tools: add __iter__ to result object to streamline reading into pandas dataframe

### DIFF
--- a/python/grass/tools/support.py
+++ b/python/grass/tools/support.py
@@ -268,6 +268,9 @@ class ToolResult:
     def __len__(self):
         return len(self._json_or_error())
 
+    def __iter__(self):
+        return iter(self._json_or_error())
+
     def __repr__(self):
         parameters = []
         parameters.append(f"returncode={self.returncode}")

--- a/python/grass/tools/tests/grass_tools_session_tools_test.py
+++ b/python/grass/tools/tests/grass_tools_session_tools_test.py
@@ -11,6 +11,15 @@ from grass.experimental.mapset import TemporaryMapsetSession
 from grass.tools import Tools
 
 
+has_pandas = False
+try:
+    import pandas as pd
+
+    has_pandas = True
+except ImportError:
+    pass
+
+
 def test_no_stdout_returns_none(xy_dataset_session):
     """Check that no stdout results in returning None"""
     tools = Tools(session=xy_dataset_session)
@@ -132,6 +141,15 @@ def test_json_as_list(xy_dataset_session):
     for item in result:
         assert "name" in item
     assert len(result)
+
+
+@pytest.mark.skipif(has_pandas is False, reason="Requires Pandas")
+def test_json_for_pandas(xy_dataset_session):
+    """Check that JSON can be read into Pandas dataframe"""
+    tools = Tools(session=xy_dataset_session)
+    # This also tests JSON parsing with a format option.
+    result = tools.run("g.region", flags="p", format="json")
+    assert not pd.DataFrame(result).empty
 
 
 def test_help_call_no_parameters(xy_dataset_session):


### PR DESCRIPTION
Previously, you needed to do:
```python
pd.DataFrame(tools.run("g.region", flags="p", format="json").json)
```

otherwise you get an error. Now this works:

```python
pd.DataFrame(tools.run("g.region", flags="p", format="json"))
```

Pandas looks for __iter__:
https://github.com/pandas-dev/pandas/blob/1feacde3b686f9fea02c440528fee1d8fb907da8/pandas/_libs/lib.pyx#L1299