### PR TITLE
grass.jupyter: Use grass.tools for running and attributes in Map

### DIFF
--- a/python/grass/jupyter/tests/conftest.py
+++ b/python/grass/jupyter/tests/conftest.py
@@ -5,12 +5,14 @@ Fixture for grass.jupyter.TimeSeries test
 Fixture for ReprojectionRenderer test with simple GRASS location, raster, vector.
 """
 
+import os
 from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
 
 import grass.script as gs
+from grass.tools import Tools
 
 
 @pytest.fixture(scope="module")
@@ -91,3 +93,22 @@ def simple_dataset(tmp_path_factory):
             vector_name=vector_name,
             full_vector_name=f"{vector_name}@PERMANENT",
         )
+
+
+@pytest.fixture
+def session(tmp_path):
+    project = tmp_path / "xy_project"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        yield session
+
+
+@pytest.fixture
+def session_with_data(tmp_path):
+    project = tmp_path / "xy_project"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        tools = Tools(session=session)
+        tools.g_region(s=0, n=5, w=0, e=2, res=1)
+        tools.r_mapcalc(expression="data = row() * col()")
+        yield session

--- a/python/grass/jupyter/tests/grass_jupyter_map_numpy_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_map_numpy_test.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+import grass.jupyter as gj
+from grass.tools import Tools
+
+
+def test_numpy_array_as_raster_use_region(session, tmp_path):
+    xx, yy = np.meshgrid(np.linspace(0, 1, 10), np.linspace(-1, 1, 20))
+    data = xx * yy
+
+    # Set the region to match the array dimensions.
+    # The region will be used later and needs to match.
+    tools = Tools(session=session)
+    rows = data.shape[0]
+    cols = data.shape[1]
+    tools.g_region(s=0, n=rows, w=0, e=cols, res=1)
+
+    map2d = gj.Map(session=session, use_region=True)
+    map2d.d_rast(map=data)
+    image = tmp_path / "test.png"
+    map2d.save(image)
+    assert image.exists()
+    assert image.stat().st_size
+
+
+def test_numpy_array_as_raster_auto_region(session, tmp_path):
+    xx, yy = np.meshgrid(np.linspace(0, 1, 10), np.linspace(-1, 1, 20))
+    data = xx * yy
+
+    # Set the region to match the array dimensions and resolution.
+    # The auto-region mechanism will not find a raster, so it will
+    # not set a region.
+    tools = Tools(session=session)
+    rows = data.shape[0]
+    cols = data.shape[1]
+    tools.g_region(s=0, n=rows, w=0, e=cols, res=1)
+
+    map2d = gj.Map(session=session)
+    map2d.d_rast(map=data)
+    image = tmp_path / "test.png"
+    map2d.save(image)
+    assert image.exists()
+    assert image.stat().st_size
+
+
+def test_numpy_multiple_arrays_as_rasters(session, tmp_path):
+    xx, yy = np.meshgrid(np.linspace(0, 1, 10), np.linspace(-1, 1, 20))
+    data = xx * yy
+
+    tools = Tools(session=session)
+    rows = data.shape[0]
+    cols = data.shape[1]
+    tools.g_region(s=0, n=rows, w=0, e=cols, res=1)
+
+    data2 = np.tri(rows, cols, -2)
+
+    map2d = gj.Map(session=session, use_region=True)
+    map2d.d_shade(color=data, shade=data2)
+    image = tmp_path / "test.png"
+    map2d.save(image)
+    assert image.exists()
+    assert image.stat().st_size

--- a/python/grass/jupyter/tests/grass_jupyter_map_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_map_test.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+import grass.jupyter as gj
+
+
+@pytest.mark.parametrize("use_region", [True, False])
+def test_created_with_env(session_with_data, use_region):
+    """Check that object can be used with environment"""
+    map2d = gj.Map(env=session_with_data.env, use_region=use_region)
+    map2d.d_rast(map="data")
+
+    image = Path(map2d.filename)
+    assert image.exists()
+    assert image.stat().st_size
+
+
+@pytest.mark.parametrize("use_region", [True, False])
+def test_created_with_session(session_with_data, use_region):
+    """Check that object can be used with a session object"""
+    map2d = gj.Map(session=session_with_data, use_region=use_region)
+    map2d.d_rast(map="data")
+
+    image = Path(map2d.filename)
+    assert image.exists()
+    assert image.stat().st_size
+
+
+def test_attribute_access_c_tools():
+    """Check C tool names can be listed without a session"""
+    map2d = gj.Map()
+    assert "d_rast" in dir(map2d)
+    assert "d_vect" in dir(map2d)
+
+
+def test_attribute_access_python_tools():
+    """Check Python tool names can be listed without a session"""
+    map2d = gj.Map()
+    assert "d_background" in dir(map2d)
+    assert "d_shade" in dir(map2d)
+
+
+def test_non_display_tools():
+    """Check non-display tools are not listed"""
+    map2d = gj.Map()
+    assert "r_info" not in dir(map2d)
+    assert "db_univar" not in dir(map2d)

--- a/python/grass/jupyter/testsuite/map_test.py
+++ b/python/grass/jupyter/testsuite/map_test.py
@@ -148,10 +148,20 @@ class TestMap(TestCase):
         # Create map
         grass_renderer = gj.Map()
         # Pass bad shortcuts
-        with self.assertRaisesRegex(AttributeError, "Module must begin with 'd_'"):
-            grass_renderer.r_watersheds()
+        with self.assertRaisesRegex(AttributeError, "r_does_not_exist"):
+            grass_renderer.r_does_not_exist()
+        with self.assertRaisesRegex(AttributeError, "r_info.*[^a-z]d_[^a-z]"):
+            grass_renderer.r_info()
         with self.assertRaisesRegex(AttributeError, "d.module.does.not.exist"):
             grass_renderer.d_module_does_not_exist()
+        with self.assertRaisesRegex(AttributeError, "d_module_does_not_exist"):
+            grass_renderer.d_module_does_not_exist()
+
+    def test_run_wrong_tool(self):
+        grass_renderer = gj.Map()
+        # We do two separate tests. Order is purely based on the current message.
+        with self.assertRaisesRegex(ValueError, "[^a-z]d[^a-z].*r.info"):
+            grass_renderer.run("r.info", map="elevation")
 
     @unittest.skipIf(not can_import_ipython(), "Cannot import IPython")
     def test_image_creation(self):

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -384,7 +384,8 @@ def get_map_name_from_d_command(module, **kwargs):
     """
     special = {"d.his": "hue", "d.legend": "raster", "d.rgb": "red", "d.shade": "shade"}
     parameter = special.get(module, "map")
