### PR TITLE
grass.script: Remove build vars from setup.py

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 from grass.script import core as grass
 from grass.script import task as gtask
-from grass.app.runtime import get_grass_config_dir
+from grass.app.runtime import get_grass_config_dir_for_version
 
 from core.gcmd import RunCommand
 from core.debug import Debug
@@ -798,7 +798,9 @@ vectorFormatExtension = {
 def GetSettingsPath():
     """Get full path to the settings directory"""
     version_major, version_minor, _ = grass.version()["version"].split(".")
-    return get_grass_config_dir(version_major, version_minor, os.environ)
+    return get_grass_config_dir_for_version(
+        version_major, version_minor, env=os.environ
+    )
 
 
 def StoreEnvVariable(key, value=None, envFile=None):

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -85,8 +85,6 @@ if ENCODING is None:
 CMD_NAME = None
 GRASS_VERSION = None
 GRASS_VERSION_MAJOR = None
-GRASS_VERSION_MINOR = None
-LD_LIBRARY_PATH_VAR = None
 CONFIG_PROJSHARE = None
 GRASS_VERSION_GIT = None
 
@@ -380,9 +378,7 @@ def create_grass_config_dir() -> str:
     from grass.app.runtime import get_grass_config_dir
 
     try:
-        directory = get_grass_config_dir(
-            GRASS_VERSION_MAJOR, GRASS_VERSION_MINOR, os.environ
-        )
+        directory = get_grass_config_dir(env=os.environ)
     except (RuntimeError, NotADirectoryError) as e:
         fatal(f"{e}")
 
@@ -2123,8 +2119,6 @@ def main() -> None:
         CMD_NAME, \
         GRASS_VERSION, \
         GRASS_VERSION_MAJOR, \
-        GRASS_VERSION_MINOR, \
-        LD_LIBRARY_PATH_VAR, \
         GRASS_VERSION_GIT, \
         GISBASE, \
         CONFIG_PROJSHARE
@@ -2133,8 +2127,6 @@ def main() -> None:
     CMD_NAME = runtime_paths.grass_exe_name
     GRASS_VERSION = runtime_paths.version
     GRASS_VERSION_MAJOR = runtime_paths.version_major
-    GRASS_VERSION_MINOR = runtime_paths.version_minor
-    LD_LIBRARY_PATH_VAR = runtime_paths.ld_library_path_var
     GRASS_VERSION_GIT = runtime_paths.grass_version_git
     GISBASE = runtime_paths.gisbase
     CONFIG_PROJSHARE = runtime_paths.config_projshare
@@ -2215,7 +2207,6 @@ def main() -> None:
     set_paths(
         install_path=GISBASE,
         grass_config_dir=grass_config_dir,
-        ld_library_path_variable_name=LD_LIBRARY_PATH_VAR,
     )
     # Set GRASS_PAGER, GRASS_PYTHON, GRASS_GNUPLOT, GRASS_PROJSHARE
     set_defaults(config_projshare_path=CONFIG_PROJSHARE)

--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -86,7 +86,14 @@ class RuntimePaths:
         return res
 
 
-def get_grass_config_dir(major_version, minor_version, env):
+def get_grass_config_dir(*, env):
+    paths = RuntimePaths(env=env)
+    return get_grass_config_dir_for_version(
+        paths.version_major, paths.version_minor, env=env
+    )
+
+
+def get_grass_config_dir_for_version(major_version, minor_version, *, env):
     """Get configuration directory
 
     Determines path of GRASS user configuration directory.
@@ -172,19 +179,18 @@ def set_executable_paths(install_path, grass_config_dir, env):
     env["PATH"] = os.pathsep.join(paths)
 
 
-def set_paths(install_path, grass_config_dir, ld_library_path_variable_name):
+def set_paths(install_path, grass_config_dir):
     """Set variables with executable paths, library paths, and other paths"""
     set_executable_paths(
         install_path=install_path, grass_config_dir=grass_config_dir, env=os.environ
     )
-    # Set LD_LIBRARY_PATH (etc) to find GRASS shared libraries
-    # this works for subprocesses but won't affect the current process
-    if ld_library_path_variable_name:
-        set_dynamic_library_path(
-            variable_name=ld_library_path_variable_name,
-            install_path=install_path,
-            env=os.environ,
-        )
+    # Set LD_LIBRARY_PATH (etc) to find GRASS shared libraries.
+    # This works for subprocesses, but won't affect the current process.
+    set_dynamic_library_path(
+        variable_name=res_paths.LD_LIBRARY_PATH_VAR,
+        install_path=install_path,
+        env=os.environ,
+    )
     set_python_path_variable(install_path=install_path, env=os.environ)
 
     # retrieving second time, but now it is always set

--- a/python/grass/script/Makefile
+++ b/python/grass/script/Makefile
@@ -17,15 +17,3 @@ $(DSTDIR):
 
 $(DSTDIR)/%: % | $(DSTDIR)
 	$(INSTALL_DATA) $< $@
-
-EXTRA_CLEAN_FILES = setup.py.tmp
-
-$(DSTDIR)/setup.py: setup.py.tmp | $(DSTDIR)
-	$(INSTALL_DATA) $< $@
-
-setup.py.tmp: setup.py
-	sed \
-	-e 's#@LD_LIBRARY_PATH_VAR@#$(LD_LIBRARY_PATH_VAR)#' \
-	-e 's#@GRASS_VERSION_MAJOR@#$(GRASS_VERSION_MAJOR)#' \
-	-e 's#@GRASS_VERSION_MINOR@#$(GRASS_VERSION_MINOR)#' \
-	$< > $@

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -33,9 +33,8 @@ and session without using grassXY.
         # executable = r'C:\Program Files (x86)\GRASS <version>\grass.bat'
         # this can be skipped if GRASS executable is added to PATH
     elif sys.platform == "darwin":
-        # Mac OS X
-        version = "@GRASS_VERSION_MAJOR@.@GRASS_VERSION_MINOR@"
-        executable = f"/Applications/GRASS-{version}.app/Contents/Resources/bin/grass"
+        # macOS
+        executable = f"/Applications/GRASS-<version>.app/Contents/Resources/bin/grass"
 
     # query GRASS itself for its Python package path
     grass_cmd = [executable, "--config", "python_path"]
@@ -91,9 +90,6 @@ import tempfile as tmpfile
 
 WINDOWS = sys.platform.startswith("win")
 MACOS = sys.platform.startswith("darwin")
-
-VERSION_MAJOR = "@GRASS_VERSION_MAJOR@"
-VERSION_MINOR = "@GRASS_VERSION_MINOR@"
 
 
 def write_gisrc(dbase, location, mapset):
@@ -222,17 +218,18 @@ def setup_runtime_env(gisbase=None, *, env=None):
         set_executable_paths,
         set_path_to_python_executable,
         set_python_path_variable,
+        RuntimePaths,
     )
 
     # Set GISBASE
     env["GISBASE"] = gisbase
     set_executable_paths(
         install_path=gisbase,
-        grass_config_dir=get_grass_config_dir(VERSION_MAJOR, VERSION_MINOR, env=env),
+        grass_config_dir=get_grass_config_dir(env=env),
         env=env,
     )
     set_dynamic_library_path(
-        variable_name="@LD_LIBRARY_PATH_VAR@", install_path=gisbase, env=env
+        variable_name=RuntimePaths().ld_library_path_var, install_path=gisbase, env=env
     )
     set_python_path_variable(install_path=gisbase, env=env)
     set_path_to_python_executable(env=env)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2475,10 +2475,11 @@ def resolve_install_prefix(path, to_system):
         path = os.environ["GISBASE"]
     if path == "$GRASS_ADDON_BASE":
         if not os.getenv("GRASS_ADDON_BASE"):
-            from grass.app.runtime import get_grass_config_dir
+            from grass.app.runtime import get_grass_config_dir_for_version
 
             path = os.path.join(
-                get_grass_config_dir(VERSION[0], VERSION[1], os.environ), "addons"
+                get_grass_config_dir_for_version(VERSION[0], VERSION[1], os.environ),
+                "addons",
             )
             gs.warning(
                 _("GRASS_ADDON_BASE is not defined, installing to {}").format(path)


### PR DESCRIPTION
Remove build vars from setup and use the existing dependency on grass.app.runtime to get the information. Additionally, move some of the parametrization to grass.app.runtime because now, both the functions executing the setup steps and the variable are there, so there is no reason to supply these from the outside.

Config dir does not require version, but I kept a general function there which is used in g.extension and in GUI because these use the runtime-obtained version as opposed to the one from grass.app.runtime (difference between running system and setup of the env).

I removed the build variables from the documentation which makes it a little simpler to edit, although less explicit assuming that the version usage there was actually correct. The example needs more unrelated edits, so I'm keeping it as is.
