### PR TITLE
CQ: Check Ruff rules outdated-version-block (UP036) and duplicate-class-field-definition (PIE794)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ ignore = [
     "PERF401", # manual-list-comprehension
     "PERF402", # manual-list-copy
     "PERF403", # manual-dict-comprehension
-    "PIE794",  # duplicate-class-field-definition
     "PLC0415", # import-outside-top-level
     "PLC1901", # compare-to-empty-string
     "PLC2701", # import-private-name
@@ -382,6 +381,7 @@ ignore = [
 "python/grass/semantic_label/reader.py" = ["PLW1514"]
 "python/grass/temporal/abstract_space_time_dataset.py" = ["PLW1514"]
 "python/grass/temporal/aggregation.py" = ["PLW1514", "SIM115"]
+"python/grass/temporal/c_libraries_interface.py" = ["PIE794"]
 "python/grass/temporal/register.py" = ["PLW1514", "SIM115"]
 "python/grass/temporal/stds_export.py" = ["PLW1514", "SIM115"]
 "python/grass/temporal/stds_import.py" = ["PLW1514", "SIM115"]


### PR DESCRIPTION
Only one instance had a problem, and is probably not fixable right away, so only ignore that file.

Ruff rule: https://docs.astral.sh/ruff/rules/outdated-version-block/

Also added another rule with a simple exclusion:

Ruff rule: https://docs.astral.sh/ruff/rules/duplicate-class-field-definition/