### PR TITLE
init: Simply import grass, try harder if it fails

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2085,25 +2085,83 @@ def validate_cmdline(params: Parameters) -> None:
 
 
 def find_grass_python_package() -> None:
-    """Find path to grass package and add it to path"""
+    """Find path to the grass package and add it to path if needed"""
+    # Wheather or not the pre-set path exists, the environment may be just
+    # set up right already. Let's try a basic import first.
+    try:
+        import grass as unused_test_import  # noqa: F401
 
-    # The "@...@" variables are being substituted during build process
+        # The import works without any setup, so there is nothing more to do.
+        return
+    except ImportError:
+        # If the grass package is not on path, we need to add it to path.
+        pass
 
-    if "GRASS_PYDIR" in os.environ and len(os.getenv("GRASS_PYDIR")) > 0:
-        GRASS_PYDIR = os.path.normpath(os.environ["GRASS_PYDIR"])
+    # Try to find the package.
+    path, exists = find_path_to_grass_python_package()
+    if exists:
+        sys.path.append(path)
+        try:
+            # We don't make assumptions about what should be in the directory
+            # and we simply try the actual import.
+            import grass as second_unused_test_import  # noqa: F401
+
+            # If import worked, we did our part.
+            return
+        except ImportError as error:
+            # Existing path provided, but there is some issue with the import.
+            # It may be a wrong path or issue in the package itself.
+            # These strings are not translatable because we can't load translations.
+            msg = (
+                f"The grass Python package cannot be imported from {path}. "
+                "Try setting PYTHONPATH or GRASS_PYDIR to where the grass is."
+            )
+            raise RuntimeError(msg) from error
+    # The path provided by the build or by the user does not exist.
+    msg = (
+        f"{path} with the grass Python package does not exist. "
+        "Is the installation of GRASS complete?"
+    )
+    raise RuntimeError(msg)
+
+
+def find_path_to_grass_python_package() -> tuple[str, bool]:
+    """Returns the most likely path to the grass package.
+
+    It prefers the directory provided by the user in an environmental variable.
+    Otherwise, it uses the build time variable.
+    It falls back to a heuristic based on where this file is located.
+    If that fails, it returns the actual set path
+    (and returns False for existence).
+
+    :return: tuple with path as a string and boolean for existence
+    """
+    env_variable = os.environ.get("GRASS_PYDIR", None)
+    if env_variable:
+        path_from_variable = os.path.normpath(env_variable)
     else:
-        GRASS_PYDIR = os.path.normpath(r"@GRASS_PYDIR@")
+        # The "@...@" variables are being substituted during build process
+        path_from_variable = os.path.normpath(r"@GRASS_PYDIR@")
+    if os.path.exists(path_from_variable):
+        return path_from_variable, True
 
-    if os.path.exists(GRASS_PYDIR):
-        sys.path.append(GRASS_PYDIR)
-        # now we can import stuff from grass package
-    else:
-        # Not translatable because we don't have translations loaded.
-        msg = (
-            "The grass Python package is missing. "
-            "Is the installation of GRASS complete?"
-        )
-        raise RuntimeError(msg)
+    base = Path(__file__).parent.parent / "lib"
+    path_from_context = base / "grass" / "etc" / "python"
+    if os.path.exists(path_from_context):
+        return str(path_from_context), True
+
+    major = "@GRASS_VERSION_MAJOR@"
+    minor = "@GRASS_VERSION_MINOR@"
+    # Try a run-together version number for the directory (long-used standard).
+    path_from_context = base / f"grass{major}{minor}" / "etc" / "python"
+    if os.path.exists(path_from_context):
+        return str(path_from_context), True
+    # Try a dotted version number (more common standard).
+    path_from_context = base / f"grass{major}.{minor}" / "etc" / "python"
+    if os.path.exists(path_from_context):
+        return str(path_from_context), True
+
+    return path_from_variable, False
 
 
 def main() -> None:


### PR DESCRIPTION
Previously, the path with the package was required to exist (both the hardcoded etc/python under GISBASE and FHS variable one). Now, the code first attempts the import and only when the import fails, it tries to work out the path. The simple import should work when FHS is actually used and the grass package is where Python looks for packages (so no GRASS_PYDIR is needed there). It will also work when a user sets up PYTHONPATH manually expecting it will work the same as when setting it before running Python and importing the grass package there (both PYTHONPATH and GRASS_PYDIR will work, but PYTHONPATH will user the Python native mechanics to make the import work, while GRASS_PYDIR needs to use sys.path.append). If GRASS_PYDIR does not work (either the env variable or the one from the build), the code will attempt to find the GISBASE directory relative to the main executable and expects a non-FHS layout (which is reasonable since import should work without any setup with FHS).
