### PR TITLE
grass.script: Raise, not fatal in create_project

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -2006,19 +2006,11 @@ def create_project(
             )
         return env
 
-    # check if location already exists
+    # check if a project with the same name already exists
     if Path(mapset_path.directory, mapset_path.location).exists():
         if not overwrite:
-            fatal(
-                _("Location <%s> already exists. Operation canceled.")
-                % mapset_path.location,
-                env=local_env(),
-            )
-        warning(
-            _("Location <%s> already exists and will be overwritten")
-            % mapset_path.location,
-            env=local_env(),
-        )
+            msg = f"Project <{mapset_path.location}> already exists"
+            raise ScriptError(msg)
         shutil.rmtree(os.path.join(mapset_path.directory, mapset_path.location))
 
     stdin = None

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 import grass.script as gs
+from grass.exceptions import ScriptError
 
 xfail_mp_spawn = pytest.mark.xfail(
     multiprocessing.get_start_method() == "spawn",
@@ -165,9 +166,20 @@ def test_files(tmp_path):
         assert description_file.read_text(encoding="utf-8").strip() == description
 
 
+@pytest.mark.parametrize("overwrite", [False, None])
+def test_project_no_overwrite(tmp_path, overwrite):
+    """Check that project we raise exception when project exists"""
+    project = tmp_path / "project_1"
+    gs.create_project(project, overwrite=overwrite)
+    assert project.exists()
+    with pytest.raises(ScriptError, match=r"project_1.*already exists"):
+        gs.create_project(project, overwrite=overwrite)
+    assert project.exists()
+
+
 def test_project_overwrite(tmp_path):
-    """Check that project can be overwritten"""
-    project = tmp_path / "project"
+    """Check that existing project can be overwritten"""
+    project = tmp_path / "project_1"
     gs.create_project(project)
     assert project.exists()
     gs.create_project(project, overwrite=True)


### PR DESCRIPTION
The create_project function (and the create_location function) specify in the documentation that it raises ScriptError on error. However, in some cases it calls fatal instead leading to system exit (SystemExit exception) instead with the default settings. This changes the fatal call into raise so that it aligns with the documentation and with other places in the function which raise ScriptError. This also makes it to behave in a more expected way in standard Python workflow.

Current GRASS code already wraps the calls into try-except with ScriptError. In case of GUI, it checks the specific existence condition ahead of time.

The exception text is not translatable according to the our new practice for exceptions.

This also removes the warning when the project exists and overwrite is set to True. This is explicitly requested behavior, so warning not required. Additionally, while it kind of fit together with fatal with overwrite set to False, not it does not fit. Removing it also removes the need for a translatable string at that place which is often used with minimal setup during startup, so the result is simpler, less fragile code.

Tests now cover all combinations cases (does not exist, exists, with and without overwrite).
