### PR TITLE
r.terraflow: Fixing Argument cannot be negative issue in stats.cpp

### DIFF
--- a/raster/r.terraflow/stats.cpp
+++ b/raster/r.terraflow/stats.cpp
@@ -118,9 +118,10 @@ char *noclobberFileName(char *fname)
             if (rename(fname, buf) != 0) {
                 G_fatal_error("%s", fname);
             }
-            close(fd);
         }
     }
+    if (fd >= 0)
+        close(fd);
     return fname;
 }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207489, 1208154)
Both argument cannot be negative and resource leak issues are fixed.
Removed close(fd) from inside if (fd < 0) which fixes the argument negative issue and placed it before return.
Also before closing fd at the end checked if fd >= 0 because there is a else condition inside (fd < 0) and if G_fatal_error does not happen program would reach till return and then again argument negative issue might occur.