### PR TITLE
libparson: use the parser wrapper functions everywhere

### DIFF
--- a/db/db.describe/main.c
+++ b/db/db.describe/main.c
@@ -19,7 +19,7 @@
 #include <grass/gis.h>
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 struct {
@@ -49,16 +49,16 @@ int main(int argc, char **argv)
     parse_command_line(argc, argv);
 
     if (parms.format == JSON) {
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_object = json_object(root_value);
-        cols_value = json_value_init_array();
+        root_object = G_json_object(root_value);
+        cols_value = G_json_value_init_array();
         if (cols_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        cols_array = json_array(cols_value);
+        cols_array = G_json_array(cols_value);
     }
 
     if (!db_table_exists(parms.driver, parms.database, parms.table)) {
@@ -100,8 +100,8 @@ int main(int argc, char **argv)
             fprintf(stdout, "nrows: %d\n", nrows);
             break;
         case JSON:
-            json_object_set_number(root_object, "ncols", ncols);
-            json_object_set_number(root_object, "nrows", nrows);
+            G_json_object_set_number(root_object, "ncols", ncols);
+            G_json_object_set_number(root_object, "nrows", nrows);
             break;
         }
 
@@ -116,32 +116,32 @@ int main(int argc, char **argv)
                         db_get_column_length(column));
                 break;
             case JSON:
-                col_value = json_value_init_object();
-                col_object = json_object(col_value);
-                json_object_set_number(col_object, "position", col + 1);
-                json_object_set_string(col_object, "name",
-                                       db_get_column_name(column));
-                json_object_set_string(
+                col_value = G_json_value_init_object();
+                col_object = G_json_object(col_value);
+                G_json_object_set_number(col_object, "position", col + 1);
+                G_json_object_set_string(col_object, "name",
+                                         db_get_column_name(column));
+                G_json_object_set_string(
                     col_object, "type",
                     db_sqltype_name(db_get_column_sqltype(column)));
-                json_object_set_number(col_object, "length",
-                                       db_get_column_length(column));
-                json_array_append_value(cols_array, col_value);
+                G_json_object_set_number(col_object, "length",
+                                         db_get_column_length(column));
+                G_json_array_append_value(cols_array, col_value);
                 break;
             }
         }
     }
 
     if (parms.format == JSON) {
-        json_object_set_value(root_object, "columns", cols_value);
+        G_json_object_set_value(root_object, "columns", cols_value);
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     db_close_database(driver);

--- a/db/db.describe/printtab.c
+++ b/db/db.describe/printtab.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/dbmi.h>
 #include "local_proto.h"
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 int print_table_definition(dbDriver *driver, dbTable *table,
                            enum OutputFormat format, JSON_Object *root_object,
@@ -18,9 +18,10 @@ int print_table_definition(dbDriver *driver, dbTable *table,
         fprintf(stdout, "description:%s\n", db_get_table_description(table));
         break;
     case JSON:
-        json_object_set_string(root_object, "table", db_get_table_name(table));
-        json_object_set_string(root_object, "description",
-                               db_get_table_description(table));
+        G_json_object_set_string(root_object, "table",
+                                 db_get_table_name(table));
+        G_json_object_set_string(root_object, "description",
+                                 db_get_table_description(table));
         break;
     }
 
@@ -40,8 +41,8 @@ int print_table_definition(dbDriver *driver, dbTable *table,
         fprintf(stdout, "nrows:%d\n", nrows);
         break;
     case JSON:
-        json_object_set_number(root_object, "ncols", ncols);
-        json_object_set_number(root_object, "nrows", nrows);
+        G_json_object_set_number(root_object, "ncols", ncols);
+        G_json_object_set_number(root_object, "nrows", nrows);
         break;
     }
 
@@ -82,38 +83,38 @@ int print_column_definition(dbColumn *column, int position,
                 db_test_column_null_allowed(column) ? "yes" : "no");
         break;
     case JSON:
-        col_value = json_value_init_object();
-        col_object = json_object(col_value);
-        json_object_set_number(col_object, "position", position);
-        json_object_set_string(col_object, "column",
-                               db_get_column_name(column));
-        json_object_set_string(col_object, "description",
-                               db_get_column_description(column));
-        json_object_set_string(col_object, "type",
-                               db_sqltype_name(db_get_column_sqltype(column)));
-        json_object_set_number(col_object, "length",
-                               db_get_column_length(column));
-        json_object_set_number(col_object, "scale",
-                               db_get_column_scale(column));
-        json_object_set_number(col_object, "precision",
-                               db_get_column_precision(column));
+        col_value = G_json_value_init_object();
+        col_object = G_json_object(col_value);
+        G_json_object_set_number(col_object, "position", position);
+        G_json_object_set_string(col_object, "column",
+                                 db_get_column_name(column));
+        G_json_object_set_string(col_object, "description",
+                                 db_get_column_description(column));
+        G_json_object_set_string(
+            col_object, "type", db_sqltype_name(db_get_column_sqltype(column)));
+        G_json_object_set_number(col_object, "length",
+                                 db_get_column_length(column));
+        G_json_object_set_number(col_object, "scale",
+                                 db_get_column_scale(column));
+        G_json_object_set_number(col_object, "precision",
+                                 db_get_column_precision(column));
         if (db_test_column_has_default_value(column)) {
             db_init_string(&value_string);
             db_convert_column_default_value_to_string(column, &value_string);
-            json_object_set_string(col_object, "default",
-                                   db_get_string(&value_string));
+            G_json_object_set_string(col_object, "default",
+                                     db_get_string(&value_string));
         }
         else {
-            json_object_set_null(col_object, "default");
+            G_json_object_set_null(col_object, "default");
         }
-        json_object_set_boolean(col_object, "nullok",
-                                db_test_column_null_allowed(column));
+        G_json_object_set_boolean(col_object, "nullok",
+                                  db_test_column_null_allowed(column));
         break;
     }
     print_priv("select", db_get_column_select_priv(column), format, col_object);
     print_priv("update", db_get_column_update_priv(column), format, col_object);
     if (format == JSON) {
-        json_array_append_value(cols_array, col_value);
+        G_json_array_append_value(cols_array, col_value);
     }
 
     return 0;
@@ -141,13 +142,13 @@ int print_priv(char *label, int priv, enum OutputFormat format,
     case JSON:
         switch (priv) {
         case DB_GRANTED:
-            json_object_set_boolean(root_object, label, 1);
+            G_json_object_set_boolean(root_object, label, 1);
             break;
         case DB_NOT_GRANTED:
-            json_object_set_boolean(root_object, label, 0);
+            G_json_object_set_boolean(root_object, label, 0);
             break;
         default:
-            json_object_set_null(root_object, label);
+            G_json_object_set_null(root_object, label);
             break;
         }
         break;

--- a/general/g.mapset/main.c
+++ b/general/g.mapset/main.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/spawn.h>
 
 enum OutputFormat { PLAIN, JSON };
@@ -31,15 +31,15 @@ enum OutputFormat { PLAIN, JSON };
 // Function to serialize and print JSON value
 static void serialize_and_print_json_object(JSON_Value *root_value)
 {
-    char *serialized_string = json_serialize_to_string_pretty(root_value);
+    char *serialized_string = G_json_serialize_to_string_pretty(root_value);
     if (!serialized_string) {
-        json_value_free(root_value);
+        G_json_value_free(root_value);
         G_fatal_error(_("Failed to serialize JSON to pretty format."));
     }
 
     puts(serialized_string);
-    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(root_value);
 }
 
 int main(int argc, char *argv[])
@@ -112,12 +112,12 @@ int main(int argc, char *argv[])
     if (strcmp(opt.format->answer, "json") == 0) {
         format = JSON;
 
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        root_object = json_object(root_value);
+        root_object = G_json_object(root_value);
     }
     else {
         format = PLAIN;
@@ -135,8 +135,8 @@ int main(int argc, char *argv[])
             break;
 
         case JSON:
-            json_object_set_string(root_object, "project", location_old);
-            json_object_set_string(root_object, "mapset", mapset_old);
+            G_json_object_set_string(root_object, "project", location_old);
+            G_json_object_set_string(root_object, "mapset", mapset_old);
             serialize_and_print_json_object(root_value);
             break;
         }
@@ -168,14 +168,14 @@ int main(int argc, char *argv[])
 
         ms = G_get_available_mapsets();
         if (format == JSON) {
-            mapsets_value = json_value_init_array();
+            mapsets_value = G_json_value_init_array();
             if (mapsets_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON array. Out of memory?"));
             }
-            mapsets_array = json_array(mapsets_value);
+            mapsets_array = G_json_array(mapsets_value);
 
-            json_object_set_string(root_object, "project", location_new);
+            G_json_object_set_string(root_object, "project", location_new);
         }
 
         for (nmapsets = 0; ms[nmapsets]; nmapsets++) {
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
                     break;
 
                 case JSON:
-                    json_array_append_string(mapsets_array, ms[nmapsets]);
+                    G_json_array_append_string(mapsets_array, ms[nmapsets]);
                     break;
                 }
             }
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
             break;
 
         case JSON:
-            json_object_set_value(root_object, "mapsets", mapsets_value);
+            G_json_object_set_value(root_object, "mapsets", mapsets_value);
             serialize_and_print_json_object(root_value);
             break;
         }

--- a/general/g.mapsets/list.c
+++ b/general/g.mapsets/list.c
@@ -3,22 +3,22 @@
 #include <grass/gis.h>
 #include <grass/glocale.h>
 #include "local_proto.h"
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 // Function to initialize a JSON object with a mapsets array
 static JSON_Object *initialize_json_object(void)
 {
-    JSON_Value *root_value = json_value_init_object();
+    JSON_Value *root_value = G_json_value_init_object();
     if (!root_value) {
         G_fatal_error(_("Failed to initialize JSON object. Out of memory?"));
     }
 
-    JSON_Object *root_object = json_value_get_object(root_value);
-    json_object_set_value(root_object, "mapsets", json_value_init_array());
+    JSON_Object *root_object = G_json_value_get_object(root_value);
+    G_json_object_set_value(root_object, "mapsets", G_json_value_init_array());
 
-    JSON_Array *mapsets = json_object_get_array(root_object, "mapsets");
+    JSON_Array *mapsets = G_json_object_get_array(root_object, "mapsets");
     if (!mapsets) {
-        json_value_free(root_value);
+        G_json_value_free(root_value);
         G_fatal_error(_("Failed to initialize mapsets array. Out of memory?"));
     }
 
@@ -28,15 +28,15 @@ static JSON_Object *initialize_json_object(void)
 // Function to serialize and print JSON object
 static void serialize_and_print_json_object(JSON_Value *root_value)
 {
-    char *serialized_string = json_serialize_to_string_pretty(root_value);
+    char *serialized_string = G_json_serialize_to_string_pretty(root_value);
     if (!serialized_string) {
-        json_value_free(root_value);
+        G_json_value_free(root_value);
         G_fatal_error(_("Failed to serialize JSON to pretty format."));
     }
 
     fprintf(stdout, "%s\n", serialized_string);
-    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(root_value);
 }
 
 void list_available_mapsets(const char **mapset_name, int nmapsets,
@@ -74,26 +74,26 @@ void list_accessible_mapsets_json(void)
 {
     const char *name;
     JSON_Object *root_object = initialize_json_object();
-    JSON_Array *mapsets = json_object_get_array(root_object, "mapsets");
+    JSON_Array *mapsets = G_json_object_get_array(root_object, "mapsets");
 
     for (int n = 0; (name = G_get_mapset_name(n)); n++) {
-        json_array_append_string(mapsets, name);
+        G_json_array_append_string(mapsets, name);
     }
 
     serialize_and_print_json_object(
-        json_object_get_wrapping_value(root_object));
+        G_json_object_get_wrapping_value(root_object));
 }
 
 // Lists available mapsets from a provided array in JSON format
 void list_avaliable_mapsets_json(const char **mapset_names, int nmapsets)
 {
     JSON_Object *root_object = initialize_json_object();
-    JSON_Array *mapsets = json_object_get_array(root_object, "mapsets");
+    JSON_Array *mapsets = G_json_object_get_array(root_object, "mapsets");
 
     for (int n = 0; n < nmapsets; n++) {
-        json_array_append_string(mapsets, mapset_names[n]);
+        G_json_array_append_string(mapsets, mapset_names[n]);
     }
 
     serialize_and_print_json_object(
-        json_object_get_wrapping_value(root_object));
+        G_json_object_get_wrapping_value(root_object));
 }

--- a/general/g.proj/output.c
+++ b/general/g.proj/output.c
@@ -21,7 +21,7 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 #include <grass/config.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 #ifdef HAVE_OGR
 #include <cpl_csv.h>
@@ -48,12 +48,12 @@ void print_projinfo(enum OutputFormat format)
             stdout,
             "-PROJ_INFO-------------------------------------------------\n");
     else if (format == JSON) {
-        value = json_value_init_object();
+        value = G_json_value_init_object();
         if (value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        object = json_object(value);
+        object = G_json_object(value);
     }
 
     for (i = 0; i < projinfo->nitems; i++) {
@@ -68,8 +68,8 @@ void print_projinfo(enum OutputFormat format)
                     projinfo->value[i]);
             break;
         case JSON:
-            json_object_set_string(object, projinfo->key[i],
-                                   projinfo->value[i]);
+            G_json_object_set_string(object, projinfo->key[i],
+                                     projinfo->value[i]);
             break;
         case PROJ4:
         case WKT:
@@ -89,7 +89,7 @@ void print_projinfo(enum OutputFormat format)
             fprintf(stdout, "%s=%s\n", "srid", projsrid);
             break;
         case JSON:
-            json_object_set_string(object, "srid", projsrid);
+            G_json_object_set_string(object, "srid", projsrid);
             break;
         case PROJ4:
         case WKT:
@@ -112,8 +112,8 @@ void print_projinfo(enum OutputFormat format)
                         projunits->value[i]);
                 break;
             case JSON:
-                json_object_set_string(object, projunits->key[i],
-                                       projunits->value[i]);
+                G_json_object_set_string(object, projunits->key[i],
+                                         projunits->value[i]);
                 break;
             case PROJ4:
             case WKT:
@@ -354,14 +354,14 @@ static int check_xy(enum OutputFormat format)
             fprintf(stdout, "XY location (unprojected)\n");
             break;
         case JSON:
-            value = json_value_init_object();
+            value = G_json_value_init_object();
             if (value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON object. Out of memory?"));
             }
-            object = json_object(value);
+            object = G_json_object(value);
 
-            json_object_set_string(object, "name", "xy_location_unprojected");
+            G_json_object_set_string(object, "name", "xy_location_unprojected");
 
             print_json(value);
             break;
