### PR TITLE
r.slope.aspect: Show behavior with repeated output name in a test

### DIFF
--- a/raster/r.slope.aspect/tests/conftest.py
+++ b/raster/r.slope.aspect/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
+
+
+@pytest.fixture
+def xy_dataset_session(tmp_path):
+    """Active session in an XY location (scope: function)"""
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with (
+        gs.setup.init(project, env=os.environ.copy()) as session,
+        Tools(session=session) as tools,
+    ):
+        tools.g_region(s=0, n=5, w=0, e=6, res=1)
+        tools.r_mapcalc(expression="rows_raster = row()")
+        yield session

--- a/raster/r.slope.aspect/tests/r_slope_aspect_test.py
+++ b/raster/r.slope.aspect/tests/r_slope_aspect_test.py
@@ -1,0 +1,27 @@
+from grass.tools import Tools
+
+
+def test_repeated_output(xy_dataset_session):
+    """Check behavior when two outputs have the same name
+
+    This is practically undefined behavior, but here, we test the current behavior
+    which is that one of the outputs wins (regardless of the order of the provided
+    parameters or other in the interface).
+    """
+    tools = Tools(session=xy_dataset_session, consistent_return_value=True)
+    name = "output_1"
+
+    tools.r_slope_aspect(elevation="rows_raster", aspect=name, slope=name)
+    stats = tools.r_univar(map=name, format="json")
+    # This is slope.
+    assert stats["min"] == 45
+    assert stats["max"] == 45
+    assert stats["sum"] == 540
+
+    name = "output_2"
+    tools.r_slope_aspect(elevation="rows_raster", dx=name, dy=name, slope=name)
+    stats = tools.r_univar(map=name, format="json")
+    # This is dy.
+    assert stats["min"] == 1
+    assert stats["max"] == 1
+    assert stats["sum"] == 12


### PR DESCRIPTION
While working in #5877, I checked how r.slope.aspect behaves when multiple output parameters are set to the same name, e.g., slope=slope aspect=slope. While the current behavior is not ideal, and I'm not adding it to the documentation, i.e., leaving it undefined, the test at least makes it clear what is the current behavior, providing a starting point for any future changes.
