### PR TITLE
CI: Fix r.texture test on macOS for v8.4

### DIFF
--- a/raster/r.texture/testsuite/test_texture.py
+++ b/raster/r.texture/testsuite/test_texture.py
@@ -130,7 +130,7 @@ class TestRasterreport(TestCase):
         # The results on macOS is slightly different from the other platforms
         if IS_MAC:
             values = """min=0
-            max=45368496
+            max=45368492
             mean=2248724.35922656
             variance=2332049429651.92
             n=996244"""


### PR DESCRIPTION
Attempt to fix  the following CI error ([log](https://github.com/OSGeo/grass/actions/runs/18382536012)) on `releasebranch_8_4` by syncing to `main`:

```python
 Running ./raster/r.texture/testsuite/test_texture.py...
========================================================================
...........F.
======================================================================
FAIL: test_sv (__main__.TestRasterreport.test_sv)
Testing method sv
----------------------------------------------------------------------
Traceback (most recent call last):
  File "raster/r.texture/testsuite/test_texture.py", line 144, in test_sv
    self.assertRasterFitsUnivar(output, reference=values, precision=1e-2)
  File "etc/python/grass/gunittest/case.py", line 289, in assertRasterFitsUnivar
    self.assertModuleKeyValue(
  File "etc/python/grass/gunittest/case.py", line 271, in assertModuleKeyValue
    self.fail(self._formatMessage(msg, stdMsg))
AssertionError: r.univar map=sv_SV percentile=90.0 nprocs=1 separator== -g difference:
mismatch values (key, reference, actual): [('max', 45368496, 45368492), ('mean', 2248724.38215788, 2248724.35922656), ('variance', 2332049495199.41, 2332049429651.92)]
command: r.univar map=sv_SV percentile=90.0 nprocs=1 separator== -g {'map': 'sv_SV', 'separator': '=', 'flags': 'g'}

----------------------------------------------------------------------
Ran 13 tests in 17.655s
FAILED (failures=1)
```

Looks like an ugly workaround here but in G85 (#5750) this part has been rewritten and backporting is too much work (for me).