### PR TITLE
grass.exceptions: Do not translate exception text

### DIFF
--- a/python/grass/exceptions/__init__.py
+++ b/python/grass/exceptions/__init__.py
@@ -77,13 +77,13 @@ class CalledModuleError(subprocess.CalledProcessError):
         executed = code if not module or module in code else f"{module} {code}"
         if errors:
             # We assume actual errors, e.g., captured stderr.
-            err = _("See the following errors:\n{errors}").format(errors=errors)
+            err = "See the following errors:\n{errors}".format(errors=errors)
         else:
             # In command line, the errors will be above, but in testing framework
             # or notebooks, the errors will be somewhere else than the traceback.
-            err = _("See errors above the traceback or in the error output.")
+            err = "See errors above the traceback or in the error output."
         # The full message
-        self.msg = _(
+        self.msg = (
             "Module run `{executed}` ended with an error.\n"
             "The subprocess ended with a non-zero return code: {returncode}."
             " {see_errors}"


### PR DESCRIPTION
CalledModuleError is trying hard to explain what is happening with several messages. In the past, we simply marked all messages for translation, so these were translatable as well. In past years, we started to not translate the messages raised in Python with the idea that this is consistent with Python exceptions and will generally be more appropriate in a traceback (discussed e.g. here #1559). As a side note, the current idea is that a user interface which is supposed to be localzied, such as GUI, should generally provide its own messages. In the context of CalledModuleError, localized messages will be the messages provided by the tool which just failed, so they may be part of the traceback (but are also accessible separately if the exception is handled by the caller).

The new code does not translate the messages, so the translation mechanism does not need to work for the exception to be generated. This is extremelly helpful in an interactive console and doctests where last result is assigned to a global variable named underscore, so any attempt to translate will end with an error: "TypeError: 'XY' object is not callable" where XY is whatever was the last line's type. Although the traceback originated still at the right top place in the code, the message was not useful and even misleading. Not translating now makes it work always without the current fragility or any other risk created by translations (even if we would address the specific issue of interaction with the underscore in interactive console and doctests).

This improves the interactive console user experience and doctest testing for grass.script, grass.pygrass, and grass.tools which all use CalledModuleError as well as for any functions which are using these (such as the other functions in grass.script).

## Before

```python
>>> import grass.script as gs
>>> from grass.tools import Tools
>>> gs.setup.init("nc_spm_08_grass7/user1")
<grass.script.setup.SessionHandle object at 0x74b8d85b9040>
>>> tools = Tools()
>>> tools.g_region(raster="elevation/dem")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../etc/python/grass/tools/support.py", line 167, in wrapper
    return self._run_function(tool_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 273, in run
    result = self.run_cmd(
             ^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 314, in run_cmd
    return self.call_cmd(
           ^^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 385, in call_cmd
    return gs.handle_errors(
           ^^^^^^^^^^^^^^^^^
  File ".../etc/python/grass/script/core.py", line 462, in handle_errors
    raise CalledModuleError(
          ^^^^^^^^^^^^^^^^^^
  File ".../etc/python/grass/exceptions/__init__.py", line 80, in __init__
    err = _("See the following errors:\n{errors}").format(errors=errors)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'SessionHandle' object is not callable
```

## After

```python
>>> import grass.script as gs
>>> from grass.tools import Tools
>>> gs.setup.init("nc_spm_08_grass7/user1")
<grass.script.setup.SessionHandle object at 0x70b5f8753a10>
>>> tools = Tools()
>>> tools.g_region(raster="elevation/dem")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../etc/python/grass/tools/support.py", line 167, in wrapper
    return self._run_function(tool_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 321, in run
    result = self.run_cmd(
             ^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 362, in run_cmd
    return self.call_cmd(
           ^^^^^^^^^^^^^^
  File ".../etc/python/grass/tools/session_tools.py", line 433, in call_cmd
    return gs.handle_errors(
           ^^^^^^^^^^^^^^^^^
  File ".../etc/python/grass/script/core.py", line 464, in handle_errors
    raise exception(
grass.tools.session_tools.ToolError: Tool run `g.region raster=elevation/dem` ended with an error.
The subprocess ended with a non-zero return code: 1. See the following errors:
WARNING: Illegal filename <elevation/dem>. Character </> not
         allowed.
ERROR: Raster map <elevation/dem> not found
```

## Additional info

Our [current style guide](https://grass.osgeo.org/grass-devel/manuals/style_guide.html) is not specific about this. The part about messages focuses on tools (scripts). The only example of `raise` is in the _Python API documentation_ section where there is no translation.