### PR TITLE
docker: Remove scikit-learn from Alpine test

### DIFF
--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -2,9 +2,6 @@
 
 # to be used in alpine Dockerfile
 
-# add dependency
-apk add --no-cache py3-scikit-learn
-
 echo "Testing the GDAL-GRASS plugins:"
 gdalinfo --formats | grep "GRASS Rasters" && \
 ogrinfo --formats | grep "GRASS Vectors" || echo "...failed"
@@ -15,14 +12,11 @@ ogrinfo --formats | grep "GRASS Vectors" || echo "...failed"
 grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test GRASS Python-addon installation
-grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add && \
-   grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+grass --tmp-project XY --exec g.extension extension=r.diversity operation=add && \
+   grass --tmp-project XY --exec g.extension extension=r.diversity operation=remove -f
 
 # Test GRASS C-addon installation: raster and vector
 grass --tmp-project XY --exec g.extension extension=r.gwr operation=add && \
    grass --tmp-project XY --exec g.extension extension=r.gwr operation=remove -f
 grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=add && \
    grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=remove -f
-
-# cleanup dependency
-apk del py3-scikit-learn


### PR DESCRIPTION
The Docker test with Alpine is using scikit-learn, presuably to support the test of installing r.learn.ml2 (which in theory should install without it). This changes the test to use r.diversity instead of r.learn.ml2 which does not come with any dependency, reducing the setup and teardown phases, while still testing installation of a Python tool from grass-addons.
