### PR TITLE
wxGUI/main_window: fix displaying save workspace dialog before close workspace action

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1710,7 +1710,8 @@ class GMFrame(wx.Frame):
 
     def OnWorkspaceClose(self, event=None):
         """Close file with workspace definition"""
-        self.workspace_manager.Close()
+        if self.workspace_manager.CanClosePage(caption=_("Close workspace")):
+            self.workspace_manager.Close()
 
     def OnDisplayClose(self, event=None):
         """Close current map display window"""


### PR DESCRIPTION
When closing workspace action is triggered via main window menu File -> Workspace -> Close. Fixes #6386.