### PR TITLE
CMake: Fix LAPACKE detection on Debian Bookworm (Debian 12)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -358,6 +358,44 @@ Please see
 - [GRASS Programming Style Guide](./doc/development/style_guide.md)
 - [Guide to contributing on GitHub](./doc/development/github_guide.md)
 
+
+## (N) Debian Bookworm (Debain 12) 
+
+To install all required build dependencies on Debian 12 (Bookworm):
+
+```bash 
+sudo apt update
+sudo apt install -y build-essential cmake gcc g++ make \
+    bison flex pkg-config gettext git \
+    libproj-dev libgdal-dev libgeos-dev \
+    libcairo2-dev libfreetype-dev libfontconfig1-dev \
+    libpng-dev libtiff-dev zlib1g-dev \
+    libbz2-dev libzstd-dev \
+    libfftw3-dev liblapacke-dev liblapack-dev libblas-dev libopenblas-dev \
+    libsqlite3-dev libpq-dev default-libmysqlclient-dev unixodbc-dev \
+    libwxgtk3.2-dev python3-numpy python3-matplotlib python3-pil python3-dateutil \
+    ffmpeg
+```
+```
+```
+```
+```
+
+These are the mandatory dependencies you need to build and compile GRASS. Copy and paste this on your terminal and hit enter.
+
+A few optional dependencies are shown below.
+
+```bash
+sudo apt install -y \
+    libnetcdf-dev \
+    libsvm-dev \
+    libpdal-dev \
+    r-base-dev \
+    python3-termcolor \
+    libglu1-mesa-dev libgl1-mesa-dev \
+    subversion```
+
 ## Authors
 
 Markus Neteler and the GRASS Development Team
+

--- a/cmake/find_scripts/FindLAPACKE.cmake
+++ b/cmake/find_scripts/FindLAPACKE.cmake
@@ -94,6 +94,7 @@ endif()
 
 unset(_default_pkgs)
 
+#[[
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_LIBRARIES ${LAPACKE_LIBRARIES})
 set(CMAKE_REQUIRED_INCLUDES ${LAPACKE_INCLUDEDIR})
@@ -102,6 +103,23 @@ check_symbol_exists(LAPACKE_dgesv "lapacke.h" HAVE_LAPACKE_DGESV)
 unset(CMAKE_REQUIRED_LIBRARIES)
 unset(CMAKE_REQUIRED_INCLUDES)
 unset(CMAKE_REQUIRED_QUIET)
+]]
+
+
+include(CheckLibraryExists)
+# Look for include and library
+find_path(LAPACKE_INCLUDE_DIR lapacke.h)
+find_library(LAPACKE_LIBRARIES lapacke)
+
+if(LAPACKE_INCLUDE_DIR AND LAPACKE_LIBRARIES)
+    set(CMAKE_REQUIRED_INCLUDES ${LAPACKE_INCLUDE_DIR})
+    set(CMAKE_REQUIRED_LIBRARIES ${LAPACKE_LIBRARIES})
+    check_library_exists(lapacke LAPACKE_dgesv "" HAVE_LAPACKE_DGESV)
+endif()
+
+unset(CMAKE_REQUIRED_LIBRARIES)
+unset(CMAKE_REQUIRED_INCLUDES)
+
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/setup_grass_dev.sh
+++ b/setup_grass_dev.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# -----------------------------------------------------------
+# Auto Install Script for Debain Bookworm (Debian 12) and/or Debian-Based Systems.
+#
+# Author: Anirban Das
+# ----------------------------------------------------------
+
+set -e
+
+echo "[+] Updating package lists..."
+sudo apt update
+
+echo "[+] Installing core build tools..."
+sudo apt install -y \
+	build-essential cmake gcc g++ make \
+	bison flex pkg-config gettext git \
+	python3 python3-dev python3-pip
+
+echo "[+] Installing core GRASS dependencies..."
+sudo apt install -y \
+	libproj-dev libgdal-dev libgeos-dev \
+	libcairo2-dev libfreetype-dev libfontconfig1-dev \
+	libpng-dev libtiff-dev zlib1g-dev \
+	libbz2-dev libzstd-dev
+
+echo "[+] Installing optional math libraries..."
+sudo apt install -y \
+	libfftw3-dev liblapacke-dev liblapack-dev libblas-dev libopenblas-dev
+
+echo "[+] Installing optional database backends..."
+sudo apt install -y \
+	libsqlite3-dev libpq-dev \
+	default-libmysqlclient-dev \
+	unixodbc-dev
+
+echo "[+] Installing optional GUI + Python support..."
+sudo apt install -y \
+	libwxgtk3.2-dev \
+	python3-numpy python3-matplotlib python3-pil python3-dateutil \
+	ffmpeg
+
+echo "[+] All dependencies installed!"
+
+echo "[+] Building GRASS GIS..."
+mkdir -p build && cd build
+cmake ..
+make -j"$(nproc)"
+
+echo "[+] Installing GRASS GIS..."
+sudo make install
+
+echo "[+] ===== GRASS GIS build complete! Run it with: grass --version ===== "

