### PR TITLE
v.extract: Fix Resource Leak Issue in extract.c

### DIFF
--- a/vector/v.extract/extract.c
+++ b/vector/v.extract/extract.c
@@ -472,6 +472,5 @@ int extract_line(int num_index, int *num_array, struct Map_info *In,
     Vect_destroy_field_info(Fi);
     Vect_destroy_cats_struct(Line_Cats_Old);
     Vect_destroy_line_struct(Points);
-    
     return 0;
 }

--- a/vector/v.extract/extract.c
+++ b/vector/v.extract/extract.c
@@ -470,6 +470,8 @@ int extract_line(int num_index, int *num_array, struct Map_info *In,
         db_close_database_shutdown_driver(driver);
     Vect_destroy_cats_struct(CCats);
     Vect_destroy_field_info(Fi);
-
+    Vect_destroy_cats_struct(Line_Cats_Old);
+    Vect_destroy_line_struct(Points);
+    
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1270318, 1270325)
Used Vect_destroy_cats_struct(), Vect_destroy_line_struct() to fix this issue.