### PR TITLE
r.kappa,r.reclass,r.report: address resource leaks

### DIFF
--- a/raster/r.kappa/mask.c
+++ b/raster/r.kappa/mask.c
@@ -11,7 +11,7 @@ static int reclass_text(char *text, struct Reclass *reclass, int next);
 
 char *maskinfo(void)
 {
-    struct Reclass reclass;
+    struct Reclass reclass = {0};
     char *results;
     char text[2 * GNAME_MAX + GMAPSET_MAX];
     int next;
@@ -24,6 +24,7 @@ char *maskinfo(void)
         return G_store("none");
     if (Rast_get_reclass(mask_name, mask_mapset, &reclass) <= 0) {
         snprintf(text, sizeof(text), "%s in %s", mask_name, mask_mapset);
+        Rast_free_reclass(&reclass);
         return append(results, text);
     }
 

--- a/raster/r.reclass/reclass.c
+++ b/raster/r.reclass/reclass.c
@@ -175,13 +175,13 @@ static void set_cats(struct Categories *cats, /* const */ int *is_default,
 static int _reclass(/* const */ RULE *rules, struct Categories *cats,
                     struct Reclass *new)
 {
-    int *is_default;
-
     init_reclass(new, rules);
-    is_default = G_calloc(new->num, sizeof(int));
+    int *is_default = G_calloc(new->num, sizeof(int));
     init_table(new, is_default);
     fill_table(new, is_default, rules);
     set_cats(cats, is_default, new);
+
+    G_free(is_default);
 
     return 0;
 }
@@ -190,7 +190,7 @@ static int re_reclass(/* const */ RULE *rules, struct Categories *cats,
                       /* const */ struct Reclass *old, struct Reclass *new,
                       const char *input_name, const char *input_mapset)
 {
-    struct Reclass mid;
+    struct Reclass mid = {0};
 
     mid.name = G_store(input_name);
     mid.mapset = G_store(input_mapset);
@@ -199,13 +199,15 @@ static int re_reclass(/* const */ RULE *rules, struct Categories *cats,
 
     compose(new, &mid, old);
 
+    Rast_free_reclass(&mid);
+
     return 0;
 }
 
 int reclass(const char *old_name, const char *old_mapset, const char *new_name,
             RULE *rules, struct Categories *cats, const char *title)
 {
-    struct Reclass old, new;
+    struct Reclass old = {0}, new = {0};
     struct History hist;
     int is_reclass;
     FILE *fd;
@@ -263,6 +265,9 @@ int reclass(const char *old_name, const char *old_mapset, const char *new_name,
     Rast_write_history(new_name, &hist);
 
     new_range(new_name, &new);
+
+    Rast_free_reclass(&old);
+    Rast_free_reclass(&new);
 
     return 0;
 }

--- a/raster/r.report/header.c
+++ b/raster/r.report/header.c
@@ -26,7 +26,6 @@ int header(int unit1, int unit2)
     char ns_res[50], ew_res[50];
     int len1, len2;
     char *label;
-    char *mask;
 
     nlines = page_length;
     if (date == NULL)
@@ -73,7 +72,8 @@ int header(int unit1, int unit2)
 
         divider("|");
 
-        mask = maskinfo();
+        char *mask_info = maskinfo();
+        char *mask = mask_info;
         label = "MASK:";
         len1 = strlen(label) + 1;
         while (mask) {
@@ -83,6 +83,7 @@ int header(int unit1, int unit2)
             fprintf(stdout, "|");
             newline();
         }
+        G_free(mask_info);
         divider("|");
 
         /*if title is available, print it, otherwise, print (untitled). in

--- a/raster/r.report/maskinfo.c
+++ b/raster/r.report/maskinfo.c
@@ -11,7 +11,7 @@ static int reclass_text(char *text, struct Reclass *reclass, int next);
 
 char *maskinfo(void)
 {
-    struct Reclass reclass;
+    struct Reclass reclass = {0};
     char *results;
     char text[2 * GNAME_MAX + GMAPSET_MAX];
     int next;
@@ -21,9 +21,10 @@ char *maskinfo(void)
 
     results = NULL;
     if (!Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL))
-        return "none";
+        return G_store("none");
     if (Rast_get_reclass(mask_name, mask_mapset, &reclass) <= 0) {
         snprintf(text, sizeof(text), "%s in %s", mask_name, mask_mapset);
+        Rast_free_reclass(&reclass);
         return append(results, text);
     }
 

--- a/raster/r.report/prt_json.c
+++ b/raster/r.report/prt_json.c
@@ -165,6 +165,7 @@ void print_json(void)
     else {
         G_json_object_set_string(root_object, "mask", mask);
     }
+    G_free(mask);
 
     JSON_Value *maps_value = G_json_value_init_array();
     JSON_Array *maps_array = G_json_array(maps_value);


### PR DESCRIPTION
Address resource leaks in `r.kappa`, `r.reclass` and `r.report`, most of which were discovered in latest run of CoverityScan.
