### PR TITLE
v.surf.idw: improve user messages

### DIFF
--- a/vector/v.surf.idw/main.c
+++ b/vector/v.surf.idw/main.c
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* read the elevation points from the input sites file */
+    /* read the vector points from the input map */
     read_sites(parm.input->answer, parm.dfield->answer, parm.col->answer,
                flag.noindex->answer);
 

--- a/vector/v.surf.idw/read_sites.c
+++ b/vector/v.surf.idw/read_sites.c
@@ -58,13 +58,14 @@ void read_sites(const char *name, const char *field_name, const char *col,
             G_fatal_error(_("Unable to open database <%s> by driver <%s>"),
                           Fi->database, Fi->driver);
 
+        G_message("Using column <%s> for interpolation...", col);
         nrec = db_select_CatValArray(Driver, Fi->table, Fi->key, col, NULL,
                                      &cvarr);
         G_debug(3, "nrec = %d", nrec);
 
         ctype = cvarr.ctype;
         if (ctype != DB_C_TYPE_INT && ctype != DB_C_TYPE_DOUBLE)
-            G_fatal_error(_("Column type not supported"));
+            G_fatal_error(_("Column type of column %s is not numeric"), col);
 
         if (nrec < 0)
             G_fatal_error(_("Unable to select data from table"));

--- a/vector/v.surf.idw/read_sites.c
+++ b/vector/v.surf.idw/read_sites.c
@@ -58,14 +58,14 @@ void read_sites(const char *name, const char *field_name, const char *col,
             G_fatal_error(_("Unable to open database <%s> by driver <%s>"),
                           Fi->database, Fi->driver);
 
-        G_message("Using column <%s> for interpolation...", col);
+        G_verbose_message("Using column <%s> for interpolation...", col);
         nrec = db_select_CatValArray(Driver, Fi->table, Fi->key, col, NULL,
                                      &cvarr);
         G_debug(3, "nrec = %d", nrec);
 
         ctype = cvarr.ctype;
         if (ctype != DB_C_TYPE_INT && ctype != DB_C_TYPE_DOUBLE)
-            G_fatal_error(_("Column type of column %s is not numeric"), col);
+            G_fatal_error(_("Column type of column <%s> is not numeric"), col);
 
         if (nrec < 0)
             G_fatal_error(_("Unable to select data from table"));


### PR DESCRIPTION
This PR adds two messages to inform the user about

- which column is used for interpolation, and
- in case, which column lacks the required numeric type.

(in addition, a confusing code comment is updated)