### PR TITLE
lib/raster: always pass stack-based buffers

### DIFF
--- a/include/grass/defs/raster.h
+++ b/include/grass/defs/raster.h
@@ -400,7 +400,8 @@ int Rast_option_to_interp_type(const struct Option *);
 /* mask_info.c */
 char *Rast_mask_info(void);
 char *Rast_mask_name(void);
-bool Rast_mask_status(char *, char *, bool *, char *, char *);
+bool Rast_mask_status(char *, char *, bool *, char[GNAME_MAX],
+                      char[GMAPSET_MAX]);
 int Rast__mask_info(char *, char *);
 bool Rast_mask_is_present(void);
 int Rast_disable_omp_on_mask(int);
@@ -558,7 +559,8 @@ bool Rast_legal_semantic_label(const char *);
 int Rast_map_to_img_str(char *, int, unsigned char *);
 
 /* reclass.c */
-int Rast_is_reclass(const char *, const char *, char *, char *);
+int Rast_is_reclass(const char *, const char *, char[GNAME_MAX],
+                    char[GMAPSET_MAX]);
 int Rast_is_reclassed_to(const char *, const char *, int *, char ***);
 int Rast_get_reclass(const char *, const char *, struct Reclass *);
 void Rast_free_reclass(struct Reclass *);

--- a/lib/raster/mask_info.c
+++ b/lib/raster/mask_info.c
@@ -136,7 +136,8 @@ static bool Rast__get_present_mask(char *name, char *mapset)
  * @return true if mask is present, false otherwise
  */
 bool Rast_mask_status(char *name, char *mapset, bool *is_mask_reclass,
-                      char *reclass_name, char *reclass_mapset)
+                      char reclass_name[GNAME_MAX],
+                      char reclass_mapset[GMAPSET_MAX])
 {
     bool present = Rast__get_present_mask(name, mapset);
 


### PR DESCRIPTION
Always pass stack-based buffers to Rast_mask_status and Rast_is_reclass.

This allows for consistency in resource handling.

Alternative solution to #6146.