### PR TITLE
r.thin: Fix argument cannot be negative issue in io.c

### DIFF
--- a/raster/r.thin/io.c
+++ b/raster/r.thin/io.c
@@ -120,7 +120,8 @@ int open_file(char *name)
     /* create the file and then open it for read and write */
     int tmpfd = creat(work_file_name, 0666);
     if (tmpfd < 0) {
-        G_fatal_error(_("Unable to create temporary file <%s>"), work_file_name);
+        G_fatal_error(_("Unable to create temporary file <%s>"),
+                      work_file_name);
     }
     close(tmpfd);
     if ((work_file = open(work_file_name, 2)) < 0) {


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1270353).