@@ -377,12 +377,12 @@ static int check_xy(enum OutputFormat format)
 
 void print_json(JSON_Value *value)
 {
-    char *serialized_string = json_serialize_to_string_pretty(value);
+    char *serialized_string = G_json_serialize_to_string_pretty(value);
     if (serialized_string == NULL) {
         G_fatal_error(_("Failed to initialize pretty JSON string."));
     }
     puts(serialized_string);
 
-    json_free_serialized_string(serialized_string);
-    json_value_free(value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(value);
 }

--- a/general/g.region/main.c
+++ b/general/g.region/main.c
@@ -21,7 +21,7 @@
 #include <grass/raster.h>
 #include <grass/raster3d.h>
 #include <grass/vector.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/glocale.h>
 #include "local_proto.h"
 
@@ -465,12 +465,12 @@ int main(int argc, char *argv[])
 
     if (strcmp(parm.format->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        root_object = json_object(root_value);
+        root_object = G_json_object(root_value);
     }
     else if (strcmp(parm.format->answer, "shell") == 0 ||
              (print_flag & PRINT_SH)) {
@@ -985,13 +985,13 @@ int main(int argc, char *argv[])
 
     if (format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     exit(EXIT_SUCCESS);

--- a/general/g.region/printwindow.c
+++ b/general/g.region/printwindow.c
@@ -258,40 +258,40 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
 #endif
             break;
         case JSON:
-            json_object_set_number(root_object, "north", window->north);
-            json_object_set_number(root_object, "south", window->south);
-            json_object_set_number(root_object, "west", window->west);
-            json_object_set_number(root_object, "east", window->east);
-            json_object_set_number(root_object, "nsres", d_nsres);
-            json_object_set_number(root_object, "ewres", d_ewres);
-            json_object_set_number(root_object, "rows", window->rows);
-            json_object_set_number(root_object, "cols", window->cols);
+            G_json_object_set_number(root_object, "north", window->north);
+            G_json_object_set_number(root_object, "south", window->south);
+            G_json_object_set_number(root_object, "west", window->west);
+            G_json_object_set_number(root_object, "east", window->east);
+            G_json_object_set_number(root_object, "nsres", d_nsres);
+            G_json_object_set_number(root_object, "ewres", d_ewres);
+            G_json_object_set_number(root_object, "rows", window->rows);
+            G_json_object_set_number(root_object, "cols", window->cols);
 
             if (print_flag & PRINT_3D) {
-                json_object_set_number(root_object, "nsres3", d_nsres3);
-                json_object_set_number(root_object, "ewres3", d_ewres3);
-                json_object_set_number(root_object, "top", window->top);
-                json_object_set_number(root_object, "bottom", window->bottom);
-                json_object_set_number(root_object, "rows3", window->rows3);
-                json_object_set_number(root_object, "cols3", window->cols3);
-                json_object_set_number(root_object, "tbres", d_tbres);
-                json_object_set_number(root_object, "depths", window->depths);
+                G_json_object_set_number(root_object, "nsres3", d_nsres3);
+                G_json_object_set_number(root_object, "ewres3", d_ewres3);
+                G_json_object_set_number(root_object, "top", window->top);
+                G_json_object_set_number(root_object, "bottom", window->bottom);
+                G_json_object_set_number(root_object, "rows3", window->rows3);
+                G_json_object_set_number(root_object, "cols3", window->cols3);
+                G_json_object_set_number(root_object, "tbres", d_tbres);
+                G_json_object_set_number(root_object, "depths", window->depths);
             }
 
 #ifdef HAVE_LONG_LONG_INT
-            json_object_set_number(root_object, "cells",
-                                   (long long)window->rows * window->cols);
+            G_json_object_set_number(root_object, "cells",
+                                     (long long)window->rows * window->cols);
             if (print_flag & PRINT_3D)
-                json_object_set_number(root_object, "cells3",
-                                       (long long)window->rows3 *
-                                           window->cols3 * window->depths);
+                G_json_object_set_number(root_object, "cells3",
+                                         (long long)window->rows3 *
+                                             window->cols3 * window->depths);
 #else
-            json_object_set_number(root_object, "cells",
-                                   (long)window->rows * window->cols);
+            G_json_object_set_number(root_object, "cells",
+                                     (long)window->rows * window->cols);
             if (print_flag & PRINT_3D)
-                json_object_set_number(root_object, "cells3",
-                                       (long)window->rows3 * window->cols3 *
-                                           window->depths);
+                G_json_object_set_number(root_object, "cells3",
+                                         (long)window->rows3 * window->cols3 *
+                                             window->depths);
 #endif
             break;
         }
@@ -444,16 +444,16 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
                 fprintf(stdout, "%-*s %11s\n", width, "center latitude:", buf);
                 break;
             case JSON:
-                json_object_set_number(root_object, "nw_long", lo1);
-                json_object_set_number(root_object, "nw_lat", la1);
-                json_object_set_number(root_object, "ne_long", lo2);
-                json_object_set_number(root_object, "ne_lat", la2);
-                json_object_set_number(root_object, "se_long", lo3);
-                json_object_set_number(root_object, "se_lat", la3);
-                json_object_set_number(root_object, "sw_long", lo4);
-                json_object_set_number(root_object, "sw_lat", la4);
-                json_object_set_number(root_object, "center_long", loc);
-                json_object_set_number(root_object, "center_lat", lac);
+                G_json_object_set_number(root_object, "nw_long", lo1);
+                G_json_object_set_number(root_object, "nw_lat", la1);
+                G_json_object_set_number(root_object, "ne_long", lo2);
+                G_json_object_set_number(root_object, "ne_lat", la2);
+                G_json_object_set_number(root_object, "se_long", lo3);
+                G_json_object_set_number(root_object, "se_lat", la3);
+                G_json_object_set_number(root_object, "sw_long", lo4);
+                G_json_object_set_number(root_object, "sw_lat", la4);
+                G_json_object_set_number(root_object, "center_long", loc);
+                G_json_object_set_number(root_object, "center_lat", lac);
                 break;
             }
 
@@ -468,8 +468,8 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
                     fprintf(stdout, "%-*s %d\n", width, "cols:", window->cols);
                     break;
                 case JSON:
-                    json_object_set_number(root_object, "rows", window->rows);
-                    json_object_set_number(root_object, "cols", window->cols);
+                    G_json_object_set_number(root_object, "rows", window->rows);
+                    G_json_object_set_number(root_object, "cols", window->cols);
                     break;
                 }
             }
@@ -511,10 +511,10 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
             }
             break;
         case JSON:
-            json_object_set_number(root_object, "ns_extent",
-                                   window->north - window->south);
-            json_object_set_number(root_object, "ew_extent",
-                                   window->east - window->west);
+            G_json_object_set_number(root_object, "ns_extent",
+                                     window->north - window->south);
+            G_json_object_set_number(root_object, "ew_extent",
+                                     window->east - window->west);
             break;
         }
     }
@@ -545,10 +545,10 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
             }
             break;
         case JSON:
-            json_object_set_number(root_object, "center_easting",
-                                   (window->west + window->east) / 2.);
-            json_object_set_number(root_object, "center_northing",
-                                   (window->north + window->south) / 2.);
+            G_json_object_set_number(root_object, "center_easting",
+                                     (window->west + window->east) / 2.);
+            G_json_object_set_number(root_object, "center_northing",
+                                     (window->north + window->south) / 2.);
             break;
         }
     }
@@ -559,7 +559,7 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
         switch (format) {
         case JSON:
             snprintf(gmt, 120, "%s/%s/%s/%s", west, east, south, north);
-            json_object_set_string(root_object, "GMT", gmt);
+            G_json_object_set_string(root_object, "GMT", gmt);
             break;
         default:
             fprintf(stdout, "%s/%s/%s/%s\n", west, east, south, north);
@@ -573,7 +573,7 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
         switch (format) {
         case JSON:
             snprintf(wms, 150, "bbox=%s,%s,%s,%s", west, south, east, north);
-            json_object_set_string(root_object, "WMS", wms);
+            G_json_object_set_string(root_object, "WMS", wms);
             break;
         default:
             G_format_northing(window->north, north, -1);
@@ -667,7 +667,8 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
                     "convergence angle:", convergence);
             break;
         case JSON:
-            json_object_set_number(root_object, "converge_angle", convergence);
+            G_json_object_set_number(root_object, "converge_angle",
+                                     convergence);
         }
     }
 
@@ -873,14 +874,14 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
                 fprintf(stdout, "%-*s  %s\n", width, "center latitude:", buf);
                 break;
             case JSON:
-                json_object_set_number(root_object, "ll_n", sh_ll_n);
-                json_object_set_number(root_object, "ll_s", sh_ll_s);
-                json_object_set_number(root_object, "ll_w", sh_ll_w);
-                json_object_set_number(root_object, "ll_e", sh_ll_e);
+                G_json_object_set_number(root_object, "ll_n", sh_ll_n);
+                G_json_object_set_number(root_object, "ll_s", sh_ll_s);
+                G_json_object_set_number(root_object, "ll_w", sh_ll_w);
+                G_json_object_set_number(root_object, "ll_e", sh_ll_e);
                 /* center of the largest bounding box */
-                json_object_set_number(root_object, "ll_clon", loc);
-                json_object_set_number(root_object, "ll_clat",
-                                       (sh_ll_n + sh_ll_s) / 2.);
+                G_json_object_set_number(root_object, "ll_clon", loc);
+                G_json_object_set_number(root_object, "ll_clat",
+                                         (sh_ll_n + sh_ll_s) / 2.);
             }
 
             /*It should be calculated which number of rows and cols we have in

--- a/lib/external/parson/gjson.c
+++ b/lib/external/parson/gjson.c
@@ -16,6 +16,7 @@
  *****************************************************************************/
 
 #include "gjson.h"
+#include "parson.h"
 
 /* *************************************************************** */
 /* ***** WRAPPER FOR PARSON FUNCTIONS USED IN GRASS ************** */
@@ -38,7 +39,7 @@ JSON_Object *G_json_value_get_object(const JSON_Value *value)
 
 JSON_Object *G_json_object(const JSON_Value *value)
 {
-    return json_object(value);
+    return G_json_object(value);
 }
 JSON_Object *G_json_object_get_object(const JSON_Object *object,
                                       const char *name)
@@ -114,7 +115,7 @@ double G_json_object_dotget_number(JSON_Object *object, const char *name)
 }
 JSON_Array *G_json_array(const JSON_Value *value)
 {
-    return json_array(value);
+    return G_json_array(value);
 }
 JSON_Value *G_json_array_get_value(const JSON_Array *array, size_t index)
 {
@@ -156,6 +157,11 @@ JSON_Status G_json_array_append_boolean(JSON_Array *array, int boolean)
 JSON_Status G_json_array_append_null(JSON_Array *array)
 {
     return json_array_append_null(array);
+}
+
+void G_json_set_float_serialization_format(const char *format)
+{
+    json_set_float_serialization_format(format);
 }
 
 char *G_json_serialize_to_string_pretty(const JSON_Value *value)

--- a/lib/external/parson/gjson.h
+++ b/lib/external/parson/gjson.h
@@ -48,6 +48,7 @@ extern JSON_Status G_json_array_append_number(JSON_Array *, double);
 extern JSON_Status G_json_array_append_boolean(JSON_Array *, int);
 extern JSON_Status G_json_array_append_null(JSON_Array *);
 
+extern void G_json_set_float_serialization_format(const char *format);
 extern char *G_json_serialize_to_string_pretty(const JSON_Value *);
 extern void G_json_free_serialized_string(char *);
 extern void G_json_value_free(JSON_Value *);

--- a/raster/r.category/main.c
+++ b/raster/r.category/main.c
@@ -23,7 +23,7 @@
 #include <grass/colors.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 static struct Categories cats;
@@ -138,11 +138,11 @@ int main(int argc, char *argv[])
     }
     if (parm.format->answer && strcmp(parm.format->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_array();
+        root_value = G_json_value_init_array();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_array = json_array(root_value);
+        root_array = G_json_array(root_value);
     }
     else {
         format = PLAIN;
@@ -407,13 +407,13 @@ int main(int argc, char *argv[])
 void print_json(JSON_Value *root_value)
 {
     char *serialized_string = NULL;
-    serialized_string = json_serialize_to_string_pretty(root_value);
+    serialized_string = G_json_serialize_to_string_pretty(root_value);
     if (serialized_string == NULL) {
         G_fatal_error(_("Failed to initialize pretty JSON string."));
     }
     puts(serialized_string);
-    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(root_value);
 }
 
 int print_label(long x, enum OutputFormat format, JSON_Array *root_array,
@@ -437,24 +437,24 @@ int print_label(long x, enum OutputFormat format, JSON_Array *root_array,
         fprintf(stdout, "\n");
         break;
     case JSON:
-        category_value = json_value_init_object();
-        category = json_object(category_value);
-        json_object_set_number(category, "category", x);
+        category_value = G_json_value_init_object();
+        category = G_json_object(category_value);
+        G_json_object_set_number(category, "category", x);
         if (strlen(label) == 0) {
-            json_object_set_null(category, "label");
+            G_json_object_set_null(category, "label");
         }
         else {
-            json_object_set_string(category, "label", label);
+            G_json_object_set_string(category, "label", label);
         }
         if (color_format != NONE) {
             if (strcmp(color, "*") == 0) {
-                json_object_set_null(category, "color");
+                G_json_object_set_null(category, "color");
             }
             else {
-                json_object_set_string(category, "color", color);
+                G_json_object_set_string(category, "color", color);
             }
         }
-        json_array_append_value(root_array, category_value);
+        G_json_array_append_value(root_array, category_value);
         break;
     }
 
@@ -486,24 +486,24 @@ int print_d_label(double x, enum OutputFormat format, JSON_Array *root_array,
         fprintf(stdout, "\n");
         break;
     case JSON:
-        category_value = json_value_init_object();
-        category = json_object(category_value);
-        json_object_set_number(category, "category", x);
+        category_value = G_json_value_init_object();
+        category = G_json_object(category_value);
+        G_json_object_set_number(category, "category", x);
         if (strlen(label) == 0) {
-            json_object_set_null(category, "label");
+            G_json_object_set_null(category, "label");
         }
         else {
-            json_object_set_string(category, "label", label);
+            G_json_object_set_string(category, "label", label);
         }
         if (color_format != NONE) {
             if (strcmp(color, "*") == 0) {
-                json_object_set_null(category, "color");
+                G_json_object_set_null(category, "color");
             }
             else {
-                json_object_set_string(category, "color", color);
+                G_json_object_set_string(category, "color", color);
             }
         }
-        json_array_append_value(root_array, category_value);
+        G_json_array_append_value(root_array, category_value);
         break;
     }
 

--- a/raster/r.describe/dumplist.c
+++ b/raster/r.describe/dumplist.c
@@ -32,21 +32,21 @@ static int show(CELL, CELL, int *, DCELL, DCELL, RASTER_MAP_TYPE, int,
 static void initialize_json_object(JSON_Value **root_value,
                                    JSON_Object **root_object)
 {
-    *root_value = json_value_init_object();
+    *root_value = G_json_value_init_object();
     if (*root_value == NULL) {
         G_fatal_error(_("Failed to initialize JSON object. Out of memory?"));
     }
-    *root_object = json_object(*root_value);
+    *root_object = G_json_object(*root_value);
 }
 
 static void initialize_json_array(JSON_Value **root_value,
                                   JSON_Array **root_array)
 {
-    *root_value = json_value_init_array();
+    *root_value = G_json_value_init_array();
     if (*root_value == NULL) {
         G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
     }
-    *root_array = json_array(*root_value);
+    *root_array = G_json_array(*root_value);
 }
 
 static void append_category_ranges(JSON_Array *range_array, long min, long max)
@@ -55,23 +55,23 @@ static void append_category_ranges(JSON_Array *range_array, long min, long max)
     JSON_Value *cat_value;
     initialize_json_object(&cat_value, &cat_object);
 
-    json_object_set_number(cat_object, "min", min);
-    json_object_set_number(cat_object, "max", max);
+    G_json_object_set_number(cat_object, "min", min);
+    G_json_object_set_number(cat_object, "max", max);
 
-    json_array_append_value(range_array, cat_value);
+    G_json_array_append_value(range_array, cat_value);
 }
 
 static void output_pretty_json(JSON_Value *root_value)
 {
-    char *serialized_string = json_serialize_to_string_pretty(root_value);
+    char *serialized_string = G_json_serialize_to_string_pretty(root_value);
     if (!serialized_string) {
-        json_value_free(root_value);
+        G_json_value_free(root_value);
         G_fatal_error(_("Failed to initialize pretty JSON string."));
     }
     puts(serialized_string);
 
-    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(root_value);
 }
 
 int long_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
@@ -97,13 +97,13 @@ int long_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
                 fprintf(stdout, "%s\n", no_data_str);
                 break;
             case JSON:
-                json_object_set_boolean(root_object, "has_nulls", true);
+                G_json_object_set_boolean(root_object, "has_nulls", true);
                 break;
             }
         }
         else {
             if (format == JSON) {
-                json_object_set_boolean(root_object, "has_nulls", false);
+                G_json_object_set_boolean(root_object, "has_nulls", false);
             }
         }
     }
@@ -124,17 +124,17 @@ int long_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
                 JSON_Value *cat_value;
                 initialize_json_object(&cat_value, &cat_object);
 
-                json_object_set_number(cat_object, "min",
-                                       dmin + (double)(cat - 1) *
-                                                  (dmax - dmin) / nsteps);
-                json_object_set_number(cat_object, "max",
-                                       dmin + (double)cat * (dmax - dmin) /
-                                                  nsteps);
+                G_json_object_set_number(cat_object, "min",
+                                         dmin + (double)(cat - 1) *
+                                                    (dmax - dmin) / nsteps);
+                G_json_object_set_number(cat_object, "max",
+                                         dmin + (double)cat * (dmax - dmin) /
+                                                    nsteps);
 
-                json_array_append_value(range_array, cat_value);
+                G_json_array_append_value(range_array, cat_value);
             }
             else {
-                json_array_append_number(range_array, (long)cat);
+                G_json_array_append_number(range_array, (long)cat);
             }
 
             break;
@@ -143,10 +143,10 @@ int long_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
 
     if (format == JSON) {
         if (map_type != CELL_TYPE) {
-            json_object_set_value(root_object, "ranges", range_value);
+            G_json_object_set_value(root_object, "ranges", range_value);
         }
         else {
-            json_object_set_value(root_object, "values", range_value);
+            G_json_object_set_value(root_object, "values", range_value);
         }
 
         output_pretty_json(root_value);
@@ -180,13 +180,13 @@ int compact_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
                 fprintf(stdout, "%s ", no_data_str);
                 break;
             case JSON:
-                json_object_set_boolean(root_object, "has_nulls", true);
+                G_json_object_set_boolean(root_object, "has_nulls", true);
                 break;
             }
         }
         else {
             if (format == JSON) {
-                json_object_set_boolean(root_object, "has_nulls", false);
+                G_json_object_set_boolean(root_object, "has_nulls", false);
             }
         }
     }
@@ -211,7 +211,7 @@ int compact_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
         fprintf(stdout, "\n");
         break;
     case JSON:
-        json_object_set_value(root_object, "ranges", range_value);
+        G_json_object_set_value(root_object, "ranges", range_value);
         output_pretty_json(root_value);
         break;
     }
@@ -246,10 +246,10 @@ static int show(CELL low, CELL high, int *len, DCELL dmin, DCELL dmax,
                      dmin + high * (dmax - dmin) / nsteps);
             break;
         case JSON:
-            json_object_set_number(cat_object, "min",
-                                   dmin + (low - 1) * (dmax - dmin) / nsteps);
-            json_object_set_number(cat_object, "max",
-                                   dmin + high * (dmax - dmin) / nsteps);
+            G_json_object_set_number(cat_object, "min",
+                                     dmin + (low - 1) * (dmax - dmin) / nsteps);
+            G_json_object_set_number(cat_object, "max",
+                                     dmin + high * (dmax - dmin) / nsteps);
             break;
         }
     }
