### PR TITLE
r.fill.dir: Fix Resource Leak Issue in dopolys.c and filldir.c

### DIFF
--- a/raster/r.fill.dir/dopolys.c
+++ b/raster/r.fill.dir/dopolys.c
@@ -76,7 +76,6 @@ int dopolys(int fd, int fm, int nl, int ns)
         G_free(dir);
         return 0;
     }
-    
     /* Loop through the list, assigning polygon numbers to unassigned entries
        and carrying the same assignment over to adjacent cells.  Repeat
        recursively */

--- a/raster/r.fill.dir/dopolys.c
+++ b/raster/r.fill.dir/dopolys.c
@@ -71,9 +71,12 @@ int dopolys(int fd, int fm, int nl, int ns)
             }
         }
     }
-    if (found == 0)
+    if (found == 0) {
+        G_free(cells);
+        G_free(dir);
         return 0;
-
+    }
+    
     /* Loop through the list, assigning polygon numbers to unassigned entries
        and carrying the same assignment over to adjacent cells.  Repeat
        recursively */

--- a/raster/r.fill.dir/filldir.c
+++ b/raster/r.fill.dir/filldir.c
@@ -39,13 +39,11 @@ void check(CELL newdir, CELL *dir, void *center, void *edge, double cnst,
 int fill_row(int nl UNUSED, int ns, struct band3 *bnd)
 {
     int j, offset, inc, rc;
-    void *min;
+    char *min;
     char *center;
     char *edge;
 
     inc = bpe();
-
-    min = G_malloc(bpe());
 
     rc = 0;
     for (j = 1; j < ns - 1; j += 1) {


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207781, 1207920, 1207921)
For CID : 1207781  i don't think we need G_malloc as min is just holding the address, no need for buffer allocation.