### PR TITLE
cmake: Fix PATH variable quoting for WSL environments with spaces in directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ else()
   set(HTML_SEARCH_STR "\'</body>\|</html>\|</div> <!-- end container -->\'")
   set(sep ":")
   set(grass_env_command
-    ${CMAKE_COMMAND} -E env "PATH=${BIN_DIR}${sep}${SCRIPTS_DIR}${sep}${env_path}"
+    ${CMAKE_COMMAND} -E env "PATH=\"${BIN_DIR}${sep}${SCRIPTS_DIR}${sep}${env_path}\""
     "PYTHONPATH=${ETC_PYTHON_DIR}${sep}${GUI_WXPYTHON_DIR}${sep}$ENV{PYTHONPATH}"
     "LD_LIBRARY_PATH=${LIB_DIR}${sep}$ENV{LD_LIBRARY_PATH}"
     "GISBASE=${RUN_GISBASE_NATIVE}" "GISRC=${GISRC}" "LC_ALL=C" "LANG=C"


### PR DESCRIPTION
Add quotes around PATH variable expansion in grass_env_command for Unix systems to properly handle Windows paths with spaces when running GRASS in WSL. This prevents path parsing issues that can occur when WSL mounts Windows directories containing spaces (e.g., 'Program Files') in the PATH.

@HuidaeCho 