### PR TITLE
v.overlay: preserve SQL type text

### DIFF
--- a/vector/v.overlay/main.c
+++ b/vector/v.overlay/main.c
@@ -475,7 +475,7 @@ int main(int argc, char *argv[])
                     db_append_string(&col_defs, buf);
                     break;
                 case DB_SQL_TYPE_TEXT:
-                    db_append_string(&col_defs, "varchar(250)");
+                    db_append_string(&col_defs, "text");
                     break;
                 case DB_SQL_TYPE_SMALLINT:
                 case DB_SQL_TYPE_INTEGER:


### PR DESCRIPTION
back [then](https://github.com/OSGeo/grass/commit/ee9579d97f51058afc28c8c5be99f65fd41d1404) support for SQL type text (unlimited varchar) was added to `v.overlay` and for reasons of backwards compatibility with dbf, columns of type "text" were converted to type "varchar(250)" which is not the same. The db drivers automatically convert text to varchar if text is not supported.

This should be regarded as a bug because column types should not be changed by modules when copying columns.