@@ -263,8 +263,8 @@ static int show(CELL low, CELL high, int *len, DCELL dmin, DCELL dmax,
                          low < 0 ? " thru " : "-", (long)high);
             break;
         case JSON:
-            json_object_set_number(cat_object, "min", (long)low);
-            json_object_set_number(cat_object, "max", (long)high);
+            G_json_object_set_number(cat_object, "min", (long)low);
+            G_json_object_set_number(cat_object, "max", (long)high);
             break;
         }
     }
@@ -281,7 +281,7 @@ static int show(CELL low, CELL high, int *len, DCELL dmin, DCELL dmax,
         fprintf(stdout, "%s", text);
         break;
     case JSON:
-        json_array_append_value(root_array, cat_value);
+        G_json_array_append_value(root_array, cat_value);
         break;
     }
 
@@ -346,19 +346,19 @@ int compact_range_list(CELL negmin, CELL negmax, CELL zero, CELL posmin,
                 fprintf(stdout, "%s\n", no_data_str);
                 break;
             case JSON:
-                json_object_set_boolean(root_object, "has_nulls", true);
+                G_json_object_set_boolean(root_object, "has_nulls", true);
                 break;
             }
         }
         else {
             if (format == JSON) {
-                json_object_set_boolean(root_object, "has_nulls", false);
+                G_json_object_set_boolean(root_object, "has_nulls", false);
             }
         }
     }
 
     if (format == JSON) {
-        json_object_set_value(root_object, "ranges", range_value);
+        G_json_object_set_value(root_object, "ranges", range_value);
         output_pretty_json(root_value);
     }
 
@@ -422,19 +422,19 @@ int range_list(CELL negmin, CELL negmax, CELL zero, CELL posmin, CELL posmax,
                 fprintf(stdout, "%s\n", no_data_str);
                 break;
             case JSON:
-                json_object_set_boolean(root_object, "has_nulls", true);
+                G_json_object_set_boolean(root_object, "has_nulls", true);
                 break;
             }
         }
         else {
             if (format == JSON) {
-                json_object_set_boolean(root_object, "has_nulls", false);
+                G_json_object_set_boolean(root_object, "has_nulls", false);
             }
         }
     }
 
     if (format == JSON) {
-        json_object_set_value(root_object, "ranges", range_value);
+        G_json_object_set_value(root_object, "ranges", range_value);
         output_pretty_json(root_value);
     }
 

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -44,7 +44,7 @@ Program was refactored by Anna Petrasova to remove most global variables.
 #include <grass/raster.h>
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 #define WHOLE_RASTER   1
 #define SINGLE_POINT   0
@@ -606,26 +606,26 @@ int main(int argc, char *argv[])
         JSON_Array *coordinates;
         JSON_Object *origin;
         if (format == JSON) {
-            root_value = json_value_init_array();
-            coordinates = json_value_get_array(root_value);
-            json_set_float_serialization_format("%lf");
+            root_value = G_json_value_init_array();
+            coordinates = G_json_array(root_value);
+            G_json_set_float_serialization_format("%lf");
         }
         for (int i = 0; i < point_count; ++i) {
             /* Calculate the horizon for each point */
             if (format == JSON) {
-                origin_value = json_value_init_object();
-                origin = json_value_get_object(origin_value);
+                origin_value = G_json_value_init_object();
+                origin = G_json_value_get_object(origin_value);
             }
             calculate_point_mode(&settings, &geometry, xcoords[i], ycoords[i],
                                  fp, format, origin);
             if (format == JSON)
-                json_array_append_value(coordinates, origin_value);
+                G_json_array_append_value(coordinates, origin_value);
         }
         if (format == JSON) {
-            char *json_string = json_serialize_to_string_pretty(root_value);
+            char *json_string = G_json_serialize_to_string_pretty(root_value);
             fprintf(fp, "%s\n", json_string);
-            json_free_serialized_string(json_string);
-            json_value_free(root_value);
+            G_json_free_serialized_string(json_string);
+            G_json_value_free(root_value);
         }
         fclose(fp);
         G_free(xcoords);
@@ -861,10 +861,10 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
         fprintf(fp, "\n");
         break;
     case JSON:
-        json_object_set_number(json_origin, "x", xcoord);
-        json_object_set_number(json_origin, "y", ycoord);
-        horizons_value = json_value_init_array();
-        horizons = json_value_get_array(horizons_value);
+        G_json_object_set_number(json_origin, "x", xcoord);
+        G_json_object_set_number(json_origin, "y", ycoord);
+        horizons_value = G_json_value_init_array();
+        horizons = G_json_array(horizons_value);
         break;
     }
 
@@ -882,8 +882,8 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
             shadow_angle *= rad2deg;
         }
         if (format == JSON) {
-            value = json_value_init_object();
-            object = json_object(value);
+            value = G_json_value_init_object();
+            object = G_json_object(value);
         }
         if (settings->compassOutput) {
             double tmpangle;
@@ -899,10 +899,10 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
                 fprintf(fp, "\n");
                 break;
             case JSON:
-                json_object_set_number(object, "azimuth", tmpangle);
-                json_object_set_number(object, "angle", shadow_angle);
-                json_object_set_number(object, "distance", horizon.length);
-                json_array_append_value(horizons, value);
+                G_json_object_set_number(object, "azimuth", tmpangle);
+                G_json_object_set_number(object, "angle", shadow_angle);
+                G_json_object_set_number(object, "distance", horizon.length);
+                G_json_array_append_value(horizons, value);
                 break;
             }
         }
@@ -915,10 +915,10 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
                 fprintf(fp, "\n");
                 break;
             case JSON:
-                json_object_set_number(object, "azimuth", printangle);
-                json_object_set_number(object, "angle", shadow_angle);
-                json_object_set_number(object, "distance", horizon.length);
-                json_array_append_value(horizons, value);
+                G_json_object_set_number(object, "azimuth", printangle);
+                G_json_object_set_number(object, "angle", shadow_angle);
+                G_json_object_set_number(object, "distance", horizon.length);
+                G_json_array_append_value(horizons, value);
                 break;
             }
         }
@@ -938,7 +938,7 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
     } /* end of for loop over angles */
 
     if (format == JSON) {
-        json_object_set_value(json_origin, "horizons", horizons_value);
+        G_json_object_set_value(json_origin, "horizons", horizons_value);
     }
 }
 

--- a/raster/r.info/main.c
+++ b/raster/r.info/main.c
@@ -25,7 +25,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 #define printline(x) fprintf(out, " | %-74.74s |\n", x)
@@ -141,12 +141,12 @@ int main(int argc, char **argv)
 
     if (strcmp(fopt->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        root_object = json_object(root_value);
+        root_object = G_json_object(root_value);
     }
     else if (strcmp(fopt->answer, "shell") == 0) {
         format = SHELL;
@@ -564,24 +564,24 @@ int main(int argc, char **argv)
                 fprintf(out, "ncats=%s\n", cats_ok ? tmp4 : "??");
                 break;
             case JSON:
-                json_object_set_number(root_object, "north", cellhd.north);
-                json_object_set_number(root_object, "south", cellhd.south);
-                json_object_set_number(root_object, "nsres", cellhd.ns_res);
+                G_json_object_set_number(root_object, "north", cellhd.north);
+                G_json_object_set_number(root_object, "south", cellhd.south);
+                G_json_object_set_number(root_object, "nsres", cellhd.ns_res);
 
-                json_object_set_number(root_object, "east", cellhd.east);
-                json_object_set_number(root_object, "west", cellhd.west);
-                json_object_set_number(root_object, "ewres", cellhd.ew_res);
+                G_json_object_set_number(root_object, "east", cellhd.east);
+                G_json_object_set_number(root_object, "west", cellhd.west);
+                G_json_object_set_number(root_object, "ewres", cellhd.ew_res);
 
-                json_object_set_number(root_object, "rows", cellhd.rows);
-                json_object_set_number(root_object, "cols", cellhd.cols);
-                json_object_set_number(root_object, "cells", total_cells);
+                G_json_object_set_number(root_object, "rows", cellhd.rows);
+                G_json_object_set_number(root_object, "cols", cellhd.cols);
+                G_json_object_set_number(root_object, "cells", total_cells);
 
-                json_object_set_string(root_object, "datatype", data_type_f);
+                G_json_object_set_string(root_object, "datatype", data_type_f);
                 if (cats_ok) {
-                    json_object_set_number(root_object, "ncats", cats.num);
+                    G_json_object_set_number(root_object, "ncats", cats.num);
                 }
                 else {
-                    json_object_set_null(root_object, "ncats");
+                    G_json_object_set_null(root_object, "ncats");
                 }
                 break;
             }
@@ -603,8 +603,8 @@ int main(int argc, char **argv)
                         fprintf(out, "max=NULL\n");
                         break;
                     case JSON:
-                        json_object_set_null(root_object, "min");
-                        json_object_set_null(root_object, "max");
+                        G_json_object_set_null(root_object, "min");
+                        G_json_object_set_null(root_object, "max");
                         break;
                     }
                 }
@@ -619,8 +619,8 @@ int main(int argc, char **argv)
                         fprintf(out, "max=%i\n", max);
                         break;
                     case JSON:
-                        json_object_set_number(root_object, "min", min);
-                        json_object_set_number(root_object, "max", max);
+                        G_json_object_set_number(root_object, "min", min);
+                        G_json_object_set_number(root_object, "max", max);
                         break;
                     }
                 }
@@ -640,8 +640,8 @@ int main(int argc, char **argv)
                         fprintf(out, "max=NULL\n");
                         break;
                     case JSON:
-                        json_object_set_null(root_object, "min");
-                        json_object_set_null(root_object, "max");
+                        G_json_object_set_null(root_object, "min");
+                        G_json_object_set_null(root_object, "max");
                         break;
                     }
                 }
@@ -668,8 +668,8 @@ int main(int argc, char **argv)
                         }
                         break;
                     case JSON:
-                        json_object_set_number(root_object, "min", min);
-                        json_object_set_number(root_object, "max", max);
+                        G_json_object_set_number(root_object, "min", min);
+                        G_json_object_set_number(root_object, "max", max);
                         break;
                     }
                 }
@@ -690,7 +690,7 @@ int main(int argc, char **argv)
                     fprintf(out, "cells=%" PRId64 "\n", total_cells);
                     break;
                 case JSON:
-                    json_object_set_number(root_object, "cells", total_cells);
+                    G_json_object_set_number(root_object, "cells", total_cells);
                     break;
                 }
             }
@@ -734,10 +734,10 @@ int main(int argc, char **argv)
                     fprintf(out, "sum=%.15g\n", rstats.sum);
                     break;
                 case JSON:
-                    json_object_set_number(root_object, "n", rstats.count);
-                    json_object_set_number(root_object, "mean", mean);
-                    json_object_set_number(root_object, "stddev", sd);
-                    json_object_set_number(root_object, "sum", rstats.sum);
+                    G_json_object_set_number(root_object, "n", rstats.count);
+                    G_json_object_set_number(root_object, "mean", mean);
+                    G_json_object_set_number(root_object, "stddev", sd);
+                    G_json_object_set_number(root_object, "sum", rstats.sum);
                     break;
                 }
             }
@@ -756,10 +756,10 @@ int main(int argc, char **argv)
                     fprintf(out, "sum=NULL\n");
                     break;
                 case JSON:
-                    json_object_set_number(root_object, "n", 0);
-                    json_object_set_null(root_object, "mean");
-                    json_object_set_null(root_object, "stddev");
-                    json_object_set_null(root_object, "sum");
+                    G_json_object_set_number(root_object, "n", 0);
+                    G_json_object_set_null(root_object, "mean");
+                    G_json_object_set_null(root_object, "stddev");
+                    G_json_object_set_null(root_object, "sum");
                     break;
                 }
             }
@@ -799,15 +799,15 @@ int main(int argc, char **argv)
                 fprintf(out, "title=\"%s\"\n", title);
                 break;
             case JSON:
-                json_object_set_string(root_object, "map", name);
-                json_object_set_string(root_object, "maptype", maptype);
-                json_object_set_string(root_object, "mapset", mapset);
-                json_object_set_string(root_object, "location", G_location());
-                json_object_set_string(root_object, "project", G_location());
-                json_object_set_string(root_object, "database", G_gisdbase());
-                json_object_set_string(root_object, "date", date);
-                json_object_set_string(root_object, "creator", creator);
-                json_object_set_string(root_object, "title", title);
+                G_json_object_set_string(root_object, "map", name);
+                G_json_object_set_string(root_object, "maptype", maptype);
+                G_json_object_set_string(root_object, "mapset", mapset);
+                G_json_object_set_string(root_object, "location", G_location());
+                G_json_object_set_string(root_object, "project", G_location());
+                G_json_object_set_string(root_object, "database", G_gisdbase());
+                G_json_object_set_string(root_object, "date", date);
+                G_json_object_set_string(root_object, "creator", creator);
+                G_json_object_set_string(root_object, "title", title);
                 break;
             }
             if (time_ok && (first_time_ok || second_time_ok)) {
@@ -823,7 +823,8 @@ int main(int argc, char **argv)
                     fprintf(out, "timestamp=\"%s\"\n", timebuff);
                     break;
                 case JSON:
-                    json_object_set_string(root_object, "timestamp", timebuff);
+                    G_json_object_set_string(root_object, "timestamp",
+                                             timebuff);
                     break;
                 }
             }
@@ -836,7 +837,7 @@ int main(int argc, char **argv)
                     fprintf(out, "timestamp=\"none\"\n");
                     break;
                 case JSON:
-                    json_object_set_null(root_object, "timestamp");
+                    G_json_object_set_null(root_object, "timestamp");
                     break;
                 }
             }
@@ -881,49 +882,50 @@ int main(int argc, char **argv)
                 break;
             case JSON:
                 if (units) {
-                    json_object_set_string(root_object, "units", units);
+                    G_json_object_set_string(root_object, "units", units);
                 }
                 else {
-                    json_object_set_null(root_object, "units");
+                    G_json_object_set_null(root_object, "units");
                 }
                 if (vdatum) {
-                    json_object_set_string(root_object, "vdatum", vdatum);
+                    G_json_object_set_string(root_object, "vdatum", vdatum);
                 }
                 else {
-                    json_object_set_null(root_object, "vdatum");
+                    G_json_object_set_null(root_object, "vdatum");
                 }
                 if (semantic_label) {
-                    json_object_set_string(root_object, "semantic_label",
-                                           semantic_label);
+                    G_json_object_set_string(root_object, "semantic_label",
+                                             semantic_label);
                 }
                 else {
-                    json_object_set_null(root_object, "semantic_label");
+                    G_json_object_set_null(root_object, "semantic_label");
                 }
 
                 if (hist_ok) {
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "source1",
                         Rast_get_history(&hist, HIST_DATSRC_1));
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "source2",
                         Rast_get_history(&hist, HIST_DATSRC_2));
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "description",
                         Rast_get_history(&hist, HIST_KEYWRD));
                     char *buffer = history_as_string(&hist);
                     if (buffer) {
-                        json_object_set_string(root_object, "comments", buffer);
+                        G_json_object_set_string(root_object, "comments",
+                                                 buffer);
                         G_free(buffer);
                     }
                     else {
-                        json_object_set_null(root_object, "comments");
+                        G_json_object_set_null(root_object, "comments");
                     }
                 }
                 else {
-                    json_object_set_null(root_object, "source1");
-                    json_object_set_null(root_object, "source2");
-                    json_object_set_null(root_object, "description");
-                    json_object_set_null(root_object, "comments");
+                    G_json_object_set_null(root_object, "source1");
+                    G_json_object_set_null(root_object, "source2");
+                    G_json_object_set_null(root_object, "description");
+                    G_json_object_set_null(root_object, "comments");
                 }
                 break;
             }
@@ -966,22 +968,23 @@ int main(int argc, char **argv)
                     }
                     break;
                 case JSON:
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "source1",
                         Rast_get_history(&hist, HIST_DATSRC_1));
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "source2",
                         Rast_get_history(&hist, HIST_DATSRC_2));
