### PR TITLE
docs: Use backticks as literal in Sphinx

### DIFF
--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -95,7 +95,7 @@ exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-# default_role = None
+default_role = "literal"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/man/sphinx/conf.py
+++ b/man/sphinx/conf.py
@@ -64,7 +64,7 @@ release = "dev"
 exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+default_role = "literal"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -155,7 +155,7 @@ exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-# default_role = None
+default_role = "literal"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True


### PR DESCRIPTION
Set the default role in Sphinx to literal so that backticks (not just double backticks) are interpreted as literal. Now they are interpreted as text in emphasis, but literal aligns that to Markdown use of backticks.

## Background

While backticks mean a different thing in Sphinx/reStructuredText and Markdown, Sphinx can be configured to produce the same thing as a typical Markdown rendering, using the default role. While in another world, having the default role as `py:obj` or `any` would be an interesting option, with all the Markdown around us, having backticks interpreted as literal or code is most advantageous because it removes the issues when switching between Sphinx with reStructuredText for Python and Markdown everywhere else (Doxygen also supports Markdown).

My motivation for this is that @echoix pointed out in #6366 that I may be wrongly assuming what backticks actually do in Python documentation.

## Before

<img width="1015" height="157" alt="image" src="https://github.com/user-attachments/assets/e09b80b0-97b5-43e9-bed2-fa61d88b29c3" />

## After

<img width="1015" height="157" alt="image" src="https://github.com/user-attachments/assets/5f6fc457-aad3-4d70-97e7-4227093e75d4" />

The result is aligned with how Python documentation displays things, at least that's what I was trying to mimic with asterisk (italics) and backticks (monospace) parts.