### PR TITLE
build: correctly report detected LFS state at the end of configure run

### DIFF
--- a/configure
+++ b/configure
@@ -16234,6 +16234,11 @@ printf "%s\n" "#define _LARGEFILE_SOURCE $ac_cv_sys_largefile_source" >>confdefs
      CFLAGS=$ac_save_cflags
    fi
 
+if test "$ac_cv_sys_large_files" != 0; then
+    USE_LARGEFILES=1
+else
+    USE_LARGEFILES=0
+fi
 
 
 USE_TERMIO=

--- a/configure.ac
+++ b/configure.ac
@@ -2007,6 +2007,11 @@ AC_SUBST(USE_OPENCL)
 # way to handle this. It sets the appropriate CFLAGS and defines necessary
 # preprocessor macros (e.g., _FILE_OFFSET_BITS=64) for the compiler.
 AC_SYS_LARGEFILE
+if test "$ac_cv_sys_large_files" != 0; then
+    USE_LARGEFILES=1
+else
+    USE_LARGEFILES=0
+fi
 AC_SUBST(LFS_CFLAGS)
 
 USE_TERMIO=


### PR DESCRIPTION
LFS detection works as expected, only reporting part was missed in PR #6509 