### PR TITLE
docker: Change Debian base image to 12.5-slim

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-20240612-slim@sha256:67f3931ad8cb1967beec602d8c0506af1e37e8d73c2a0b38b181ec5d8560d395
+FROM debian:12.5-slim@sha256:67f3931ad8cb1967beec602d8c0506af1e37e8d73c2a0b38b181ec5d8560d395
 
 # apt-get update && apt-get install lsb-release -y && lsb_release -a
 


### PR DESCRIPTION
The current image is still pinned to an image generated on June 2025. We are not getting new Renovate PRs for it, as the suffix is not recognized as a version. Since we are not pinning the image disgest, we can use a numeric prefix that will be recognized by Renovate. I chose 12.5-slim, instead of bookworm-slim or 12-slim, as I think it is easier to understand what is changed when receiving a PR, that would only contain a digest update otherwise.

Also note that 12.5-slim has the same digest as what we currently have, since it is the exact same image, but with another tag (same build).

After merging, we would unblock PRs for 12.12-slim, and maybe also for the trixie 13.x-slim (a major version, so if our configuration allows it, but I think Ubuntu docker images have some, so it should be enabled)