### PR TITLE
r3.out.ascii/r3.out.v5d: Adjust for GCC-17

### DIFF
--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -57,7 +57,7 @@ void fatalError(char *errorMsg)
         /* should unopen map here! */
         if (!Rast3d_close(map))
             Rast3d_fatal_error("%s (%s)",errorMsg,
-                                _("Unable to close 3D raster map"));
+                               _("Unable to close 3D raster map"));
     }
 
     Rast3d_fatal_error("%s", errorMsg);

--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -56,7 +56,7 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            Rast3d_fatal_error("%s (%s)",errorMsg,
+            Rast3d_fatal_error("%s (%s)", errorMsg,
                                _("Unable to close 3D raster map"));
     }
 

--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -56,7 +56,8 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            fatalError(_("Unable to close 3D raster map"));
+            Rast3d_fatal_error("%s\n%s", _("Unable to close 3D raster map"),
+                               errorMsg);
     }
 
     Rast3d_fatal_error("%s", errorMsg);

--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -56,8 +56,8 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            Rast3d_fatal_error("%s\n%s", _("Unable to close 3D raster map"),
-                               errorMsg);
+            Rast3d_fatal_error("%s (%s)",errorMsg,
+                                _("Unable to close 3D raster map"));
     }
 
     Rast3d_fatal_error("%s", errorMsg);

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -48,7 +48,8 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            fatalError(_("Unable to close 3D raster map"));
+            Rast3d_fatal_error("%s\n%s", _("Unable to close 3D raster map"),
+                               errorMsg);
     }
 
     Rast3d_fatal_error("%s", errorMsg);

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -48,7 +48,7 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            Rast3d_fatal_error("%s (%s)",errorMsg,
+            Rast3d_fatal_error("%s (%s)", errorMsg,
                                _("Unable to close 3D raster map"));
     }
 

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -48,8 +48,8 @@ void fatalError(char *errorMsg)
     if (map != NULL) {
         /* should unopen map here! */
         if (!Rast3d_close(map))
-            Rast3d_fatal_error("%s\n%s", _("Unable to close 3D raster map"),
-                               errorMsg);
+            Rast3d_fatal_error("%s (%s)",errorMsg,
+                                _("Unable to close 3D raster map"));
     }
 
     Rast3d_fatal_error("%s", errorMsg);

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -49,7 +49,7 @@ void fatalError(char *errorMsg)
         /* should unopen map here! */
         if (!Rast3d_close(map))
             Rast3d_fatal_error("%s (%s)",errorMsg,
-                                _("Unable to close 3D raster map"));
+                               _("Unable to close 3D raster map"));
     }
 
     Rast3d_fatal_error("%s", errorMsg);


### PR DESCRIPTION
r3.out.ascii/r3.out.v5d fail to compile with GCC-17. This PR attempts to fix the issue.