### PR TITLE
grass.gunittest: Exclude test files with tests ran with pytest

### DIFF
--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -24,6 +24,17 @@ exclude =
     vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
     vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
     vector/v.out.lidar/testsuite/test_v_out_lidar.py
+    # Already running with pytest, see include list in .github/workflows/pytest_args_gunittest.txt
+    lib/gis/testsuite/test_gis_lib_getl.py
+    lib/init/testsuite/test_grass_tmp_mapset.py
+    lib/vector/Vlib/testsuite/test_vlib_box.py
+    python/grass/exceptions/testsuite/test_ScriptError.py
+    python/grass/gunittest/testsuite/test_checkers.py
+    python/grass/pygrass/modules/interface/testsuite/test_flag.py
+    python/grass/pygrass/modules/interface/testsuite/test_parameter.py
+    python/grass/pygrass/vector/testsuite/test_filters.py
+    python/grass/script/testsuite/test_core_make_val.py
+    python/grass/script/testsuite/test_utils.py
 
 # Maximum time for execution of one test file (not a test function)
 # after which test is terminated (which may not terminate child processes


### PR DESCRIPTION
Since May, these tests are ran with pytest. We didn't see a difference between both, so it is safe to exclude them from running in gunittest too.