### PR TITLE
CI: minimalistic flake8 backport to re-enable pre-commit and CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,10 @@
 ignore =
     # whitespace before ':' (Black)
     E203,
+    # E501 line too long
+    E501,
+    # global unused (TODO: Solve and remove exclusion)
+    F824,
     # line break before binary operator (Black)
     W503,
 
@@ -196,6 +200,7 @@ per-file-ignores =
 
 
 max-line-length = 88
+# Remember to remove the exclusions from .pre-commit-config.yaml when removing here
 exclude =
     .git,
     __pycache__,
@@ -213,6 +218,7 @@ exclude =
     # Test output directory
     testreport,
     # Not yet compliant
+    python/grass/temporal/ply,
     python/libgrass_interface_generator,
     # No tests checked for now
     testsuite,

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           fetch-depth: 31
 
-      - name: Check for CRLF endings
-        uses: erclu/check-crlf@94acb86c2a41b0a46bd8087b63a06f0457dd0c6c # v1.2.0
-        with:
-          # Ignore all test data, Windows-specific directories and scripts.
-          exclude: mswindows .*\.bat .*/testsuite/data/.*
 
       - name: Set up Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,14 @@ repos:
                 python/libgrass_interface_generator/
           )
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 7.3.0
     hooks:
       - id: flake8
         exclude: |
           (?x)^(
-                python/libgrass_interface_generator/
+                python/grass/temporal/ply/|
+                python/libgrass_interface_generator/|
+                .*/testsuite/.*
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v15.0.6

--- a/raster/r.geomorphon/r.geomorphon.html
+++ b/raster/r.geomorphon/r.geomorphon.html
@@ -34,7 +34,7 @@ different from the horizon. Two lines-of-sight are necessary due to zenith
 LOS only, does not detect positive forms correctly.
 
 <p> There are 3**8 = 6561 possible ternary patterns (8-tuples). By removing
-all patterns that are the result of either rotation or reflection of other 
+all patterns that are the result of either rotation or reflection of other
 patterns, a set of 498 patterns remains, referred to as geomorphons.
 This is a comprehensive and exhaustive set of idealized landforms that are
 independent of the size, relief, and orientation of the actual landform.


### PR DESCRIPTION
This PR is a minimalistic flake8 settings backport to re-enable pre-commit and CI in relbranch84.
