### PR TITLE
r.viewshed: Add missing <algorithm> include for std::max

### DIFF
--- a/raster/r.viewshed/statusstructure.cpp
+++ b/raster/r.viewshed/statusstructure.cpp
@@ -37,6 +37,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <assert.h>
 
 extern "C" {


### PR DESCRIPTION
When looking at the build scripts for compiling from source the PROJ, GDAL, PDAL and GEOS libraries in Docker, I found a nice script in PDAL to check some missing includes in C++ files. I adapted it for us, and it only found one problem, where `#include <algorithm>` was not present when we are using `std:max` in the file.  `#include <algorithm>` was not included in another file yet, only in grass-addons there was some other matches.

So, I'm adding it to the file.