### PR TITLE
ctypesgen: Fix handling of multiline #define directives in ctypesgen parser

### DIFF
--- a/python/libgrass_interface_generator/ctypesgen/parser/pplexer.py
+++ b/python/libgrass_interface_generator/ctypesgen/parser/pplexer.py
@@ -347,6 +347,13 @@ def t_PRAGMA_error(t):
     return t
 
 
+@TOKEN(r"\\\n")
+def t_DEFINE_backslash_newline(t):
+    # Handle backslash continuation in #define - ignore this sequence
+    t.lexer.lineno += 1
+    return None  # Skip this token, don't return it to parser
+
+
 @TOKEN(r"\n")
 def t_DEFINE_newline(t):
     t.type = "PP_END_DEFINE"

--- a/python/libgrass_interface_generator/ctypesgen/parser/preprocessor.py
+++ b/python/libgrass_interface_generator/ctypesgen/parser/preprocessor.py
@@ -169,10 +169,20 @@ class PreprocessorParser(object):
 
         first_token_reg = re.compile(r"^\s*#\s*([^ ]+)($|\s)")
 
-        for line in ppout.split("\n"):
-            line += "\n"
+        lines = ppout.split("\n")
+        n = len(lines)
+        i = 0
+        while i < n:
+            line = lines[i] + "\n"
+            i += 1
             search = first_token_reg.match(line)
             hash_token = search.group(1) if search else None
+
+            if hash_token:
+                # collect multiple lines
+                while i < n and line.endswith("\\\n"):
+                    line += lines[i] + "\n"
+                    i += 1
 
             if (not hash_token) or hash_token == "pragma":
                 source_lines.append(line)


### PR DESCRIPTION
- Add support for backslash continuation in `#define` lexer token
- Implement proper multiline directive collection in preprocessor
- Handle line continuation sequences (`\\\n`) correctly
- Ensures multiline #define statements are processed as single units

=> The python wrapper file `arraystats.py` for `grass_arraystats` is generated correctly with the constants.


@HuidaeCho 