### PR TITLE
CI: Use released libtre, not libtre-git

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -62,7 +62,7 @@ jobs:
             gettext
             libiconv
             libsystre
-            libtre-git
+            libtre
             libwinpthread-git
             openblas
             pcre


### PR DESCRIPTION
libtre-git is no longer available, so the build in CI fails, but libtre is, so using it should make the CI build work again.

Fixes #6463