-    return kwargs.get(parameter, "")
+    value = kwargs.get(parameter, "")
+    return value if isinstance(value, str) else None
 
 
 def get_rendering_size(region, width, height, default_width=600, default_height=400):

--- a/python/grass/tools/tests/grass_tools_tool_function_wrap_test.py
+++ b/python/grass/tools/tests/grass_tools_tool_function_wrap_test.py
@@ -1,5 +1,7 @@
 """Tests of grass.tools.support.ToolFunctionResolver"""
 
+import os
+
 import pytest
 
 from grass.tools.support import ToolFunctionResolver
@@ -69,3 +71,47 @@ def test_levenshtein_distance_empty_text():
     ToolFunctionResolver.levenshtein_distance(non_empty_text, empty_text) == len(
         non_empty_text
     )
+
+
+def test_allowed_prefix_no_separator():
+    """Check that dotted tool name is resolved"""
+    prefix = "r"
+    resolver = ToolFunctionResolver(
+        run_function=lambda x: x, env=os.environ.copy(), allowed_prefix=prefix
+    )
+    assert resolver.r_watershed() == "r.watershed"
+    assert "r_info" in resolver.names()
+    for name in resolver.names():
+        assert name.startswith(prefix)
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        assert resolver.does_not_exist
+    with pytest.raises(AttributeError, match="r_does_not_exist"):
+        assert resolver.r_does_not_exist
+    with pytest.raises(AttributeError, match="v_does_not_exist"):
+        assert resolver.v_does_not_exist
+    with pytest.raises(AttributeError, match="v_info"):
+        assert resolver.v_info
+    with pytest.raises(TypeError, match="v_info"):
+        assert resolver.get_function("v_info", exception_type=TypeError)
+
+
+def test_allowed_prefix_d_with_underscore():
+    """Check that dotted tool name is resolved"""
+    prefix = "d_"
+    resolver = ToolFunctionResolver(
+        run_function=lambda x: x, env=os.environ.copy(), allowed_prefix=prefix
+    )
+    assert resolver.d_rast() == "d.rast"
+    assert "d_vect" in resolver.names()
+    for name in resolver.names():
+        assert name.startswith(prefix)
+    with pytest.raises(AttributeError, match="does_not_exist"):
+        assert resolver.does_not_exist
+    with pytest.raises(AttributeError, match="d_does_not_exist"):
+        assert resolver.d_does_not_exist
+    with pytest.raises(AttributeError, match="v_does_not_exist"):
+        assert resolver.v_does_not_exist
+    with pytest.raises(AttributeError, match="r_info"):
+        assert resolver.r_info
+    with pytest.raises(TypeError, match="r_info"):
+        assert resolver.get_function("r_info", exception_type=TypeError)


### PR DESCRIPTION
Uses Tools from grass.tools to run the underlying display tool. This allows NumPy arrays to be passed to display tools when used with grass.jupyter.Map. Small adjustments to automatic region handling were needed so that the arrays are ignored (and only raster names, i.e., strings, are used).

The Map objects already allow syntax similar to Tools in terms of access to tools as attributes. This migrates the attribute access handling to use the functionality from grass.tools.support and overall syncs the code to Tools. As a result, Map provides the same error messages and attribute completion as Tools. To achieve expected results with the limit for display tools only, the underlying class now supports an allowed prefix parameter which limits the tools to only those with the allowed prefix (and Map sets this prefix).

For further sync with Tools, Map now accepts a session parameter in the same way as Tools (except that env is copied at creation, not linked, but that keeps the current Map behavior with the env parameter - Map always modifies the env and needs the env to be consistent, while Tools typically does not touch the env and may be used in context where the env is changed).