--- a/setup_grass_extra.sh
+++ b/setup_grass_extra.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+echo "[+] Updating package lists..."
+sudo apt update
+
+echo "[+] Installing remaining optional GRASS dependencies..."
+sudo apt install -y \
+	libnetcdf-dev \
+	libsvm-dev \
+	libpdal-dev \
+	r-base-dev \
+	python3-termcolor \
+	libglu1-mesa-dev libgl1-mesa-dev \
+	subversion
+
+echo "[+] Optional dependencies installed!"
+echo "[+] For docs support, also run:     pip install mkdocs mkdocs-material"


### PR DESCRIPTION
This pull request is an attempt to fix #6364. 

# Fix-1: LAPACKE detection error by CMake
## The Bug
on debian 12 (bookworm)... building GRASS failed with the following error
``` Could NOT find LAPACKE (missing: HAVE_LAPACKE_DGESV) ```

<img width="816" height="277" alt="image" src="https://github.com/user-attachments/assets/cb2ebcc4-cb3c-4ee2-adbb-9ba7c28a62bb" />


Even though `liblapacke-dev` and `libopenblas-dev` were installed, CMake couldn’t detect LAPACKE because the check relied on `check_symbol_exists()`, which doesn’t actually link against `liblapacke.so`.

## Debugging
> 1. created a build directory and ran the following
``` 
mkdir build && cd build
cmake .. 
```

> 2. confirmed headers and library exists:
```
ls /usr/include/lapacke.h
ls /usr/lib/x86_64-linux-gnu/liblapacke.so
```

> 3. wrote a tiny test program 
```c
#include <lapacke.h>
#include <stdio.h>

int main() {
    printf("LAPACKE_dgesv is here: %p\n", LAPACKE_dgesv);
    return 0;
}
```
> 4. compile
```bash
gcc test_lapacke.c -o test_lapacke -llapacke -llapack -lblas
./test_lapacke.c
```
> 5. output `LAPACKE_dgesv is here: 0x7fe4658c1320`
This ensures that lapacke exists and is working fine

## The Fix
Edited `cmake/find_scripts/FindLAPACKE.cmake` to replace the header-only check with a proper library check.
Initially it was 
```cmake
include(CheckSymbolExists)
set(CMAKE_REQUIRED_LIBRARIES ${LAPACKE_LIBRARIES})
set(CMAKE_REQUIRED_INCLUDES ${LAPACKE_INCLUDEDIR})
set(CMAKE_REQUIRED_QUIET ${LAPACKE_FIND_QUIETLY})
check_symbol_exists(LAPACKE_dgesv "lapacke.h" HAVE_LAPACKE_DGESV)
unset(CMAKE_REQUIRED_LIBRARIES)
unset(CMAKE_REQUIRED_INCLUDES)
unset(CMAKE_REQUIRED_QUIET)
```

Which was changed to 
```cmake
include(CheckLibraryExists)
# Look for include and library
find_path(LAPACKE_INCLUDE_DIR lapacke.h)
find_library(LAPACKE_LIBRARIES lapacke)

if(LAPACKE_INCLUDE_DIR AND LAPACKE_LIBRARIES)
    set(CMAKE_REQUIRED_INCLUDES ${LAPACKE_INCLUDE_DIR})
    set(CMAKE_REQUIRED_LIBRARIES ${LAPACKE_LIBRARIES})
    check_library_exists(lapacke LAPACKE_dgesv "" HAVE_LAPACKE_DGESV)
endif()

unset(CMAKE_REQUIRED_LIBRARIES)
unset(CMAKE_REQUIRED_INCLUDES)
```

# Fix-2: Automated Script for installing build dependencies

The scripts are in `setup_grass_dev.sh` and `setup_grass_extra.sh`. 