### PR TITLE
docs: Better use of computational region in NumPy examples

### DIFF
--- a/python/grass/tools/session_tools.py
+++ b/python/grass/tools/session_tools.py
@@ -75,8 +75,10 @@ class Tools:
     Raster input and outputs can be NumPy arrays:
 
     >>> import numpy as np
-    >>> tools.g_region(rows=2, cols=3)
-    >>> slope = tools.r_slope_aspect(elevation=np.ones((2, 3)), slope=np.ndarray)
+    >>> rows = 2
+    >>> cols = 3
+    >>> tools.g_region(s=0, n=rows, w=0, e=cols, res=1)
+    >>> slope = tools.r_slope_aspect(elevation=np.ones((rows, cols)), slope=np.ndarray)
     >>> tools.r_grow(
     ...     input=np.array([[1, np.nan, np.nan], [np.nan, np.nan, np.nan]]),
     ...     radius=1.5,
@@ -113,6 +115,7 @@ class Tools:
     and text outputs from the tool as the result object has the same
     attributes and functionality as without arrays:
 
+    >>> # In this case, the tool did not produce any text, so the text is empty.
     >>> result.text
     ''
     """


### PR DESCRIPTION
This improves how computational region is handled in all NumPy examples. Specifically, it creates variables for number of rows and columns and only then sets the computational region to be clear what is happening.

```python
tools = Tools(session=session)
rows = elevation.shape[0]
cols = elevation.shape[1]
tools.g_region(s=0, n=rows, w=0, e=cols, res=1)
```

This still has limited applicability as it works without a geographical context. Notably, NumPy arrays are generally not georeferenced, so XY project is applicable and I added creation of the project to the example. Maybe this is enough for the basic example.

While this builds on #6313 (and currently contains also the changes from there), I'm opening a separate PR to allow for a separate discussion on how to handle this.