### PR TITLE
grass.gunittest: Avoid printing errors twice

### DIFF
--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -72,13 +72,6 @@ class TextTestResult(grass.gunittest.result.TestResult, unittest.TextTestResult)
 
     def stopTestRun(self) -> None:
         super().stopTestRun()
-        self.printErrors()
-        self.stream.writeln(self.separator2)
-        run = self.testsRun
-        self.stream.write("Ran %d test%s" % (run, (run != 1 and "s") or ""))
-        if self.time_taken:
-            self.stream.write(" in %.3fs" % (self.time_taken))
-        self.stream.writeln()
 
         expectedFails = unexpectedSuccesses = skipped = 0
         results = map(


### PR DESCRIPTION
For failed tests, the errors were printed twice, once by the GRASS gunittest class and once the Python unittest class. This removes the duplicated prints.
