### PR TITLE
v.overlay: fix collapsed lines after snapping

### DIFF
--- a/vector/v.overlay/area_area.c
+++ b/vector/v.overlay/area_area.c
@@ -79,6 +79,8 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
             Vect_select_lines_by_box(Tmp, &box, GV_BOUNDARY, boxlist);
 
             if (boxlist->n_values > 0) {
+                int npoints_org;
+
                 Vect_reset_list(reflist);
                 for (j = 0; j < boxlist->n_values; j++) {
                     int aline = boxlist->id[j];
@@ -90,17 +92,26 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
                 }
 
                 /* snap bline to alines */
+                npoints_org = Points->n_points;
                 if (Vect_snap_line(Tmp, reflist, Points, snap, 0, NULL, NULL)) {
-                    /* rewrite bline */
+                    Vect_line_prune(Points);
+                    if (Points->n_points < 2) {
+                        G_message(_("Line with %d points reduced to %d point, "
+                                    "deleting line."),
+                                  npoints_org, Points->n_points);
+                        Vect_delete_line(Tmp, line);
+                    }
+                    else {
+                        /* rewrite bline */
 #if 0
-                    Vect_delete_line(Tmp, line);
-                    ret = Vect_write_line(Tmp, GV_BOUNDARY, Points, Cats);
-                    G_ilist_add(BList, ret);
+                        Vect_delete_line(Tmp, line);
+                        ret = Vect_write_line(Tmp, GV_BOUNDARY, Points, Cats);
+                        G_ilist_add(BList, ret);
 #else
-                    ret =
-                        Vect_rewrite_line(Tmp, line, GV_BOUNDARY, Points, Cats);
+                        ret = Vect_rewrite_line(Tmp, line, GV_BOUNDARY, Points,
+                                                Cats);
 #endif
-
+                    }
                     snapped_lines++;
                     G_debug(3, "line %d snapped", line);
                 }


### PR DESCRIPTION
`Vect_snap_line()` can reduce lines/boundaries to zero-length lines with only one vertex. Such lines with only one vertex are not supported by `Vect_break_lines_list()`. Deleting these lines/boundaries is apparently safe because adjoining lines/boundaries will be snapped to the same anchor point, preserving topology. This PR adds a check if a line has been collapsed to one vertex and deletes such lines.