### PR TITLE
CI(Docker): Fix failures in forks when fetching latest tag or current branch fails

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,23 +86,38 @@ jobs:
             | head -n 1)"
           echo "latest_tag=${latest_tag}" >> "${GITHUB_OUTPUT}"
           echo "latest_tag is: ${latest_tag}"
+          if [ -z "$latest_tag" ]; then
+              echo "Error getting latest tag information"
+              echo "error_latest=yes" >> "${GITHUB_OUTPUT}"
+              exit 0
+          fi
           latest_rel_branch="$(git branch --all --list 'origin/*' \
-            --contains "${latest_tag}" --format "%(refname:lstrip=3)")"
+            --contains "${latest_tag}" --format "%(refname:lstrip=3)" || echo "")"
           echo "latest_rel_branch=${latest_rel_branch}" >> "${GITHUB_OUTPUT}"
           echo "latest_rel_branch is: ${latest_rel_branch}"
+          if [ -z "$latest_rel_branch" ]; then
+              echo "Error getting latest release branch information"
+              echo "error_latest_rel_branch=yes" >> "${GITHUB_OUTPUT}"
+              exit 0
+          fi
+          echo "error_latest=no" >> "${GITHUB_OUTPUT}"
+          echo "error_latest_rel_branch=no" >> "${GITHUB_OUTPUT}"
       - name: Get enable values for meta step
         id: enable
         run: |
           latest="${{
             (github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name))
               == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
-            && matrix.os == 'ubuntu' }}"
+            && matrix.os == 'ubuntu' && steps.tag-branch.outputs.error_latest == 'no' }}"
           current="${{
             ( contains(fromJSON('["tag", "release"]'), github.event_name)
               && (github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name))
                   == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
             )
-            || github.ref == format('refs/heads/{0}', steps.tag-branch.outputs.latest_rel_branch)
+            || ( github.ref == format('refs/heads/{0}', steps.tag-branch.outputs.latest_rel_branch)
+                  && steps.tag-branch.outputs.error_latest == 'no'
+                  && steps.tag-branch.outputs.error_latest_rel_branch == 'no'
+                )
           }}"
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
           echo "latest is ${latest}"


### PR DESCRIPTION
As discovered in the PR of the fork of https://github.com/OSGeo/grass/pull/6481, when a fork doesn't have tags or all branches, the step that gets the information needed for marking the image as current or latest fails, and won't build at all. Instead, make sure that these two tags are false and try avoiding errors in that step.