### PR TITLE
v.vect.stats: Update test file

### DIFF
--- a/vector/v.vect.stats/testsuite/test_vect_stats.py
+++ b/vector/v.vect.stats/testsuite/test_vect_stats.py
@@ -14,6 +14,289 @@ from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
 
 
+output1 = """area_cat|count|sum
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|7
+10|0|null
+11|0|null
+12|0|null
+13|1|10
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|6
+29|1|146
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|8
+40|2|9
+41|0|null
+42|0|null
+43|1|9
+44|0|null
+"""
+
+output2 = """area_cat|count|average
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|7
+10|0|null
+11|0|null
+12|0|null
+13|1|10
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|6
+29|1|146
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|8
+40|2|4.5
+41|0|null
+42|0|null
+43|1|9
+44|0|null
+"""
+
+output3 = """area_cat|count|variance
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|0
+10|0|null
+11|0|null
+12|0|null
+13|1|0
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|0
+29|1|0
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|0
+40|2|0.25
+41|0|null
+42|0|null
+43|1|0
+44|0|null
+"""
+
+output4 = """area_cat|count|range
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|0
+10|0|null
+11|0|null
+12|0|null
+13|1|0
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|0
+29|1|0
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|0
+40|2|1
+41|0|null
+42|0|null
+43|1|0
+44|0|null
+"""
+
+output5 = """area_cat|count|max_cat
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|7
+10|0|null
+11|0|null
+12|0|null
+13|1|10
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|6
+29|1|146
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|8
+40|2|5
+41|0|null
+42|0|null
+43|1|9
+44|0|null
+"""
+
+output6 = """area_cat|count|mode
+1|0|null
+2|0|null
+3|0|null
+4|0|null
+5|0|null
+6|0|null
+7|0|null
+8|0|null
+9|1|7
+10|0|null
+11|0|null
+12|0|null
+13|1|10
+14|0|null
+15|0|null
+16|0|null
+17|0|null
+18|0|null
+19|0|null
+20|0|null
+21|0|null
+22|0|null
+23|0|null
+24|0|null
+25|0|null
+26|0|null
+27|0|null
+28|1|6
+29|1|146
+30|0|null
+31|0|null
+32|0|null
+33|0|null
+34|0|null
+35|0|null
+36|0|null
+37|0|null
+38|0|null
+39|1|8
+40|2|4
+41|0|null
+42|0|null
+43|1|9
+44|0|null
+"""
+
+
 class Testrr(TestCase):
     input = "hospitals"
     areas = "zipcodes_wake"
@@ -28,18 +311,6 @@ class Testrr(TestCase):
 
     def test_sum(self):
         """Testing method sum"""
-        string = """area_cat|count|sum
-        1|0|null
-        2|0|null
-        3|0|null
-        4|0|null
-        5|0|null
-        6|0|null
-        7|0|null
-        8|0|null
-        9|1|7
-        10|0|null
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -48,24 +319,13 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output1, actual=v_vect_stats.outputs.stdout)
 
     def test_average(self):
         """Testing method average"""
-        string = """area_cat|count|average
-        1|1|2681
-        2|0|null
-        3|2|3958.5
-        4|0|null
-        5|0|null
-        6|8|4012
-        7|7|4185.42857142857
-        8|19|4396.78947368421
-        9|4|4222
-        10|3|4400.33333333333
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -74,24 +334,13 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output2, actual=v_vect_stats.outputs.stdout)
 
     def test_median(self):
         """Testing method variance"""
-        string = """area_cat|count|variance
-        1|1|0
-        2|0|null
-        3|2|702.25
-        4|0|null
-        5|0|null
-        6|8|7639
-        7|7|2661.38775510204
-        8|19|69198.7977839335
-        9|4|42.5
-        10|3|3968.22222222222
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -100,24 +349,13 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output3, actual=v_vect_stats.outputs.stdout)
 
     def test_mincat(self):
         """Testing method min_cat"""
-        string = """area_cat|count|range
-        1|1|0
-        2|0|null
-        3|2|53
-        4|0|null
-        5|0|null
-        6|8|255
-        7|7|168
-        8|19|892
-        9|4|17
-        10|3|152
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -126,24 +364,13 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output4, actual=v_vect_stats.outputs.stdout)
 
     def test_maxcat(self):
         """Testing method max_cat"""
-        string = """area_cat|count|max_cat
-        1|0|null
-        2|0|null
-        3|0|null
-        4|0|null
-        5|0|null
-        6|0|null
-        7|0|null
-        8|0|null
-        9|1|7
-        10|0|null
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -152,24 +379,13 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output5, actual=v_vect_stats.outputs.stdout)
 
     def test_mode(self):
         """Testing method mode"""
-        string = """area_cat|count|mode
-        1|0|null
-        2|0|null
-        3|0|null
-        4|0|null
-        5|0|null
-        6|0|null
-        7|0|null
-        8|0|null
-        9|1|7
-        10|0|null
-        """
         v_vect_stats = SimpleModule(
             "v.vect.stats",
             points=self.input,
@@ -178,9 +394,10 @@ class Testrr(TestCase):
             count_column="num_points",
             stats_column="avg_elev",
             points_column="cat",
+            flags="p",
         )
-        v_vect_stats.outputs.stdout = string
-        self.assertLooksLike(reference=string, actual=v_vect_stats.outputs.stdout)
+        self.assertModule(v_vect_stats)
+        self.assertLooksLike(reference=output6, actual=v_vect_stats.outputs.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ref: #6228 

This PR updates the regression test suite for the `v.vect.stats` module. The previously added tests were not useful, so this change replaces them with tests that check actual behavior. This ensures that future changes—particularly the upcoming addition of JSON support—do not break existing functionality.
