### PR TITLE
GUI: add functions for disabling processing events about mapset content changes in datacatalog

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -256,6 +256,7 @@ class DataCatalogTree(TreeView):
         self.UpdateCurrentDbLocationMapsetNode()
         self._lastWatchdogUpdate = gs.clock()
         self._updateMapsetWhenIdle = None
+        self._watchingMapsetEnabled = False
 
         #  mapset watchdog
         self._mapset_watchdog = MapsetWatchdog(
@@ -301,13 +302,7 @@ class DataCatalogTree(TreeView):
         )
         self.startEdit.connect(self.OnStartEditLabel)
         self.endEdit.connect(self.OnEditLabel)
-        self.Bind(
-            EVT_UPDATE_MAPSET, lambda evt: self._onWatchdogMapsetReload(evt.src_path)
-        )
-        self.Bind(wx.EVT_IDLE, self._onUpdateMapsetWhenIdle)
-        self.Bind(
-            EVT_CURRENT_MAPSET_CHANGED, lambda evt: self._updateAfterMapsetChanged()
-        )
+        self.EnableWatchingMapset()
 
     def _resetSelectVariables(self):
         """Reset variables related to item selection."""
@@ -623,6 +618,7 @@ class DataCatalogTree(TreeView):
         self._lastWatchdogUpdate = time
         if (time_diff) < 0.5:
             self._updateMapsetWhenIdle = event_path
+            self.DisableWatchingMapset()
             return
         mapset_path = os.path.dirname(os.path.dirname(os.path.abspath(event_path)))
         location_path = os.path.dirname(os.path.abspath(mapset_path))
@@ -642,8 +638,30 @@ class DataCatalogTree(TreeView):
         If watchdog is active, updating is skipped here
         to avoid double updating.
         """
-        if not watchdog_used:
+        if not (watchdog_used or self._watchingMapsetEnabled):
             self._updateAfterMapsetChanged()
+
+    def DisableWatchingMapset(self):
+        """Disable watching of current mapset folder for changes with watchdog."""
+        if not self._watchingMapsetEnabled:
+            return
+        self._watchingMapsetEnabled = False
+        self.Unbind(EVT_UPDATE_MAPSET)
+        self.Unbind(wx.EVT_IDLE)
+        self.Unbind(EVT_CURRENT_MAPSET_CHANGED)
+
+    def EnableWatchingMapset(self):
+        """Enable watching of current mapset folder for changes with watchdog."""
+        if self._watchingMapsetEnabled:
+            return
+        self._watchingMapsetEnabled = True
+        self.Bind(
+            EVT_UPDATE_MAPSET, lambda evt: self._onWatchdogMapsetReload(evt.src_path)
+        )
+        self.Bind(wx.EVT_IDLE, self._onUpdateMapsetWhenIdle)
+        self.Bind(
+            EVT_CURRENT_MAPSET_CHANGED, lambda evt: self._updateAfterMapsetChanged()
+        )
 
     def GetDbNode(self, grassdb, location=None, mapset=None, map=None, map_type=None):
         """Returns node representing db/location/mapset/map or None if not found."""
@@ -1819,6 +1837,7 @@ class DataCatalogTree(TreeView):
             # instead the watchdog handler takes care of refreshing tree
             if (
                 watchdog_used
+                and self._watchingMapsetEnabled
                 and grassdb == self.current_grassdb_node.data["name"]
                 and location == self.current_location_node.data["name"]
                 and mapset == self.current_mapset_node.data["name"]


### PR DESCRIPTION
This change is specifically done for Tangible Landscape [plugin](https://github.com/tangible-landscape/grass-tangible-landscape), I need to programatically disable processing watchdog events and restart again. It could be done in different places, this approach only removes the bindings, watchdog itself is still running. I didn't expose this anywhere in the GUI itself, I was not sure how useful that would be. If we want that, maybe an option in the context menu might be the least intrusive.