### PR TITLE
lib/gis: Fix Dereference after null check issue in parser.c

### DIFF
--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -357,7 +357,7 @@ int G_parser(int argc, char **argv)
 
         if (!opt->key)
             G_warning(_("Bug in UI description. Missing option key"));
-        if (!valid_option_name(opt->key))
+        if (opt->key && !valid_option_name(opt->key))
             G_warning(_("Bug in UI description. Option key <%s> is not valid"),
                       opt->key);
         if (!opt->label && !opt->description)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan ( CID : 1415810)
We first check if `opt->key` is `NULL`. Since it only prints a `G_warning`, execution continues and there is still a chance that `NULL` could be passed to `valid_option_name()`.
To prevent this, I added an extra condition in the second `if` to make sure `opt->key` is `not NULL`.
Another option would be to use `G_fatal_error()`, which would stop execution immediately, but I’m not sure if the guidelines prefer to continue or to stop early