### PR TITLE
tests: Use copy of env for init

### DIFF
--- a/python/grass/tools/tests/grass_tools_session_tools_pack_test.py
+++ b/python/grass/tools/tests/grass_tools_session_tools_pack_test.py
@@ -700,7 +700,7 @@ def test_workflow_create_project_and_run_general_crs(
     raster = tmp_path / "raster.grass_raster"
     gs.create_project(project, crs=ones_raster_file_epsg3358)
     with (
-        gs.setup.init(project) as session,
+        gs.setup.init(project, env=os.environ.copy()) as session,
         Tools(session=session) as tools,
     ):
         assert tools.g_region(flags="p", format="json")["crs"]["type"] == "other"
@@ -726,7 +726,7 @@ def test_workflow_create_project_and_run_ll_crs(tmp_path, ones_raster_file_epsg4
     raster = tmp_path / "raster.grass_raster"
     gs.create_project(project, crs=ones_raster_file_epsg4326)
     with (
-        gs.setup.init(project) as session,
+        gs.setup.init(project, env=os.environ.copy()) as session,
         Tools(session=session) as tools,
     ):
         assert tools.g_region(flags="p", format="json")["crs"]["type"] == "ll"
@@ -752,7 +752,7 @@ def test_workflow_create_project_and_run_xy_crs(tmp_path, rows_raster_file4x5):
     raster = tmp_path / "raster.grass_raster"
     gs.create_project(project, crs=rows_raster_file4x5)
     with (
-        gs.setup.init(project) as session,
+        gs.setup.init(project, env=os.environ.copy()) as session,
         Tools(session=session) as tools,
     ):
         assert tools.g_region(flags="p", format="json")["crs"]["type"] == "xy"

--- a/raster/r.out.gdal/tests/test_r_out_gdal.py
+++ b/raster/r.out.gdal/tests/test_r_out_gdal.py
@@ -1,5 +1,8 @@
-import grass.script as gs
+import os
+
 import pytest
+
+import grass.script as gs
 from grass.tools import Tools
 
 FORMAT_DICT = {
@@ -27,7 +30,7 @@ def simple_raster_map(tmp_path_factory):
     project = tmp_path / "grassdata"
     gs.create_project(project, epsg=4326)
 
-    with gs.setup.init(project) as session:
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         tools = Tools(session=session, consistent_return_value=True)
         tools.g_region(n=10, s=0, e=10, w=0, res=1)
 

--- a/vector/v.colors/tests/test_v_colors.py
+++ b/vector/v.colors/tests/test_v_colors.py
@@ -1,6 +1,8 @@
+import os
 import re
-import pytest
 import io
+
+import pytest
 
 import grass.script as gs
 import grass.exceptions
@@ -22,7 +24,7 @@ def simple_vector_map(tmp_path_factory):
     project = tmp_path / "grassdata"
     gs.create_project(project)
 
-    with gs.setup.init(project) as session:
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         tools = Tools(session=session)
         tools.g_region(n=10, s=0, e=10, w=0, res=1)
 

--- a/vector/v.decimate/tests/test_v_decimate.py
+++ b/vector/v.decimate/tests/test_v_decimate.py
@@ -1,6 +1,8 @@
-import pytest
+import os
 import io
 from types import SimpleNamespace
+
+import pytest
 
 import grass.script as gs
 from grass.tools import Tools
@@ -30,7 +32,7 @@ def setup_point_map(tmp_path):
     project = tmp_path / "grassdata"
     gs.create_project(project)
 
-    with gs.setup.init(project) as session:
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         tools = Tools(session=session)
         tools.g_region(n=110, s=90, e=110, w=90, res=1)
 


### PR DESCRIPTION
Some tests were not using a copy of the global environment and were modifying os.environ. This is a bad practice in the tests. While the fix is easy, preventing this from happening again is not possible with the current code since we want it to be easy to use the global environment.