-                    json_object_set_string(
+                    G_json_object_set_string(
                         root_object, "description",
                         Rast_get_history(&hist, HIST_KEYWRD));
                     char *buffer = history_as_string(&hist);
                     if (buffer) {
-                        json_object_set_string(root_object, "comments", buffer);
+                        G_json_object_set_string(root_object, "comments",
+                                                 buffer);
                         G_free(buffer);
                     }
                     else {
-                        json_object_set_null(root_object, "comments");
+                        G_json_object_set_null(root_object, "comments");
                     }
 
                     break;
@@ -992,13 +995,13 @@ int main(int argc, char **argv)
 
     if (format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     return EXIT_SUCCESS;

--- a/raster/r.mask.status/main.c
+++ b/raster/r.mask.status/main.c
@@ -18,7 +18,7 @@
 #include <unistd.h>
 
 #include <grass/gis.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
@@ -97,21 +97,21 @@ int report_status(struct Parameters *params)
         full_underlying = G_fully_qualified_name(reclass_name, reclass_mapset);
 
     if (strcmp(params->format->answer, "json") == 0) {
-        JSON_Value *root_value = json_value_init_object();
-        JSON_Object *root_object = json_object(root_value);
-        json_object_set_boolean(root_object, "present", present);
-        json_object_set_string(root_object, "name", full_mask);
+        JSON_Value *root_value = G_json_value_init_object();
+        JSON_Object *root_object = G_json_object(root_value);
+        G_json_object_set_boolean(root_object, "present", present);
+        G_json_object_set_string(root_object, "name", full_mask);
         if (is_mask_reclass)
-            json_object_set_string(root_object, "is_reclass_of",
-                                   full_underlying);
+            G_json_object_set_string(root_object, "is_reclass_of",
+                                     full_underlying);
         else
-            json_object_set_null(root_object, "is_reclass_of");
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+            G_json_object_set_null(root_object, "is_reclass_of");
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (!serialized_string)
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
     else if (strcmp(params->format->answer, "shell") == 0) {
         printf("present=");

--- a/raster/r.object.geometry/main.c
+++ b/raster/r.object.geometry/main.c
@@ -22,7 +22,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 enum OutputFormat { PLAIN, JSON };
 
@@ -100,8 +100,8 @@ int main(int argc, char *argv[])
 
     if (strcmp(fmt_opt->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_array();
-        root_array = json_array(root_value);
+        root_value = G_json_value_init_array();
+        root_array = G_json_array(root_value);
     }
     else {
         format = PLAIN;
@@ -359,16 +359,17 @@ int main(int argc, char *argv[])
             fprintf(out_fp, "%f", mean_y);
             break;
         case JSON:
-            object_value = json_value_init_object();
-            object = json_object(object_value);
-            json_object_set_number(object, "category", min + i);
-            json_object_set_number(object, "area", obj_geos[i].area);
-            json_object_set_number(object, "perimeter", obj_geos[i].perimeter);
-            json_object_set_number(object, "compact_square", compact_square);
-            json_object_set_number(object, "compact_circle", compact_circle);
-            json_object_set_number(object, "fd", fd);
-            json_object_set_number(object, "mean_x", mean_x);
-            json_object_set_number(object, "mean_y", mean_y);
+            object_value = G_json_value_init_object();
+            object = G_json_object(object_value);
+            G_json_object_set_number(object, "category", min + i);
+            G_json_object_set_number(object, "area", obj_geos[i].area);
+            G_json_object_set_number(object, "perimeter",
+                                     obj_geos[i].perimeter);
+            G_json_object_set_number(object, "compact_square", compact_square);
+            G_json_object_set_number(object, "compact_circle", compact_circle);
+            G_json_object_set_number(object, "fd", fd);
+            G_json_object_set_number(object, "mean_x", mean_x);
+            G_json_object_set_number(object, "mean_y", mean_y);
             break;
         }
         /* object id: i + min */
@@ -390,19 +391,19 @@ int main(int argc, char *argv[])
             fprintf(out_fp, "\n");
             break;
         case JSON:
-            json_array_append_value(root_array, object_value);
+            G_json_array_append_value(root_array, object_value);
             break;
         }
     }
 
     if (format == JSON) {
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     if (out_fp != stdout)

--- a/raster/r.profile/main.c
+++ b/raster/r.profile/main.c
@@ -8,7 +8,7 @@
  */
 
 #include <stdlib.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -173,8 +173,8 @@ int main(int argc, char *argv[])
 
     if (strcmp(parm.format->answer, "json") == 0) {
         format = JSON;
-        array_value = json_value_init_array();
-        array = json_array(array_value);
+        array_value = G_json_value_init_array();
+        array = G_json_array(array_value);
     }
     else if (strcmp(parm.format->answer, "csv") == 0) {
         format = CSV;
@@ -314,13 +314,14 @@ int main(int argc, char *argv[])
     }
 
     if (format == JSON) {
-        char *serialized_string = json_serialize_to_string_pretty(array_value);
+        char *serialized_string =
+            G_json_serialize_to_string_pretty(array_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(array_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(array_value);
     }
 
     Rast_close(fd);

--- a/raster/r.profile/read_rast.c
+++ b/raster/r.profile/read_rast.c
@@ -10,7 +10,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 int read_rast(double east, double north, double dist, int fd, int coords,
@@ -28,8 +28,8 @@ int read_rast(double east, double north, double dist, int fd, int coords,
     JSON_Value *value;
 
     if (format == JSON) {
-        value = json_value_init_object();
-        object = json_object(value);
+        value = G_json_value_init_object();
+        object = G_json_object(value);
     }
 
     if (!dcell) {
@@ -56,10 +56,10 @@ int read_rast(double east, double north, double dist, int fd, int coords,
     switch (format) {
     case JSON:
         if (coords) {
-            json_object_set_number(object, "easting", east);
-            json_object_set_number(object, "northing", north);
+            G_json_object_set_number(object, "easting", east);
+            G_json_object_set_number(object, "northing", north);
         }
-        json_object_set_number(object, "distance", dist);
+        G_json_object_set_number(object, "distance", dist);
         break;
     case PLAIN:
         if (coords)
@@ -78,7 +78,7 @@ int read_rast(double east, double north, double dist, int fd, int coords,
     if (outofbounds || Rast_is_d_null_value(&dcell[col])) {
         switch (format) {
         case JSON:
-            json_object_set_null(object, "value");
+            G_json_object_set_null(object, "value");
             break;
         case PLAIN:
             fprintf(fp, " %s", null_string);
@@ -93,7 +93,7 @@ int read_rast(double east, double north, double dist, int fd, int coords,
             int dvalue = (int)dcell[col];
             switch (format) {
             case JSON:
-                json_object_set_number(object, "value", dvalue);
+                G_json_object_set_number(object, "value", dvalue);
                 break;
             case PLAIN:
                 fprintf(fp, " %d", dvalue);
@@ -106,7 +106,7 @@ int read_rast(double east, double north, double dist, int fd, int coords,
         else {
             switch (format) {
             case JSON:
-                json_object_set_number(object, "value", dcell[col]);
+                G_json_object_set_number(object, "value", dcell[col]);
                 break;
             case PLAIN:
                 fprintf(fp, " %f", dcell[col]);
@@ -131,7 +131,7 @@ int read_rast(double east, double north, double dist, int fd, int coords,
         switch (format) {
         case JSON:
             G_color_to_str(red, green, blue, clr_frmt, color_str);
-            json_object_set_string(object, "color", color_str);
+            G_json_object_set_string(object, "color", color_str);
             break;
         case PLAIN:
             if (clr_frmt != TRIPLET) {
@@ -155,7 +155,7 @@ int read_rast(double east, double north, double dist, int fd, int coords,
 
     switch (format) {
     case JSON:
-        json_array_append_value(array, value);
+        G_json_array_append_value(array, value);
         break;
     case PLAIN:
     case CSV:

--- a/raster/r.proj/main.c
+++ b/raster/r.proj/main.c
@@ -63,7 +63,7 @@
 #include <grass/raster.h>
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "r.proj.h"
 
 /* modify this table to add new methods */
@@ -339,12 +339,12 @@ int main(int argc, char **argv)
         JSON_Value *maps_value = NULL;
 
         if (outputFormat == JSON) {
-            maps_value = json_value_init_array();
+            maps_value = G_json_value_init_array();
             if (maps_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON array. Out of memory?"));
             }
-            maps_array = json_array(maps_value);
+            maps_array = G_json_array(maps_value);
         }
 
         G_verbose_message(_("Checking project <%s> mapset <%s>"),
@@ -359,19 +359,19 @@ int main(int argc, char **argv)
                 break;
 
             case JSON:
-                json_array_append_string(maps_array, srclist[i]);
+                G_json_array_append_string(maps_array, srclist[i]);
                 break;
             }
         }
         if (outputFormat == JSON) {
             char *serialized_string = NULL;
-            serialized_string = json_serialize_to_string_pretty(maps_value);
+            serialized_string = G_json_serialize_to_string_pretty(maps_value);
             if (serialized_string == NULL) {
                 G_fatal_error(_("Failed to initialize pretty JSON string."));
             }
             puts(serialized_string);
-            json_free_serialized_string(serialized_string);
-            json_value_free(maps_value);
+            G_json_free_serialized_string(serialized_string);
+            G_json_value_free(maps_value);
         }
         else {
             fflush(stdout);
@@ -481,12 +481,12 @@ int main(int argc, char **argv)
         G_format_easting(iwest, west_str, curr_proj);
 
         if (outputFormat == JSON) {
-            root_value = json_value_init_object();
+            root_value = G_json_value_init_object();
             if (root_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON object. Out of memory?"));
             }
-            root_object = json_object(root_value);
+            root_object = G_json_object(root_value);
         }
 
         switch (outputFormat) {
@@ -506,47 +506,47 @@ int main(int argc, char **argv)
 
         case JSON:
             if (isfinite(inorth)) {
-                json_object_set_number(root_object, "north", inorth);
+                G_json_object_set_number(root_object, "north", inorth);
             }
             else {
-                json_object_set_null(root_object, "north");
+                G_json_object_set_null(root_object, "north");
             }
 
             if (isfinite(isouth)) {
-                json_object_set_number(root_object, "south", isouth);
+                G_json_object_set_number(root_object, "south", isouth);
             }
             else {
-                json_object_set_null(root_object, "south");
+                G_json_object_set_null(root_object, "south");
             }
 
             if (isfinite(iwest)) {
-                json_object_set_number(root_object, "west", iwest);
+                G_json_object_set_number(root_object, "west", iwest);
             }
             else {
-                json_object_set_null(root_object, "west");
+                G_json_object_set_null(root_object, "west");
             }
 
             if (isfinite(ieast)) {
-                json_object_set_number(root_object, "east", ieast);
+                G_json_object_set_number(root_object, "east", ieast);
             }
             else {
-                json_object_set_null(root_object, "east");
+                G_json_object_set_null(root_object, "east");
             }
 
-            json_object_set_number(root_object, "rows", irows);
-            json_object_set_number(root_object, "cols", icols);
+            G_json_object_set_number(root_object, "rows", irows);
+            G_json_object_set_number(root_object, "cols", icols);
             break;
         }
 
         if (outputFormat == JSON) {
             char *serialized_string = NULL;
-            serialized_string = json_serialize_to_string_pretty(root_value);
+            serialized_string = G_json_serialize_to_string_pretty(root_value);
             if (serialized_string == NULL) {
                 G_fatal_error(_("Failed to initialize pretty JSON string."));
             }
             puts(serialized_string);
-            json_free_serialized_string(serialized_string);
-            json_value_free(root_value);
+            G_json_free_serialized_string(serialized_string);
+            G_json_value_free(root_value);
         }
 
         exit(EXIT_SUCCESS);

--- a/raster/r.report/prt_json.c
+++ b/raster/r.report/prt_json.c
@@ -2,32 +2,32 @@
 #include <string.h>
 #include <time.h>
 #include "global.h"
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/glocale.h>
 
 JSON_Value *make_units(int ns, int nl)
 {
-    JSON_Value *units_value = json_value_init_array();
-    JSON_Array *units_array = json_array(units_value);
+    JSON_Value *units_value = G_json_value_init_array();
+    JSON_Array *units_array = G_json_array(units_value);
     for (int i = 0; i < nunits; i++) {
         int _ns = ns;
 
-        JSON_Value *unit_value = json_value_init_object();
-        JSON_Object *unit_object = json_object(unit_value);
+        JSON_Value *unit_value = G_json_value_init_object();
+        JSON_Object *unit_object = G_json_object(unit_value);
 
         if (unit[i].type == CELL_COUNTS) {
-            json_object_set_string(unit_object, "unit", "cells");
-            json_object_set_number(unit_object, "value", count_sum(&_ns, nl));
+            G_json_object_set_string(unit_object, "unit", "cells");
+            G_json_object_set_number(unit_object, "value", count_sum(&_ns, nl));
         }
         else if (unit[i].type == PERCENT_COVER) {
-            json_object_set_string(unit_object, "unit", "percent");
+            G_json_object_set_string(unit_object, "unit", "percent");
             int k = ns - 1;
             while (k >= 0 && same_cats(k, ns, nl - 1))
                 k--;
             k++;
             double area = area_sum(&k, nl - 1);
             area = 100.0 * area_sum(&_ns, nl) / area;
-            json_object_set_number(unit_object, "value", area);
+            G_json_object_set_number(unit_object, "value", area);
         }
         else {
             char *unit_name = NULL;
@@ -46,36 +46,37 @@ JSON_Value *make_units(int ns, int nl)
             else if (unit[i].type == SQ_KILOMETERS) {
                 unit_name = "square kilometers";
             }
-            json_object_set_string(unit_object, "unit", unit_name);
-            json_object_set_number(unit_object, "value",
-                                   area_sum(&_ns, nl) * unit[i].factor);
+            G_json_object_set_string(unit_object, "unit", unit_name);
+            G_json_object_set_number(unit_object, "value",
+                                     area_sum(&_ns, nl) * unit[i].factor);
         }
-        json_array_append_value(units_array, unit_value);
+        G_json_array_append_value(units_array, unit_value);
     }
     return units_value;
 }
 
 JSON_Value *make_category(int ns, int nl, JSON_Value *sub_categories)
 {
-    JSON_Value *object_value = json_value_init_object();
-    JSON_Object *object = json_object(object_value);
+    JSON_Value *object_value = G_json_value_init_object();
+    JSON_Object *object = G_json_object(object_value);
 
     CELL *cats = Gstats[ns].cats;
-    json_object_set_number(object, "category", cats[nl]);
+    G_json_object_set_number(object, "category", cats[nl]);
 
     DCELL dLow, dHigh;
 
     if (!is_fp[nl] || as_int)
-        json_object_set_string(object, "label",
-                               Rast_get_c_cat(&cats[nl], &layers[nl].labels));
+        G_json_object_set_string(object, "label",
+                                 Rast_get_c_cat(&cats[nl], &layers[nl].labels));
     else {
         /* find or construct the label for floating point range to print */
         if (Rast_is_c_null_value(&cats[nl]))
-            json_object_set_null(object, "label");
+            G_json_object_set_null(object, "label");
         else if (cat_ranges) {
-            json_object_set_string(object, "label",
-                                   Rast_get_ith_d_cat(&layers[nl].labels,
-                                                      cats[nl], &dLow, &dHigh));
+            G_json_object_set_string(object, "label",
+                                     Rast_get_ith_d_cat(&layers[nl].labels,
+                                                        cats[nl], &dLow,
+                                                        &dHigh));
         }
         else {
             dLow = (DMAX[nl] - DMIN[nl]) / (double)nsteps *
@@ -84,33 +85,33 @@ JSON_Value *make_category(int ns, int nl, JSON_Value *sub_categories)
             dHigh = (DMAX[nl] - DMIN[nl]) / (double)nsteps * (double)cats[nl] +
                     DMIN[nl];
 
-            json_object_set_string(object, "label", "from to");
+            G_json_object_set_string(object, "label", "from to");
 
-            JSON_Value *range_value = json_value_init_object();
-            JSON_Object *range_object = json_object(range_value);
-            json_object_set_number(range_object, "from", dLow);
-            json_object_set_number(range_object, "to", dHigh);
-            json_object_set_value(object, "range", range_value);
+            JSON_Value *range_value = G_json_value_init_object();
+            JSON_Object *range_object = G_json_object(range_value);
+            G_json_object_set_number(range_object, "from", dLow);
+            G_json_object_set_number(range_object, "to", dHigh);
+            G_json_object_set_value(object, "range", range_value);
         }
     }
 
     JSON_Value *units_value = make_units(ns, nl);
-    json_object_set_value(object, "units", units_value);
+    G_json_object_set_value(object, "units", units_value);
 
     if (sub_categories != NULL) {
-        json_object_set_value(object, "categories", sub_categories);
+        G_json_object_set_value(object, "categories", sub_categories);
     }
     return object_value;
 }
 
 JSON_Value *make_categories(int start, int end, int level)
 {
-    JSON_Value *array_value = json_value_init_array();
-    JSON_Array *array = json_array(array_value);
+    JSON_Value *array_value = G_json_value_init_array();
+    JSON_Array *array = G_json_array(array_value);
     if (level == nlayers - 1) {
         for (int i = start; i < end; i++) {
             JSON_Value *category = make_category(i, level, NULL);
-            json_array_append_value(array, category);
+            G_json_array_append_value(array, category);
         }
     }
     else {
@@ -122,7 +123,7 @@ JSON_Value *make_categories(int start, int end, int level)
             JSON_Value *sub_categories =
                 make_categories(start, curr, level + 1);
             JSON_Value *category = make_category(start, level, sub_categories);
-            json_array_append_value(array, category);
+            G_json_array_append_value(array, category);
             start = curr;
         }
     }
@@ -133,10 +134,10 @@ void print_json(void)
 {
     compute_unit_format(0, nunits - 1, JSON);
 
-    JSON_Value *root_value = json_value_init_object();
-    JSON_Object *root_object = json_object(root_value);
+    JSON_Value *root_value = G_json_value_init_object();
+    JSON_Object *root_object = G_json_object(root_value);
 
-    json_object_set_string(root_object, "project", G_location());
+    G_json_object_set_string(root_object, "project", G_location());
 
     char date[64];
     time_t now;
@@ -145,61 +146,61 @@ void print_json(void)
     time(&now);
     tm_info = localtime(&now);
     strftime(date, 64, "%Y-%m-%dT%H:%M:%S%z", tm_info);
-    json_object_set_string(root_object, "created", date);
+    G_json_object_set_string(root_object, "created", date);
 
-    JSON_Value *region_value = json_value_init_object();
-    JSON_Object *region_object = json_object(region_value);
-    json_object_set_number(region_object, "north", window.north);
-    json_object_set_number(region_object, "south", window.south);
-    json_object_set_number(region_object, "east", window.east);
-    json_object_set_number(region_object, "west", window.west);
-    json_object_set_number(region_object, "ewres", window.ew_res);
-    json_object_set_number(region_object, "nsres", window.ns_res);
-    json_object_set_value(root_object, "region", region_value);
+    JSON_Value *region_value = G_json_value_init_object();
+    JSON_Object *region_object = G_json_object(region_value);
+    G_json_object_set_number(region_object, "north", window.north);
+    G_json_object_set_number(region_object, "south", window.south);
+    G_json_object_set_number(region_object, "east", window.east);
+    G_json_object_set_number(region_object, "west", window.west);
+    G_json_object_set_number(region_object, "ewres", window.ew_res);
+    G_json_object_set_number(region_object, "nsres", window.ns_res);
+    G_json_object_set_value(root_object, "region", region_value);
 
     char *mask = maskinfo();
     if (strcmp(mask, "none") == 0) {
-        json_object_set_null(root_object, "mask");
+        G_json_object_set_null(root_object, "mask");
     }
     else {
-        json_object_set_string(root_object, "mask", mask);
+        G_json_object_set_string(root_object, "mask", mask);
     }
 
-    JSON_Value *maps_value = json_value_init_array();
-    JSON_Array *maps_array = json_array(maps_value);
+    JSON_Value *maps_value = G_json_value_init_array();
+    JSON_Array *maps_array = G_json_array(maps_value);
 
     for (int i = 0; i < nlayers; i++) {
-        JSON_Value *map_value = json_value_init_object();
-        JSON_Object *map_object = json_object(map_value);
-        json_object_set_string(map_object, "name", layers[i].name);
+        JSON_Value *map_value = G_json_value_init_object();
+        JSON_Object *map_object = G_json_object(map_value);
+        G_json_object_set_string(map_object, "name", layers[i].name);
 
         char *label;
         label = Rast_get_cats_title(&(layers[i].labels));
         if (label == NULL || *label == 0) {
-            json_object_set_null(map_object, "title");
+            G_json_object_set_null(map_object, "title");
         }
         else {
             G_strip(label);
-            json_object_set_string(map_object, "title", label);
+            G_json_object_set_string(map_object, "title", label);
         }
 
-        json_object_set_string(map_object, "type", "raster");
-        json_array_append_value(maps_array, map_value);
+        G_json_object_set_string(map_object, "type", "raster");
+        G_json_array_append_value(maps_array, map_value);
     }
-    json_object_set_value(root_object, "maps", maps_value);
+    G_json_object_set_value(root_object, "maps", maps_value);
 
     JSON_Value *root_categories_value = make_categories(0, nstats, 0);
-    json_object_set_value(root_object, "categories", root_categories_value);
+    G_json_object_set_value(root_object, "categories", root_categories_value);
 
     JSON_Value *totals = make_units(0, -1);
-    json_object_set_value(root_object, "totals", totals);
+    G_json_object_set_value(root_object, "totals", totals);
 
     char *serialized_string = NULL;
-    serialized_string = json_serialize_to_string_pretty(root_value);
+    serialized_string = G_json_serialize_to_string_pretty(root_value);
     if (serialized_string == NULL) {
         G_fatal_error(_("Failed to initialize pretty JSON string."));
     }
     puts(serialized_string);
-    json_free_serialized_string(serialized_string);
-    json_value_free(root_value);
+    G_json_free_serialized_string(serialized_string);
+    G_json_value_free(root_value);
 }

--- a/raster/r.stats/cell_stats.c
+++ b/raster/r.stats/cell_stats.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/glocale.h>
 #include "global.h"
 

--- a/raster/r.stats/main.c
+++ b/raster/r.stats/main.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/glocale.h>
 
 #include "global.h"
@@ -258,8 +258,8 @@ int main(int argc, char *argv[])
 
     if (strcmp(option.format->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_array();
-        root_array = json_array(root_value);
+        root_value = G_json_value_init_array();
+        root_array = G_json_array(root_value);
     }
     else if (strcmp(option.format->answer, "csv") == 0) {
         format = CSV;
@@ -422,13 +422,13 @@ int main(int argc, char *argv[])
 
     if (format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     exit(EXIT_SUCCESS);

--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -1,5 +1,5 @@
 #include <stdlib.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -75,10 +75,10 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
 
         for (col = 0; col < ncols; col++) {
             if (format == JSON) {
-                object_value = json_value_init_object();
-                object = json_object(object_value);
-                categories_value = json_value_init_array();
-                categories = json_array(categories_value);
+                object_value = G_json_value_init_object();
+                object = G_json_object(object_value);
+                categories_value = G_json_value_init_array();
+                categories = G_json_array(categories_value);
             }
             if (no_nulls || no_nulls_all) {
                 nulls_found = 0;
@@ -102,13 +102,13 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
             switch (format) {
             case JSON:
                 if (with_coordinates) {
-                    json_object_set_number(
+                    G_json_object_set_number(
                         object, "east", Rast_col_to_easting(col + .5, &window));
-                    json_object_set_number(object, "north", northing);
+                    G_json_object_set_number(object, "north", northing);
                 }
                 if (with_xy) {
-                    json_object_set_number(object, "col", col + 1);
-                    json_object_set_number(object, "row", row + 1);
+                    G_json_object_set_number(object, "col", col + 1);
+                    G_json_object_set_number(object, "row", row + 1);
                 }
                 break;
             case CSV:
@@ -126,16 +126,16 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
 
             for (i = 0; i < nfiles; i++) {
                 if (format == JSON) {
-                    category_value = json_value_init_object();
-                    category = json_object(category_value);
+                    category_value = G_json_value_init_object();
+                    category = G_json_object(category_value);
                 }
 
                 if (Rast_is_null_value(rastp[i], map_type[i])) {
                     switch (format) {
                     case JSON:
-                        json_object_set_null(category, "category");
+                        G_json_object_set_null(category, "category");
                         if (with_labels)
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_c_cat(&null_cell, &labels[i]));
                         break;
@@ -151,10 +151,10 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                 else if (map_type[i] == CELL_TYPE) {
                     switch (format) {
                     case JSON:
-                        json_object_set_number(category, "category",
-                                               (long)*((CELL *)rastp[i]));
+                        G_json_object_set_number(category, "category",
+                                                 (long)*((CELL *)rastp[i]));
                         if (with_labels && !is_fp[i]) {
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_c_cat((CELL *)rastp[i], &labels[i]));
                         }
@@ -181,10 +181,10 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                 else if (map_type[i] == FCELL_TYPE) {
                     switch (format) {
                     case JSON:
-                        json_object_set_number(category, "category",
-                                               *((FCELL *)rastp[i]));
+                        G_json_object_set_number(category, "category",
+                                                 *((FCELL *)rastp[i]));
                         if (with_labels)
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_f_cat((FCELL *)rastp[i], &labels[i]));
                         break;
@@ -205,10 +205,10 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                 else if (map_type[i] == DCELL_TYPE) {
                     switch (format) {
                     case JSON:
-                        json_object_set_number(category, "category",
-                                               *((DCELL *)rastp[i]));
+                        G_json_object_set_number(category, "category",
+                                                 *((DCELL *)rastp[i]));
                         if (with_labels)
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_d_cat((DCELL *)rastp[i], &labels[i]));
                         break;
@@ -230,7 +230,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                     G_fatal_error(_("Invalid map type"));
 
                 if (format == JSON) {
-                    json_array_append_value(categories, category_value);
+                    G_json_array_append_value(categories, category_value);
                 }
 
                 rastp[i] =
@@ -239,8 +239,8 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
 
             switch (format) {
             case JSON:
-                json_object_set_value(object, "categories", categories_value);
-                json_array_append_value(array, object_value);
+                G_json_object_set_value(object, "categories", categories_value);
+                G_json_array_append_value(array, object_value);
                 break;
             case CSV:
             case PLAIN:

--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include "global.h"
 
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 /* hash definitions (these should be prime numbers) ************* */
 #define HASHSIZE 7307
@@ -345,10 +345,10 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
 
         for (n = 0; n < node_count; n++) {
             if (format == JSON) {
-                object_value = json_value_init_object();
-                object = json_object(object_value);
-                categories_value = json_value_init_array();
-                categories = json_array(categories_value);
+                object_value = G_json_value_init_object();
+                object = G_json_object(object_value);
+                categories_value = G_json_value_init_array();
+                categories = G_json_array(categories_value);
             }
 
             node = sorted_list[n];
@@ -372,20 +372,20 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
 
             for (i = 0; i < nfiles; i++) {
                 if (format == JSON) {
-                    category_value = json_value_init_object();
-                    category = json_object(category_value);
+                    category_value = G_json_value_init_object();
+                    category = G_json_object(category_value);
                 }
                 if (node->values[i] == NULL_CELL) {
                     switch (format) {
                     case JSON:
                         if (raw_output || !is_fp[i] || as_int)
-                            json_object_set_null(category, "category");
+                            G_json_object_set_null(category, "category");
                         else if (averaged)
-                            json_object_set_null(category, "average");
+                            G_json_object_set_null(category, "average");
                         else
-                            json_object_set_null(category, "range");
+                            G_json_object_set_null(category, "range");
                         if (with_labels && !(raw_output && is_fp[i]))
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_c_cat(&null_cell, &labels[i]));
                         break;
@@ -408,10 +408,10 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                 else if (raw_output || !is_fp[i] || as_int) {
                     switch (format) {
                     case JSON:
-                        json_object_set_number(category, "category",
-                                               (long)node->values[i]);
+                        G_json_object_set_number(category, "category",
+                                                 (long)node->values[i]);
                         if (with_labels && !is_fp[i]) {
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 category, "label",
                                 Rast_get_c_cat((CELL *)&(node->values[i]),
                                                &labels[i]));
@@ -456,8 +456,8 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                         double average = (dLow + dHigh) / 2.0;
                         switch (format) {
                         case JSON:
-                            json_object_set_number(category, "average",
-                                                   average);
+                            G_json_object_set_number(category, "average",
+                                                     average);
                             break;
                         case CSV:
                         case PLAIN:
@@ -471,10 +471,10 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                     else {
                         switch (format) {
                         case JSON:
-                            json_object_dotset_number(category, "range.from",
-                                                      dLow);
-                            json_object_dotset_number(category, "range.to",
-                                                      dHigh);
+                            G_json_object_dotset_number(category, "range.from",
+                                                        dLow);
+                            G_json_object_dotset_number(category, "range.to",
+                                                        dHigh);
                             break;
                         case CSV:
                         case PLAIN:
@@ -493,15 +493,15 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                     case JSON:
                         if (with_labels) {
                             if (cat_ranges) {
-                                json_object_set_string(
+                                G_json_object_set_string(
                                     category, "label",
                                     labels[i].labels[node->values[i]]);
                             }
                             else {
-                                json_object_dotset_string(
+                                G_json_object_dotset_string(
                                     category, "label.from",
                                     Rast_get_d_cat(&dLow, &labels[i]));
-                                json_object_dotset_string(
+                                G_json_object_dotset_string(
                                     category, "label.to",
                                     Rast_get_d_cat(&dHigh, &labels[i]));
                             }
@@ -523,18 +523,18 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                 }
 
                 if (format == JSON) {
-                    json_array_append_value(categories, category_value);
+                    G_json_array_append_value(categories, category_value);
                 }
             }
 
             if (format == JSON) {
-                json_object_set_value(object, "categories", categories_value);
+                G_json_object_set_value(object, "categories", categories_value);
             }
 
             if (with_areas) {
                 switch (format) {
                 case JSON:
-                    json_object_set_number(object, "area", node->area);
+                    G_json_object_set_number(object, "area", node->area);
                     break;
                 case CSV:
                 case PLAIN:
@@ -546,7 +546,7 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
             if (with_counts) {
                 switch (format) {
                 case JSON:
-                    json_object_set_number(object, "count", node->count);
+                    G_json_object_set_number(object, "count", node->count);
                     break;
                 case CSV:
                 case PLAIN:
@@ -558,7 +558,7 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                 double percent = (double)100 * node->count / total_count;
                 switch (format) {
                 case JSON:
-                    json_object_set_number(object, "percent", percent);
+                    G_json_object_set_number(object, "percent", percent);
                     break;
                 case CSV:
                 case PLAIN:
@@ -569,7 +569,7 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
 
             switch (format) {
             case JSON:
-                json_array_append_value(array, object_value);
+                G_json_array_append_value(array, object_value);
                 break;
             case CSV:
             case PLAIN:

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "globals.h"
 
 /* *************************************************************** */
@@ -90,20 +90,20 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
 
     if (format == JSON) {
         if (zone_info.n_zones) {
-            root_value = json_value_init_array();
+            root_value = G_json_value_init_array();
             if (root_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON array. Out of memory?"));
             }
-            root_array = json_array(root_value);
+            root_array = G_json_array(root_value);
         }
         else {
-            zone_value = json_value_init_object();
+            zone_value = G_json_value_init_object();
             if (zone_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON object. Out of memory?"));
             }
-            zone_object = json_object(zone_value);
+            zone_object = G_json_object(zone_value);
         }
     }
 
@@ -142,12 +142,12 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
         G_trim_decimal(sum_str);
 
         if (format == JSON && zone_info.n_zones) {
-            zone_value = json_value_init_object();
+            zone_value = G_json_value_init_object();
             if (zone_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON object. Out of memory?"));
             }
-            zone_object = json_object(zone_value);
+            zone_object = G_json_object(zone_value);
         }
         if (zone_info.n_zones) {
             int z_cat = z + zone_info.min;
@@ -162,8 +162,8 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                         Rast_get_c_cat(&z_cat, &(zone_info.cats)));
                 break;
             case JSON:
-                json_object_set_number(zone_object, "zone", z_cat);
-                json_object_set_string(
+                G_json_object_set_number(zone_object, "zone", z_cat);
+                G_json_object_set_string(
                     zone_object, "zone_label",
                     Rast_get_c_cat(&z_cat, &(zone_info.cats)));
                 break;
@@ -208,57 +208,57 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             fprintf(stdout, "sum=%s\n", sum_str);
             break;
         case JSON:
-            json_object_set_number(zone_object, "n", stats[z].n);
-            json_object_set_number(zone_object, "null_cells",
-                                   stats[z].size - stats[z].n);
-            json_object_set_number(zone_object, "cells", stats[z].size);
+            G_json_object_set_number(zone_object, "n", stats[z].n);
+            G_json_object_set_number(zone_object, "null_cells",
+                                     stats[z].size - stats[z].n);
+            G_json_object_set_number(zone_object, "cells", stats[z].size);
 
             if (isfinite(stats[z].min))
-                json_object_set_number(zone_object, "min", stats[z].min);
+                G_json_object_set_number(zone_object, "min", stats[z].min);
             else
-                json_object_set_null(zone_object, "min");
+                G_json_object_set_null(zone_object, "min");
 
             if (isfinite(stats[z].max))
-                json_object_set_number(zone_object, "max", stats[z].max);
+                G_json_object_set_number(zone_object, "max", stats[z].max);
             else
-                json_object_set_null(zone_object, "max");
+                G_json_object_set_null(zone_object, "max");
 
             if (isfinite(stats[z].max - stats[z].min))
-                json_object_set_number(zone_object, "range",
-                                       stats[z].max - stats[z].min);
+                G_json_object_set_number(zone_object, "range",
+                                         stats[z].max - stats[z].min);
             else
-                json_object_set_null(zone_object, "range");
+                G_json_object_set_null(zone_object, "range");
 
             if (isfinite(mean))
-                json_object_set_number(zone_object, "mean", mean);
+                G_json_object_set_number(zone_object, "mean", mean);
             else
-                json_object_set_null(zone_object, "mean");
+                G_json_object_set_null(zone_object, "mean");
 
             if (isfinite(stats[z].sum_abs / stats[z].n))
-                json_object_set_number(zone_object, "mean_of_abs",
-                                       stats[z].sum_abs / stats[z].n);
+                G_json_object_set_number(zone_object, "mean_of_abs",
+                                         stats[z].sum_abs / stats[z].n);
             else
-                json_object_set_null(zone_object, "mean_of_abs");
+                G_json_object_set_null(zone_object, "mean_of_abs");
 
             if (isfinite(stdev))
-                json_object_set_number(zone_object, "stddev", stdev);
+                G_json_object_set_number(zone_object, "stddev", stdev);
             else
-                json_object_set_null(zone_object, "stddev");
+                G_json_object_set_null(zone_object, "stddev");
 
             if (isfinite(variance))
-                json_object_set_number(zone_object, "variance", variance);
+                G_json_object_set_number(zone_object, "variance", variance);
             else
-                json_object_set_null(zone_object, "variance");
+                G_json_object_set_null(zone_object, "variance");
 
             if (isfinite(var_coef))
-                json_object_set_number(zone_object, "coeff_var", var_coef);
+                G_json_object_set_number(zone_object, "coeff_var", var_coef);
             else
-                json_object_set_null(zone_object, "coeff_var");
+                G_json_object_set_null(zone_object, "coeff_var");
 
             if (isfinite(stats[z].sum))
-                json_object_set_number(zone_object, "sum", stats[z].sum);
+                G_json_object_set_number(zone_object, "sum", stats[z].sum);
             else
-                json_object_set_null(zone_object, "sum");
+                G_json_object_set_null(zone_object, "sum");
 
             break;
         case CSV:
@@ -362,21 +362,21 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                 break;
             case JSON:
                 if (isfinite(quartile_25))
-                    json_object_set_number(zone_object, "first_quartile",
-                                           quartile_25);
+                    G_json_object_set_number(zone_object, "first_quartile",
+                                             quartile_25);
                 else
-                    json_object_set_null(zone_object, "first_quartile");
+                    G_json_object_set_null(zone_object, "first_quartile");
 
                 if (isfinite(median))
-                    json_object_set_number(zone_object, "median", median);
+                    G_json_object_set_number(zone_object, "median", median);
                 else
-                    json_object_set_null(zone_object, "median");
+                    G_json_object_set_null(zone_object, "median");
 
                 if (isfinite(quartile_75))
-                    json_object_set_number(zone_object, "third_quartile",
-                                           quartile_75);
+                    G_json_object_set_number(zone_object, "third_quartile",
+                                             quartile_75);
                 else
-                    json_object_set_null(zone_object, "third_quartile");
+                    G_json_object_set_null(zone_object, "third_quartile");
 
                 break;
             case CSV:
@@ -390,12 +390,12 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             JSON_Object *percentile_object = NULL;
 
             if (format == JSON) {
-                percentiles_array_value = json_value_init_array();
+                percentiles_array_value = G_json_value_init_array();
                 if (percentiles_array_value == NULL) {
                     G_fatal_error(
                         _("Failed to initialize JSON array. Out of memory?"));
                 }
-                percentiles_array = json_array(percentiles_array_value);
+                percentiles_array = G_json_array(percentiles_array_value);
             }
 
             for (i = 0; i < stats[z].n_perc; i++) {
@@ -434,27 +434,27 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                             quartile_perc[i]);
                     break;
                 case JSON:
-                    percentile_value = json_value_init_object();
+                    percentile_value = G_json_value_init_object();
                     if (percentile_value == NULL) {
                         G_fatal_error(_("Failed to initialize JSON object. "
                                         "Out of memory?"));
                     }
-                    percentile_object = json_object(percentile_value);
+                    percentile_object = G_json_object(percentile_value);
 
                     if (isfinite(stats[z].perc[i]))
-                        json_object_set_number(percentile_object, "percentile",
-                                               stats[z].perc[i]);
+                        G_json_object_set_number(
+                            percentile_object, "percentile", stats[z].perc[i]);
                     else
-                        json_object_set_null(percentile_object, "percentile");
+                        G_json_object_set_null(percentile_object, "percentile");
 
                     if (isfinite(quartile_perc[i]))
-                        json_object_set_number(percentile_object, "value",
-                                               quartile_perc[i]);
+                        G_json_object_set_number(percentile_object, "value",
+                                                 quartile_perc[i]);
                     else
-                        json_object_set_null(percentile_object, "value");
+                        G_json_object_set_null(percentile_object, "value");
 
-                    json_array_append_value(percentiles_array,
-                                            percentile_value);
+                    G_json_array_append_value(percentiles_array,
+                                              percentile_value);
                     break;
                 case CSV:
                     /* already addressed in print_stats_table */
@@ -463,8 +463,8 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             }
 
             if (format == JSON) {
-                json_object_set_value(zone_object, "percentiles",
-                                      percentiles_array_value);
+                G_json_object_set_value(zone_object, "percentiles",
+                                        percentiles_array_value);
             }
 
             G_free((void *)quartile_perc);
@@ -476,30 +476,30 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
         /* if (!(param.shell_style->answer))
            G_message("\n"); */
         if (format == JSON && zone_info.n_zones) {
-            json_array_append_value(root_array, zone_value);
+            G_json_array_append_value(root_array, zone_value);
         }
     }
 
     if (format == JSON) {
         char *serialized_string = NULL;
         if (zone_info.n_zones) {
-            serialized_string = json_serialize_to_string_pretty(root_value);
+            serialized_string = G_json_serialize_to_string_pretty(root_value);
         }
         else {
-            serialized_string = json_serialize_to_string_pretty(zone_value);
+            serialized_string = G_json_serialize_to_string_pretty(zone_value);
         }
 
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
+        G_json_free_serialized_string(serialized_string);
 
         if (zone_info.n_zones) {
-            json_value_free(root_value);
+            G_json_value_free(root_value);
         }
         else {
-            json_value_free(zone_value);
+            G_json_value_free(zone_value);
         }
     }
 

--- a/raster/r.what.color/main.c
+++ b/raster/r.what.color/main.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <grass/colors.h>
 #include <grass/gis.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
@@ -45,13 +45,13 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
     JSON_Value *color_value = NULL;
 
     if (outputFormat == JSON) {
-        color_value = json_value_init_object();
+        color_value = G_json_value_init_object();
         if (color_value == NULL) {
-            json_value_free(root_value);
+            G_json_value_free(root_value);
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        color_object = json_object(color_value);
+        color_object = G_json_object(color_value);
     }
 
     switch (type) {
@@ -63,9 +63,9 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_null(color_object, "value");
-                json_object_set_null(color_object, "color");
-                json_array_append_value(root_array, color_value);
+                G_json_object_set_null(color_object, "value");
+                G_json_object_set_null(color_object, "color");
+                G_json_array_append_value(root_array, color_value);
                 break;
             }
             return 0;
@@ -77,9 +77,9 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_number(color_object, "value", ival);
-                json_object_set_null(color_object, "color");
-                json_array_append_value(root_array, color_value);
+                G_json_object_set_number(color_object, "value", ival);
+                G_json_object_set_null(color_object, "color");
+                G_json_array_append_value(root_array, color_value);
                 break;
             }
             return 0;
@@ -98,10 +98,10 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
             break;
 
         case JSON:
-            json_object_set_number(color_object, "value", ival);
+            G_json_object_set_number(color_object, "value", ival);
             G_color_to_str(red, grn, blu, colorFormat, color_str);
-            json_object_set_string(color_object, "color", color_str);
-            json_array_append_value(root_array, color_value);
+            G_json_object_set_string(color_object, "color", color_str);
+            G_json_array_append_value(root_array, color_value);
             break;
         }
         return 1;
@@ -115,9 +115,9 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_null(color_object, "value");
-                json_object_set_null(color_object, "color");
-                json_array_append_value(root_array, color_value);
+                G_json_object_set_null(color_object, "value");
+                G_json_object_set_null(color_object, "color");
+                G_json_array_append_value(root_array, color_value);
                 break;
             }
             return 0;
@@ -129,9 +129,9 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_number(color_object, "value", fval);
-                json_object_set_null(color_object, "color");
-                json_array_append_value(root_array, color_value);
+                G_json_object_set_number(color_object, "value", fval);
+                G_json_object_set_null(color_object, "color");
+                G_json_array_append_value(root_array, color_value);
                 break;
             }
             return 0;
@@ -150,16 +150,16 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
             break;
 
         case JSON:
-            json_object_set_number(color_object, "value", fval);
+            G_json_object_set_number(color_object, "value", fval);
             G_color_to_str(red, grn, blu, colorFormat, color_str);
-            json_object_set_string(color_object, "color", color_str);
-            json_array_append_value(root_array, color_value);
+            G_json_object_set_string(color_object, "color", color_str);
+            G_json_array_append_value(root_array, color_value);
             break;
         }
         return 1;
     default:
         if (outputFormat == JSON)
-            json_value_free(root_value);
+            G_json_value_free(root_value);
         G_fatal_error("Invalid map type %d", type);
         return 0;
     }
@@ -241,11 +241,11 @@ int main(int argc, char **argv)
     if (strcmp(fmt, "json") == 0) {
         outputFormat = JSON;
 
-        root_value = json_value_init_array();
+        root_value = G_json_value_init_array();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_array = json_array(root_value);
+        root_array = G_json_array(root_value);
     }
     else {
         outputFormat = PLAIN;
@@ -284,14 +284,14 @@ int main(int argc, char **argv)
 
     if (outputFormat == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
-            json_value_free(root_value);
+            G_json_value_free(root_value);
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     return EXIT_SUCCESS;

--- a/raster/r.what/main.c
+++ b/raster/r.what/main.c
@@ -30,7 +30,7 @@
 #include <grass/raster.h>
 #include <grass/vector.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 struct order {
     int point;
@@ -275,11 +275,11 @@ int main(int argc, char *argv[])
         format = PLAIN;
 
     if (format == JSON) {
-        root_value = json_value_init_array();
+        root_value = G_json_value_init_array();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_array = json_array(root_value);
+        root_array = G_json_array(root_value);
     }
 
     /* print header row */
@@ -549,57 +549,58 @@ int main(int argc, char *argv[])
                 fprintf(stdout, "\n");
             }
             else {
-                point_value = json_value_init_object();
-                point_object = json_object(point_value);
+                point_value = G_json_value_init_object();
+                point_object = G_json_object(point_value);
 
                 if (flg.cat->answer) {
-                    json_object_set_number(point_object, "cat",
-                                           cache[point].cat);
+                    G_json_object_set_number(point_object, "cat",
+                                             cache[point].cat);
                 }
 
-                json_object_set_number(point_object, "easting",
-                                       atof(cache[point].east_buf));
-                json_object_set_number(point_object, "northing",
-                                       atof(cache[point].north_buf));
-                json_object_set_string(point_object, "site_name",
-                                       cache[point].lab_buf);
+                G_json_object_set_number(point_object, "easting",
+                                         atof(cache[point].east_buf));
+                G_json_object_set_number(point_object, "northing",
+                                         atof(cache[point].north_buf));
+                G_json_object_set_string(point_object, "site_name",
+                                         cache[point].lab_buf);
 
                 for (i = 0; i < nfiles; i++) {
-                    layer_value = json_value_init_object();
-                    layer_object = json_object(layer_value);
+                    layer_value = G_json_value_init_object();
+                    layer_object = G_json_object(layer_value);
 
                     if (Rast_is_c_null_value(&cache[point].value[i]) ||
                         Rast_is_d_null_value(&cache[point].dvalue[i])) {
-                        json_object_set_null(layer_object, "value");
+                        G_json_object_set_null(layer_object, "value");
                         if (flg.label->answer)
-                            json_object_set_null(layer_object, "label");
+                            G_json_object_set_null(layer_object, "label");
                         if (flg.color->answer)
-                            json_object_set_null(layer_object, "color");
+                            G_json_object_set_null(layer_object, "color");
                     }
                     else {
                         if (out_type[i] == CELL_TYPE) {
-                            json_object_set_number(layer_object, "value",
-                                                   (long)cache[point].value[i]);
+                            G_json_object_set_number(
+                                layer_object, "value",
+                                (long)cache[point].value[i]);
                             cache[point].dvalue[i] = cache[point].value[i];
                         }
                         else { /* FCELL or DCELL */
-                            json_object_set_number(layer_object, "value",
-                                                   cache[point].dvalue[i]);
+                            G_json_object_set_number(layer_object, "value",
+                                                     cache[point].dvalue[i]);
                         }
                         if (flg.label->answer)
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 layer_object, "label",
                                 Rast_get_d_cat(&(cache[point].dvalue[i]),
                                                &cats[i]));
                         if (flg.color->answer)
-                            json_object_set_string(layer_object, "color",
-                                                   cache[point].clr_buf[i]);
+                            G_json_object_set_string(layer_object, "color",
+                                                     cache[point].clr_buf[i]);
                     }
 
-                    json_object_set_value(point_object, opt.input->answers[i],
-                                          layer_value);
+                    G_json_object_set_value(point_object, opt.input->answers[i],
+                                            layer_value);
                 }
-                json_array_append_value(root_array, point_value);
+                G_json_array_append_value(root_array, point_value);
             }
         }
 
@@ -614,13 +615,13 @@ int main(int argc, char *argv[])
 
     if (format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     if (!opt.coords->answers && !opt.points->answers && tty)

--- a/vector/v.category/main.c
+++ b/vector/v.category/main.c
@@ -19,7 +19,7 @@
 
 #include <grass/glocale.h>
 #include <grass/gis.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include <grass/vector.h>
 
 #define O_ADD       1
@@ -59,14 +59,14 @@ void format_json_fr(FREPORT *freport, int fr_type, char *name,
     JSON_Object *object;
     JSON_Value *value;
     if (freport->count[fr_type] > 0) {
-        value = json_value_init_object();
-        object = json_object(value);
-        json_object_set_string(object, "type", name);
-        json_object_set_number(object, "layer", freport->field);
-        json_object_set_number(object, "count", freport->count[fr_type]);
-        json_object_set_number(object, "min", freport->min[fr_type]);
-        json_object_set_number(object, "max", freport->max[fr_type]);
-        json_array_append_value(array, value);
+        value = G_json_value_init_object();
+        object = G_json_object(value);
+        G_json_object_set_string(object, "type", name);
+        G_json_object_set_number(object, "layer", freport->field);
+        G_json_object_set_number(object, "count", freport->count[fr_type]);
+        G_json_object_set_number(object, "min", freport->min[fr_type]);
+        G_json_object_set_number(object, "max", freport->max[fr_type]);
+        G_json_array_append_value(array, value);
     }
 }
 
@@ -258,12 +258,12 @@ int main(int argc, char *argv[])
         JSON_Array *layers_array = NULL;
         JSON_Value *layers_value = NULL;
         if (format == JSON) {
-            layers_value = json_value_init_array();
+            layers_value = G_json_value_init_array();
             if (layers_value == NULL) {
                 G_fatal_error(
                     _("Failed to initialize JSON array. Out of memory?"));
             }
-            layers_array = json_array(layers_value);
+            layers_array = G_json_array(layers_value);
         }
 
         /* print vector layer numbers */
@@ -293,7 +293,7 @@ int main(int argc, char *argv[])
                         break;
 
                     case JSON:
-                        json_array_append_number(layers_array, field);
+                        G_json_array_append_number(layers_array, field);
                         break;
                     }
                 }
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
                 break;
 
             case JSON:
-                json_array_append_string(layers_array, field_opt->answer);
+                G_json_array_append_string(layers_array, field_opt->answer);
                 break;
             }
         }
@@ -315,24 +315,24 @@ int main(int argc, char *argv[])
         if (format == JSON) {
 
             char *serialized_string = NULL;
-            serialized_string = json_serialize_to_string_pretty(layers_value);
+            serialized_string = G_json_serialize_to_string_pretty(layers_value);
             if (serialized_string == NULL) {
                 G_fatal_error(_("Failed to initialize pretty JSON string."));
             }
             puts(serialized_string);
-            json_free_serialized_string(serialized_string);
-            json_value_free(layers_value);
+            G_json_free_serialized_string(serialized_string);
+            G_json_value_free(layers_value);
         }
         Vect_close(&In);
         exit(EXIT_SUCCESS);
     }
 
     if ((option == O_REP || option == O_PRN) && format == JSON) {
-        root_value = json_value_init_array();
+        root_value = G_json_value_init_array();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_array = json_array(root_value);
+        root_array = G_json_array(root_value);
     }
 
     cat = atoi(cat_opt->answer);
@@ -937,12 +937,12 @@ int main(int argc, char *argv[])
                         JSON_Object *cat_object = NULL;
                         JSON_Value *cat_value = NULL;
                         if (format == JSON) {
-                            cat_value = json_value_init_object();
+                            cat_value = G_json_value_init_object();
                             if (cat_value == NULL) {
                                 G_fatal_error(_("Failed to initialize JSON "
                                                 "object. Out of memory?"));
                             }
-                            cat_object = json_object(cat_value);
+                            cat_object = G_json_object(cat_value);
                         }
 
                         switch (format) {
@@ -960,13 +960,13 @@ int main(int argc, char *argv[])
                             break;
 
                         case JSON:
-                            json_object_set_number(cat_object, "id", id);
-                            json_object_set_number(cat_object, "layer",
-                                                   fields[i]);
-                            json_object_set_number(cat_object, "category",
-                                                   Cats->cat[j]);
+                            G_json_object_set_number(cat_object, "id", id);
+                            G_json_object_set_number(cat_object, "layer",
+                                                     fields[i]);
+                            G_json_object_set_number(cat_object, "category",
+                                                     Cats->cat[j]);
 
-                            json_array_append_value(root_array, cat_value);
+                            G_json_array_append_value(root_array, cat_value);
                             break;
                         }
 
@@ -984,13 +984,13 @@ int main(int argc, char *argv[])
 
     if ((option == O_REP || option == O_PRN) && format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     if (option == O_ADD || option == O_DEL || option == O_CHFIELD ||

--- a/vector/v.distance/main.c
+++ b/vector/v.distance/main.c
@@ -30,7 +30,7 @@
 #include <grass/gis.h>
 #include <grass/glocale.h>
 #include <grass/vector.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 /* Supported command lines:
@@ -305,11 +305,11 @@ int main(int argc, char *argv[])
 
     if (strcmp(opt.format->answer, "json") == 0) {
         format = JSON;
-        root_value = json_value_init_array();
+        root_value = G_json_value_init_array();
         if (root_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        root_array = json_array(root_value);
+        root_array = G_json_array(root_value);
     }
     else {
         format = PLAIN;
@@ -1572,19 +1572,19 @@ int main(int argc, char *argv[])
                 }
                 break;
             case JSON:
-                object_value = json_value_init_object();
+                object_value = G_json_value_init_object();
                 if (object_value == NULL) {
                     G_fatal_error(
                         _("Failed to initialize JSON object. Out of memory?"));
                 }
-                root_object = json_object(object_value);
+                root_object = G_json_object(object_value);
 
-                json_object_set_number(root_object, "from_cat",
-                                       Near[i].from_cat);
-                json_object_set_number(root_object, "to_cat", Near[i].to_cat);
+                G_json_object_set_number(root_object, "from_cat",
+                                         Near[i].from_cat);
+                G_json_object_set_number(root_object, "to_cat", Near[i].to_cat);
                 print_upload(Near, Upload, i, &cvarr, catval, sep, format,
                              root_object);
-                json_array_append_value(root_array, object_value);
+                G_json_array_append_value(root_array, object_value);
                 break;
             }
         }
@@ -1794,13 +1794,13 @@ int main(int argc, char *argv[])
     }
 
     if (format == JSON) {
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     G_percent(count, count, 1);

--- a/vector/v.distance/print.c
+++ b/vector/v.distance/print.c
@@ -21,52 +21,52 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                 switch (Upload[j].upload) {
                 case CAT:
                     if (Near[i].to_cat >= 0)
-                        json_object_set_number(object, "to_cat",
-                                               Near[i].to_cat);
+                        G_json_object_set_number(object, "to_cat",
+                                                 Near[i].to_cat);
                     else {
-                        json_object_set_null(object, "to_cat");
+                        G_json_object_set_null(object, "to_cat");
                     }
                     break;
                 case DIST:
-                    json_object_set_number(object, "dist", Near[i].dist);
+                    G_json_object_set_number(object, "dist", Near[i].dist);
                     break;
                 case FROM_X:
-                    json_object_set_number(object, "from_x", Near[i].from_x);
+                    G_json_object_set_number(object, "from_x", Near[i].from_x);
                     break;
                 case FROM_Y:
-                    json_object_set_number(object, "from_y", Near[i].from_y);
+                    G_json_object_set_number(object, "from_y", Near[i].from_y);
                     break;
                 case TO_X:
-                    json_object_set_number(object, "to_x", Near[i].to_x);
+                    G_json_object_set_number(object, "to_x", Near[i].to_x);
                     break;
                 case TO_Y:
-                    json_object_set_number(object, "to_y", Near[i].to_y);
+                    G_json_object_set_number(object, "to_y", Near[i].to_y);
                     break;
                 case FROM_ALONG:
-                    json_object_set_number(object, "from_along",
-                                           Near[i].from_along);
+                    G_json_object_set_number(object, "from_along",
+                                             Near[i].from_along);
                     break;
                 case TO_ALONG:
-                    json_object_set_number(object, "to_along",
-                                           Near[i].to_along);
+                    G_json_object_set_number(object, "to_along",
+                                             Near[i].to_along);
                     break;
                 case TO_ANGLE:
-                    json_object_set_number(object, "to_angle",
-                                           Near[i].to_angle);
+                    G_json_object_set_number(object, "to_angle",
+                                             Near[i].to_angle);
                     break;
                 case TO_ATTR:
                     if (catval) {
                         switch (cvarr->ctype) {
                         case DB_C_TYPE_INT:
-                            json_object_set_number(object, "to_attr",
-                                                   catval->val.i);
+                            G_json_object_set_number(object, "to_attr",
+                                                     catval->val.i);
                             break;
                         case DB_C_TYPE_DOUBLE:
-                            json_object_set_number(object, "to_attr",
-                                                   catval->val.d);
+                            G_json_object_set_number(object, "to_attr",
+                                                     catval->val.d);
                             break;
                         case DB_C_TYPE_STRING:
-                            json_object_set_string(
+                            G_json_object_set_string(
                                 object, "to_attr",
                                 db_get_string(catval->val.s));
                             break;
@@ -76,7 +76,7 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                         }
                     }
                     else {
-                        json_object_set_null(object, "to_attr");
+                        G_json_object_set_null(object, "to_attr");
                     }
                     break;
                 default:

--- a/vector/v.info/main.c
+++ b/vector/v.info/main.c
@@ -83,8 +83,8 @@ int main(int argc, char *argv[])
     }
 
     if (format == JSON) {
-        root_value = json_value_init_object();
-        root_object = json_value_get_object(root_value);
+        root_value = G_json_value_init_object();
+        root_object = G_json_value_get_object(root_value);
     }
 
     if ((print_content & PRINT_CONTENT_TEXT)) {
@@ -101,13 +101,13 @@ int main(int argc, char *argv[])
     }
 
     if (format == JSON) {
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     Vect_close(&Map);

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -5,7 +5,7 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 #include "local_proto.h"
 
@@ -67,12 +67,12 @@ void print_region(struct Map_info *Map, enum OutputFormat format,
         fprintf(stdout, "bottom=%f\n", box.B);
         break;
     case JSON:
-        json_object_set_number(root_object, "north", box.N);
-        json_object_set_number(root_object, "south", box.S);
-        json_object_set_number(root_object, "east", box.E);
-        json_object_set_number(root_object, "west", box.W);
-        json_object_set_number(root_object, "top", box.T);
-        json_object_set_number(root_object, "bottom", box.B);
+        G_json_object_set_number(root_object, "north", box.N);
+        G_json_object_set_number(root_object, "south", box.S);
+        G_json_object_set_number(root_object, "east", box.E);
+        G_json_object_set_number(root_object, "west", box.W);
+        G_json_object_set_number(root_object, "top", box.T);
+        G_json_object_set_number(root_object, "bottom", box.B);
         break;
     }
 }
@@ -148,30 +148,30 @@ void print_topo(struct Map_info *Map, enum OutputFormat format,
 
         break;
     case JSON:
-        json_object_set_number(root_object, "nodes", Vect_get_num_nodes(Map));
-        json_object_set_number(root_object, "points",
-                               Vect_get_num_primitives(Map, GV_POINT));
-        json_object_set_number(root_object, "lines",
-                               Vect_get_num_primitives(Map, GV_LINE));
-        json_object_set_number(root_object, "boundaries",
-                               Vect_get_num_primitives(Map, GV_BOUNDARY));
-        json_object_set_number(root_object, "centroids",
-                               Vect_get_num_primitives(Map, GV_CENTROID));
-        json_object_set_number(root_object, "areas", Vect_get_num_areas(Map));
-        json_object_set_number(root_object, "islands",
-                               Vect_get_num_islands(Map));
+        G_json_object_set_number(root_object, "nodes", Vect_get_num_nodes(Map));
+        G_json_object_set_number(root_object, "points",
+                                 Vect_get_num_primitives(Map, GV_POINT));
+        G_json_object_set_number(root_object, "lines",
+                                 Vect_get_num_primitives(Map, GV_LINE));
+        G_json_object_set_number(root_object, "boundaries",
+                                 Vect_get_num_primitives(Map, GV_BOUNDARY));
+        G_json_object_set_number(root_object, "centroids",
+                                 Vect_get_num_primitives(Map, GV_CENTROID));
+        G_json_object_set_number(root_object, "areas", Vect_get_num_areas(Map));
+        G_json_object_set_number(root_object, "islands",
+                                 Vect_get_num_islands(Map));
         if (with_z) {
-            json_object_set_number(root_object, "faces",
-                                   Vect_get_num_primitives(Map, GV_FACE));
-            json_object_set_number(root_object, "kernels",
-                                   Vect_get_num_primitives(Map, GV_KERNEL));
-            json_object_set_number(root_object, "volumes",
-                                   Vect_get_num_primitives(Map, GV_VOLUME));
-            json_object_set_number(root_object, "holes",
-                                   Vect_get_num_holes(Map));
+            G_json_object_set_number(root_object, "faces",
+                                     Vect_get_num_primitives(Map, GV_FACE));
+            G_json_object_set_number(root_object, "kernels",
+                                     Vect_get_num_primitives(Map, GV_KERNEL));
+            G_json_object_set_number(root_object, "volumes",
+                                     Vect_get_num_primitives(Map, GV_VOLUME));
+            G_json_object_set_number(root_object, "holes",
+                                     Vect_get_num_holes(Map));
         }
-        json_object_set_number(root_object, "primitives", nprimitives);
-        json_object_set_boolean(root_object, "map3d", Vect_is_3d(Map));
+        G_json_object_set_number(root_object, "primitives", nprimitives);
+        G_json_object_set_boolean(root_object, "map3d", Vect_is_3d(Map));
     }
 }
 
@@ -234,11 +234,11 @@ void print_columns(struct Map_info *Map, const char *input_opt,
     JSON_Array *columns_array = NULL;
 
     if (format == JSON) {
-        root_value = json_value_init_object();
-        root_object = json_object(root_value);
-        columns_value = json_value_init_array();
-        columns_array = json_array(columns_value);
-        json_object_set_value(root_object, "columns", columns_value);
+        root_value = G_json_value_init_object();
+        root_object = G_json_object(root_value);
+        columns_value = G_json_value_init_array();
+        columns_array = G_json_array(columns_value);
+        G_json_object_set_value(root_object, "columns", columns_value);
     }
 
     ncols = db_get_table_number_of_columns(table);
@@ -252,24 +252,24 @@ void print_columns(struct Map_info *Map, const char *input_opt,
             break;
 
         case JSON:
-            column_value = json_value_init_object();
-            column_object = json_object(column_value);
+            column_value = G_json_value_init_object();
+            column_object = G_json_object(column_value);
 
-            json_object_set_string(
+            G_json_object_set_string(
                 column_object, "name",
                 db_get_column_name(db_get_table_column(table, col)));
 
             int sql_type =
                 db_get_column_sqltype(db_get_table_column(table, col));
-            json_object_set_string(column_object, "sql_type",
-                                   db_sqltype_name(sql_type));
+            G_json_object_set_string(column_object, "sql_type",
+                                     db_sqltype_name(sql_type));
 
             int c_type = db_sqltype_to_Ctype(sql_type);
-            json_object_set_boolean(
+            G_json_object_set_boolean(
                 column_object, "is_number",
                 (c_type == DB_C_TYPE_INT || c_type == DB_C_TYPE_DOUBLE));
 
-            json_array_append_value(columns_array, column_value);
+            G_json_array_append_value(columns_array, column_value);
             break;
 
         case PLAIN:
@@ -283,16 +283,16 @@ void print_columns(struct Map_info *Map, const char *input_opt,
 
     if (format == JSON) {
         char *serialized_string = NULL;
-        serialized_string = json_serialize_to_string_pretty(root_value);
+        serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
-            json_value_free(root_value);
+            G_json_value_free(root_value);
             db_close_database_shutdown_driver(driver);
             Vect_close(Map);
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     Vect_destroy_field_info(fi);
@@ -345,17 +345,17 @@ void print_shell(struct Map_info *Map, const char *field_opt,
         fprintf(stdout, "source_date=%s\n", Vect_get_map_date(Map));
         break;
     case JSON:
-        json_object_set_string(root_object, "name", Vect_get_name(Map));
-        json_object_set_string(root_object, "mapset", Vect_get_mapset(Map));
-        json_object_set_string(root_object, "project", G_location());
-        json_object_set_string(root_object, "database", G_gisdbase());
-        json_object_set_string(root_object, "title", Vect_get_map_name(Map));
-        json_object_set_string(root_object, "scale", scale_tmp);
-        json_object_set_string(root_object, "creator", Vect_get_person(Map));
-        json_object_set_string(root_object, "organization",
-                               Vect_get_organization(Map));
-        json_object_set_string(root_object, "source_date",
-                               Vect_get_map_date(Map));
+        G_json_object_set_string(root_object, "name", Vect_get_name(Map));
+        G_json_object_set_string(root_object, "mapset", Vect_get_mapset(Map));
+        G_json_object_set_string(root_object, "project", G_location());
+        G_json_object_set_string(root_object, "database", G_gisdbase());
+        G_json_object_set_string(root_object, "title", Vect_get_map_name(Map));
+        G_json_object_set_string(root_object, "scale", scale_tmp);
+        G_json_object_set_string(root_object, "creator", Vect_get_person(Map));
+        G_json_object_set_string(root_object, "organization",
+                                 Vect_get_organization(Map));
+        G_json_object_set_string(root_object, "source_date",
+                                 Vect_get_map_date(Map));
         break;
     }
 
@@ -369,7 +369,7 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "timestamp=%s\n", timebuff);
             break;
         case JSON:
-            json_object_set_string(root_object, "timestamp", timebuff);
+            G_json_object_set_string(root_object, "timestamp", timebuff);
             break;
         }
     }
@@ -381,7 +381,7 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "timestamp=none\n");
             break;
         case JSON:
-            json_object_set_null(root_object, "timestamp");
+            G_json_object_set_null(root_object, "timestamp");
             break;
         }
     }
@@ -398,13 +398,13 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "feature_type=%s\n", geom_type);
             break;
         case JSON:
-            json_object_set_string(root_object, "format", maptype_str);
-            json_object_set_string(root_object, "format-detail",
-                                   Vect_get_finfo_format_info(Map));
-            json_object_set_string(root_object, "ogr_layer", finfo_lname);
-            json_object_set_string(root_object, "ogr_dsn",
-                                   Vect_get_finfo_dsn_name(Map));
-            json_object_set_string(root_object, "feature_type", geom_type);
+            G_json_object_set_string(root_object, "format", maptype_str);
+            G_json_object_set_string(root_object, "format-detail",
+                                     Vect_get_finfo_format_info(Map));
+            G_json_object_set_string(root_object, "ogr_layer", finfo_lname);
+            G_json_object_set_string(root_object, "ogr_dsn",
+                                     Vect_get_finfo_dsn_name(Map));
+            G_json_object_set_string(root_object, "feature_type", geom_type);
             break;
         }
     }
@@ -427,15 +427,15 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "feature_type=%s\n", geom_type);
             break;
         case JSON:
-            json_object_set_string(root_object, "format", maptype_str);
-            json_object_set_string(root_object, "format-detail",
-                                   Vect_get_finfo_format_info(Map));
-            json_object_set_string(root_object, "pg_table", finfo_lname);
-            json_object_set_string(root_object, "pg_dbname",
-                                   Vect_get_finfo_dsn_name(Map));
-            json_object_set_string(root_object, "geometry_column",
-                                   finfo->pg.geom_column);
-            json_object_set_string(root_object, "feature_type", geom_type);
+            G_json_object_set_string(root_object, "format", maptype_str);
+            G_json_object_set_string(root_object, "format-detail",
+                                     Vect_get_finfo_format_info(Map));
+            G_json_object_set_string(root_object, "pg_table", finfo_lname);
+            G_json_object_set_string(root_object, "pg_dbname",
+                                     Vect_get_finfo_dsn_name(Map));
+            G_json_object_set_string(root_object, "geometry_column",
+                                     finfo->pg.geom_column);
+            G_json_object_set_string(root_object, "feature_type", geom_type);
             break;
         }
 
@@ -450,10 +450,10 @@ void print_shell(struct Map_info *Map, const char *field_opt,
                 fprintf(stdout, "pg_topo_column=%s\n", topogeom_column);
                 break;
             case JSON:
-                json_object_set_string(root_object, "pg_topo_schema",
-                                       toposchema_name);
-                json_object_set_string(root_object, "pg_topo_column",
-                                       topogeom_column);
+                G_json_object_set_string(root_object, "pg_topo_schema",
+                                         toposchema_name);
+                G_json_object_set_string(root_object, "pg_topo_column",
+                                         topogeom_column);
                 break;
             }
         }
@@ -468,7 +468,7 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "format=%s\n", maptype_str);
             break;
         case JSON:
-            json_object_set_string(root_object, "format", maptype_str);
+            G_json_object_set_string(root_object, "format", maptype_str);
             break;
         }
     }
@@ -480,7 +480,7 @@ void print_shell(struct Map_info *Map, const char *field_opt,
         fprintf(stdout, "level=%d\n", Vect_level(Map));
         break;
     case JSON:
-        json_object_set_number(root_object, "level", Vect_level(Map));
+        G_json_object_set_number(root_object, "level", Vect_level(Map));
         break;
     }
     if (Vect_level(Map) > 0) {
@@ -491,8 +491,8 @@ void print_shell(struct Map_info *Map, const char *field_opt,
             fprintf(stdout, "num_dblinks=%d\n", Vect_get_num_dblinks(Map));
             break;
         case JSON:
-            json_object_set_number(root_object, "num_dblinks",
-                                   Vect_get_num_dblinks(Map));
+            G_json_object_set_number(root_object, "num_dblinks",
+                                     Vect_get_num_dblinks(Map));
             break;
         }
 
@@ -512,18 +512,18 @@ void print_shell(struct Map_info *Map, const char *field_opt,
                     fprintf(stdout, "attribute_primary_key=%s\n", fi->key);
                     break;
                 case JSON:
-                    json_object_set_number(
+                    G_json_object_set_number(
                         root_object, "attribute_layer_number", fi->number);
-                    json_object_set_string(root_object, "attribute_layer_name",
-                                           fi->name);
-                    json_object_set_string(root_object, "attribute_database",
-                                           fi->database);
-                    json_object_set_string(
+                    G_json_object_set_string(root_object,
+                                             "attribute_layer_name", fi->name);
+                    G_json_object_set_string(root_object, "attribute_database",
+                                             fi->database);
+                    G_json_object_set_string(
                         root_object, "attribute_database_driver", fi->driver);
-                    json_object_set_string(root_object, "attribute_table",
-                                           fi->table);
-                    json_object_set_string(root_object, "attribute_primary_key",
-                                           fi->key);
+                    G_json_object_set_string(root_object, "attribute_table",
+                                             fi->table);
+                    G_json_object_set_string(root_object,
+                                             "attribute_primary_key", fi->key);
                     break;
                 }
             }
@@ -543,14 +543,14 @@ void print_shell(struct Map_info *Map, const char *field_opt,
         fprintf(stdout, "comment=%s\n", Vect_get_comment(Map));
         break;
     case JSON:
-        json_object_set_string(root_object, "projection",
-                               Vect_get_proj_name(Map));
+        G_json_object_set_string(root_object, "projection",
+                                 Vect_get_proj_name(Map));
         if (G_projection() == PROJECTION_UTM) {
-            json_object_set_number(root_object, "zone", Vect_get_zone(Map));
+            G_json_object_set_number(root_object, "zone", Vect_get_zone(Map));
         }
-        json_object_set_number(root_object, "digitization_threshold",
-                               Vect_get_thresh(Map));
-        json_object_set_string(root_object, "comment", Vect_get_comment(Map));
+        G_json_object_set_number(root_object, "digitization_threshold",
+                                 Vect_get_thresh(Map));
+        G_json_object_set_string(root_object, "comment", Vect_get_comment(Map));
         break;
     }
     G_free(finfo_lname);
@@ -819,19 +819,19 @@ void add_record_to_json(char *command, char *user, char *date,
                         int history_number)
 {
 
-    JSON_Value *info_value = json_value_init_object();
+    JSON_Value *info_value = G_json_value_init_object();
     if (info_value == NULL) {
         G_fatal_error(_("Failed to initialize JSON object. Out of memory?"));
     }
-    JSON_Object *info_object = json_object(info_value);
+    JSON_Object *info_object = G_json_object(info_value);
 
-    json_object_set_number(info_object, "history_number", history_number);
-    json_object_set_string(info_object, "command", command);
-    json_object_set_string(info_object, "mapset_path", mapset_path);
-    json_object_set_string(info_object, "user", user);
-    json_object_set_string(info_object, "date", date);
+    G_json_object_set_number(info_object, "history_number", history_number);
+    G_json_object_set_string(info_object, "command", command);
+    G_json_object_set_string(info_object, "mapset_path", mapset_path);
+    G_json_object_set_string(info_object, "user", user);
+    G_json_object_set_string(info_object, "date", date);
 
-    json_array_append_value(record_array, info_value);
+    G_json_array_append_value(record_array, info_value);
 }
 
 /*!
@@ -854,18 +854,18 @@ void print_history(struct Map_info *Map, enum OutputFormat format)
     JSON_Array *record_array = NULL;
 
     if (format == JSON) {
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        root_object = json_object(root_value);
+        root_object = G_json_object(root_value);
 
-        record_value = json_value_init_array();
+        record_value = G_json_value_init_array();
         if (record_value == NULL) {
             G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
         }
-        record_array = json_array(record_value);
+        record_array = G_json_array(record_value);
     }
 
     Vect_hist_rewind(Map);
@@ -899,16 +899,16 @@ void print_history(struct Map_info *Map, enum OutputFormat format)
     }
 
     if (format == JSON) {
-        json_object_set_value(root_object, "records", record_value);
+        G_json_object_set_value(root_object, "records", record_value);
 
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (!serialized_string) {
-            json_value_free(root_value);
+            G_json_value_free(root_value);
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
 
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 }

--- a/vector/v.to.db/report.c
+++ b/vector/v.to.db/report.c
@@ -15,16 +15,16 @@ int report(enum OutputFormat format)
     // todo: add measurement unit
 
     if (format == JSON) {
-        root_value = json_value_init_object();
-        root_object = json_object(root_value);
-        records_value = json_value_init_array();
-        records_array = json_array(records_value);
+        root_value = G_json_value_init_object();
+        root_object = G_json_object(root_value);
+        records_value = G_json_value_init_array();
+        records_array = G_json_array(records_value);
 
-        units_value = json_value_init_object();
-        units_object = json_object(units_value);
+        units_value = G_json_value_init_object();
+        units_object = G_json_object(units_value);
 
-        totals_value = json_value_init_object();
-        totals_object = json_object(totals_value);
+        totals_value = G_json_value_init_object();
+        totals_object = G_json_object(totals_value);
 
         get_unit_name(unit_name);
     }
@@ -52,10 +52,10 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_array_append_value(records_array, record_value);
             }
         }
         break;
@@ -81,14 +81,14 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "count", Values[i].count1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "count", Values[i].count1);
+                G_json_array_append_value(records_array, record_value);
                 sum += Values[i].count1;
             }
-            json_object_set_number(totals_object, "count", sum);
+            G_json_object_set_number(totals_object, "count", sum);
             break;
         }
         break;
@@ -114,15 +114,15 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "area", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "area", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
                 fsum += Values[i].d1;
             }
-            json_object_set_string(units_object, "area", unit_name);
-            json_object_set_number(totals_object, "area", fsum);
+            G_json_object_set_string(units_object, "area", unit_name);
+            G_json_object_set_number(totals_object, "area", fsum);
             break;
         }
         break;
@@ -142,14 +142,14 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
 
                 Values[i].d1 = Values[i].d2 / (2.0 * sqrt(M_PI * Values[i].d1));
-                json_object_set_number(record, "compact", Values[i].d1);
+                G_json_object_set_number(record, "compact", Values[i].d1);
 
-                json_array_append_value(records_array, record_value);
+                G_json_array_append_value(records_array, record_value);
             }
             break;
         }
@@ -180,16 +180,16 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
 
                 if (Values[i].d1 == 1) /* log(1) == 0 */
                     Values[i].d1 += 0.000001;
                 Values[i].d1 = 2.0 * log(Values[i].d2) / log(Values[i].d1);
-                json_object_set_number(record, "fd", Values[i].d1);
+                G_json_object_set_number(record, "fd", Values[i].d1);
 
-                json_array_append_value(records_array, record_value);
+                G_json_array_append_value(records_array, record_value);
             }
             break;
         }
@@ -206,13 +206,13 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "perimeter", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "perimeter", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
             }
-            json_object_set_string(units_object, "perimeter", unit_name);
+            G_json_object_set_string(units_object, "perimeter", unit_name);
             break;
         }
         break;
@@ -232,14 +232,14 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "north", Values[i].d1);
-                json_object_set_number(record, "south", Values[i].d2);
-                json_object_set_number(record, "east", Values[i].d3);
-                json_object_set_number(record, "west", Values[i].d4);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "north", Values[i].d1);
+                G_json_object_set_number(record, "south", Values[i].d2);
+                G_json_object_set_number(record, "east", Values[i].d3);
+                G_json_object_set_number(record, "west", Values[i].d4);
+                G_json_array_append_value(records_array, record_value);
             }
             break;
         }
@@ -266,15 +266,15 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "length", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "length", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
                 fsum += Values[i].d1;
             }
-            json_object_set_string(units_object, "length", unit_name);
-            json_object_set_number(totals_object, "length", fsum);
+            G_json_object_set_string(units_object, "length", unit_name);
+            G_json_object_set_number(totals_object, "length", fsum);
             break;
         }
         break;
@@ -289,11 +289,11 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "slope", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "slope", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
             }
             break;
         }
@@ -310,11 +310,11 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "sinuous", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "sinuous", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
             }
             break;
         }
@@ -337,13 +337,13 @@ int report(enum OutputFormat format)
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
                 if (Values[i].count1 == 1) {
-                    record_value = json_value_init_object();
-                    record = json_object(record_value);
-                    json_object_set_number(record, "category", Values[i].cat);
-                    json_object_set_number(record, "x", Values[i].d1);
-                    json_object_set_number(record, "y", Values[i].d2);
-                    json_object_set_number(record, "z", Values[i].d3);
-                    json_array_append_value(records_array, record_value);
+                    record_value = G_json_value_init_object();
+                    record = G_json_object(record_value);
+                    G_json_object_set_number(record, "category", Values[i].cat);
+                    G_json_object_set_number(record, "x", Values[i].d1);
+                    G_json_object_set_number(record, "y", Values[i].d2);
+                    G_json_object_set_number(record, "z", Values[i].d3);
+                    G_json_array_append_value(records_array, record_value);
                 }
             }
             break;
@@ -393,39 +393,39 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
 
                 if (Values[i].count1 == 1) {
                     if (Values[i].i1 >= 0)
-                        json_object_set_number(record, "left", Values[i].i1);
+                        G_json_object_set_number(record, "left", Values[i].i1);
                     else
-                        json_object_set_number(record, "left",
-                                               -1); /* NULL, no area/cat */
+                        G_json_object_set_number(record, "left",
+                                                 -1); /* NULL, no area/cat */
                 }
                 else if (Values[i].count1 > 1) {
-                    json_object_set_null(record, "left");
+                    G_json_object_set_null(record, "left");
                 }
                 else { /* Values[i].count1 == 0 */
                     /* It can be OK if the category is assigned to an element
                        type which is not GV_BOUNDARY */
                     /* -> TODO: print only if there is boundary with that cat */
-                    json_object_set_null(record, "left");
+                    G_json_object_set_null(record, "left");
                 }
 
                 if (Values[i].count2 == 1) {
                     if (Values[i].i2 >= 0)
-                        json_object_set_number(record, "right", Values[i].i2);
+                        G_json_object_set_number(record, "right", Values[i].i2);
                     else
-                        json_object_set_number(record, "right",
-                                               -1); /* NULL, no area/cat */
+                        G_json_object_set_number(record, "right",
+                                                 -1); /* NULL, no area/cat */
                 }
                 else if (Values[i].count2 > 1) {
-                    json_object_set_null(record, "right");
+                    G_json_object_set_null(record, "right");
                 }
                 else { /* Values[i].count1 == 0 */
-                    json_object_set_null(record, "right");
+                    G_json_object_set_null(record, "right");
                 }
             }
             break;
@@ -461,21 +461,22 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
                 if (Values[i].null) {
-                    json_object_set_null(record, "query");
+                    G_json_object_set_null(record, "query");
                 }
                 else {
                     switch (vstat.qtype) {
                     case (DB_C_TYPE_INT):
-                        json_object_set_number(record, "query", Values[i].i1);
+                        G_json_object_set_number(record, "query", Values[i].i1);
                         break;
                     case (DB_C_TYPE_DOUBLE):
-                        json_object_set_number(record, "query", Values[i].d1);
+                        G_json_object_set_number(record, "query", Values[i].d1);
                         break;
                     case (DB_C_TYPE_STRING):
-                        json_object_set_string(record, "query", Values[i].str1);
+                        G_json_object_set_string(record, "query",
+                                                 Values[i].str1);
                         break;
                     }
                 }
@@ -493,29 +494,29 @@ int report(enum OutputFormat format)
             break;
         case JSON:
             for (i = 0; i < vstat.rcat; i++) {
-                record_value = json_value_init_object();
-                record = json_object(record_value);
-                json_object_set_number(record, "category", Values[i].cat);
-                json_object_set_number(record, "azimuth", Values[i].d1);
-                json_array_append_value(records_array, record_value);
+                record_value = G_json_value_init_object();
+                record = G_json_object(record_value);
+                G_json_object_set_number(record, "category", Values[i].cat);
+                G_json_object_set_number(record, "azimuth", Values[i].d1);
+                G_json_array_append_value(records_array, record_value);
             }
-            json_object_set_string(units_object, "azimuth", unit_name);
+            G_json_object_set_string(units_object, "azimuth", unit_name);
             break;
         }
         break;
     }
 
     if (format == JSON) {
-        json_object_set_value(root_object, "units", units_value);
-        json_object_set_value(root_object, "totals", totals_value);
-        json_object_set_value(root_object, "records", records_value);
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        G_json_object_set_value(root_object, "units", units_value);
+        G_json_object_set_value(root_object, "totals", totals_value);
+        G_json_object_set_value(root_object, "records", records_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 
     return 0;

--- a/vector/v.univar/main.c
+++ b/vector/v.univar/main.c
@@ -43,7 +43,7 @@
 #include <grass/vector.h>
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
+#include <grass/gjson.h>
 
 static void select_from_geometry(void);
 static void select_from_database(void);
@@ -624,43 +624,43 @@ void summary(void)
     G_debug(3, "otype %d:", otype);
 
     if (format == JSON) {
-        root_value = json_value_init_object();
+        root_value = G_json_value_init_object();
         if (root_value == NULL) {
             G_fatal_error(
                 _("Failed to initialize JSON object. Out of memory?"));
         }
-        root_object = json_object(root_value);
+        root_object = G_json_object(root_value);
 
-        json_object_set_number(root_object, "n", count);
+        G_json_object_set_number(root_object, "n", count);
         if (geometry->answer) {
-            json_object_set_number(root_object, "nzero", nzero);
+            G_json_object_set_number(root_object, "nzero", nzero);
         }
         else {
-            json_object_set_number(root_object, "missing", nmissing);
-            json_object_set_number(root_object, "nnull", nnull);
+            G_json_object_set_number(root_object, "missing", nmissing);
+            G_json_object_set_number(root_object, "nnull", nnull);
         }
         if (count > 0) {
-            json_object_set_number(root_object, "min", min);
-            json_object_set_number(root_object, "max", max);
-            json_object_set_number(root_object, "range", max - min);
-            json_object_set_number(root_object, "sum", sum);
+            G_json_object_set_number(root_object, "min", min);
+            G_json_object_set_number(root_object, "max", max);
+            G_json_object_set_number(root_object, "range", max - min);
+            G_json_object_set_number(root_object, "sum", sum);
             if (compatible) {
-                json_object_set_number(root_object, "mean", mean);
-                json_object_set_number(root_object, "mean_abs", mean_abs);
+                G_json_object_set_number(root_object, "mean", mean);
+                G_json_object_set_number(root_object, "mean_abs", mean_abs);
                 if (geometry->answer || !weight_flag->answer) {
-                    json_object_set_number(root_object, "population_stddev",
-                                           pop_stdev);
-                    json_object_set_number(root_object, "population_variance",
-                                           pop_variance);
-                    json_object_set_number(root_object,
-                                           "population_coeff_variation",
-                                           pop_coeff_variation);
-                    json_object_set_number(root_object, "sample_stddev",
-                                           sample_stdev);
-                    json_object_set_number(root_object, "sample_variance",
-                                           sample_variance);
-                    json_object_set_number(root_object, "kurtosis", kurtosis);
-                    json_object_set_number(root_object, "skewness", skewness);
+                    G_json_object_set_number(root_object, "population_stddev",
+                                             pop_stdev);
+                    G_json_object_set_number(root_object, "population_variance",
+                                             pop_variance);
+                    G_json_object_set_number(root_object,
+                                             "population_coeff_variation",
+                                             pop_coeff_variation);
+                    G_json_object_set_number(root_object, "sample_stddev",
+                                             sample_stdev);
+                    G_json_object_set_number(root_object, "sample_variance",
+                                             sample_variance);
+                    G_json_object_set_number(root_object, "kurtosis", kurtosis);
+                    G_json_object_set_number(root_object, "skewness", skewness);
                 }
             }
         }
@@ -772,20 +772,23 @@ void summary(void)
         }
 
         if (format == JSON) {
-            json_object_set_number(root_object, "first_quartile", quartile_25);
-            json_object_set_number(root_object, "median", median);
-            json_object_set_number(root_object, "third_quartile", quartile_75);
+            G_json_object_set_number(root_object, "first_quartile",
+                                     quartile_25);
+            G_json_object_set_number(root_object, "median", median);
+            G_json_object_set_number(root_object, "third_quartile",
+                                     quartile_75);
 
-            JSON_Value *percentiles_array_value = json_value_init_array();
-            JSON_Array *percentiles_array = json_array(percentiles_array_value);
-            JSON_Value *percentile_value = json_value_init_object();
-            JSON_Object *percentile_object = json_object(percentile_value);
+            JSON_Value *percentiles_array_value = G_json_value_init_array();
+            JSON_Array *percentiles_array =
+                G_json_array(percentiles_array_value);
+            JSON_Value *percentile_value = G_json_value_init_object();
+            JSON_Object *percentile_object = G_json_object(percentile_value);
 
-            json_object_set_number(percentile_object, "percentile", perc);
-            json_object_set_number(percentile_object, "value", quartile_perc);
-            json_array_append_value(percentiles_array, percentile_value);
-            json_object_set_value(root_object, "percentiles",
-                                  percentiles_array_value);
+            G_json_object_set_number(percentile_object, "percentile", perc);
+            G_json_object_set_number(percentile_object, "value", quartile_perc);
+            G_json_array_append_value(percentiles_array, percentile_value);
+            G_json_object_set_value(root_object, "percentiles",
+                                    percentiles_array_value);
         }
         else if (format == SHELL) {
             fprintf(stdout, "first_quartile=%g\n", quartile_25);
@@ -813,12 +816,12 @@ void summary(void)
     }
 
     if (format == JSON) {
-        char *serialized_string = json_serialize_to_string_pretty(root_value);
+        char *serialized_string = G_json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);
-        json_free_serialized_string(serialized_string);
-        json_value_free(root_value);
+        G_json_free_serialized_string(serialized_string);
+        G_json_value_free(root_value);
     }
 }


### PR DESCRIPTION
In light of #6398, this PR replaces the direct use of parson with the wrapper functions. It does not solve the problem, but we would have to do that in any case. Leaving as draft to review this again to see if I didn't miss anything.