### PR TITLE
tests: Add a smoke test for r.colors

### DIFF
--- a/raster/r.colors/tests/r_colors_test.py
+++ b/raster/r.colors/tests/r_colors_test.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.parametrize("color", ["viridis", "grey", "srtm_percent"])
+def test_set_color_table(session_tools, color):
+    """Check that we can set color table (smoke test)"""
+    session_tools.r_mapcalc(expression="raster = row() + col()")
+    session_tools.r_colors(map="raster", color=color)


### PR DESCRIPTION
To test that color tables are built and that r.colors can access them, this adds a simple smoke test which fails if a color table file is not found.

This supports testing of changes in paths in #5630.
