### PR TITLE
lib/raster: Update JSON structure in Rast_print_json_colors

### DIFF
--- a/lib/raster/json_color_out.c
+++ b/lib/raster/json_color_out.c
@@ -97,12 +97,19 @@ static void write_json_rule(DCELL *val, DCELL *min, DCELL *max, int r, int g,
 void Rast_print_json_colors(struct Colors *colors, DCELL min, DCELL max,
                             FILE *fp, int perc, ColorFormat clr_frmt)
 {
-    G_JSON_Value *root_value = G_json_value_init_array();
+    G_JSON_Value *root_value = G_json_value_init_object();
     if (root_value == NULL) {
+        close_file(fp);
+        G_fatal_error(_("Failed to initialize JSON object. Out of memory?"));
+    }
+    G_JSON_Object *root_object = G_json_object(root_value);
+
+    G_JSON_Value *table_value = G_json_value_init_array();
+    if (table_value == NULL) {
         close_file(fp);
         G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
     }
-    G_JSON_Array *root_array = G_json_array(root_value);
+    G_JSON_Array *table_array = G_json_array(table_value);
 
     char color_str[COLOR_STRING_LENGTH];
 
@@ -119,8 +126,8 @@ void Rast_print_json_colors(struct Colors *colors, DCELL min, DCELL max,
 
             // Look up the color for the current value and write JSON rule
             Rast_lookup_c_colors(&i, &r, &g, &b, &set, 1, colors);
-            write_json_rule(&val, &min, &max, r, g, b, root_array, perc,
-                            clr_frmt, fp, root_value);
+            write_json_rule(&val, &min, &max, r, g, b, table_array, perc,
+                            clr_frmt, fp, table_value);
         }
     }
     else {
@@ -136,12 +143,15 @@ void Rast_print_json_colors(struct Colors *colors, DCELL min, DCELL max,
                                    colors, count - 1 - i);
 
             // write JSON rule
-            write_json_rule(&val1, &min, &max, r1, g1, b1, root_array, perc,
-                            clr_frmt, fp, root_value);
-            write_json_rule(&val2, &min, &max, r2, g2, b2, root_array, perc,
-                            clr_frmt, fp, root_value);
+            write_json_rule(&val1, &min, &max, r1, g1, b1, table_array, perc,
+                            clr_frmt, fp, table_value);
+            write_json_rule(&val2, &min, &max, r2, g2, b2, table_array, perc,
+                            clr_frmt, fp, table_value);
         }
     }
+
+    // Add the color table to the root object
+    G_json_object_set_value(root_object, "table", table_value);
 
     //  Add special color entries for "null" and "default" values
     {
@@ -149,33 +159,13 @@ void Rast_print_json_colors(struct Colors *colors, DCELL min, DCELL max,
 
         // Get RGB color for null values and create JSON entry
         Rast_get_null_value_color(&r, &g, &b, colors);
-        G_JSON_Value *nv_value = G_json_value_init_object();
-        if (nv_value == NULL) {
-            G_json_value_free(root_value);
-            close_file(fp);
-            G_fatal_error(
-                _("Failed to initialize JSON object. Out of memory?"));
-        }
-        G_JSON_Object *nv_object = G_json_object(nv_value);
-        G_json_object_set_string(nv_object, "value", "nv");
         G_color_to_str(r, g, b, clr_frmt, color_str);
-        G_json_object_set_string(nv_object, "color", color_str);
-        G_json_array_append_value(root_array, nv_value);
+        G_json_object_set_string(root_object, "nv", color_str);
 
         // Get RGB color for default values and create JSON entry
         Rast_get_default_color(&r, &g, &b, colors);
-        G_JSON_Value *default_value = G_json_value_init_object();
-        if (default_value == NULL) {
-            G_json_value_free(root_value);
-            close_file(fp);
-            G_fatal_error(
-                _("Failed to initialize JSON object. Out of memory?"));
-        }
-        G_JSON_Object *default_object = G_json_object(default_value);
-        G_json_object_set_string(default_object, "value", "default");
         G_color_to_str(r, g, b, clr_frmt, color_str);
-        G_json_object_set_string(default_object, "color", color_str);
-        G_json_array_append_value(root_array, default_value);
+        G_json_object_set_string(root_object, "default", color_str);
     }
 
     // Serialize JSON array to a string and print to the file

--- a/raster/r.colors.out/r.colors.out.md
+++ b/raster/r.colors.out/r.colors.out.md
@@ -45,40 +45,36 @@ which includes the following options:
     The JSON output looks like:
 
     ```json
-    [
-        {
-            "value": 55.578792572021484,
-            "color": "#00BFBF"
-        },
-        {
-            "value": 75.729006957999999,
-            "color": "#00FF00"
-        },
-        {
-            "value": 95.879221344000001,
-            "color": "#FFFF00"
-        },
-        {
-            "value": 116.02943573,
-            "color": "#FF7F00"
-        },
-        {
-            "value": 136.179650116,
-            "color": "#BF7F3F"
-        },
-        {
-            "value": 156.32986450195312,
-            "color": "#141414"
-        },
-        {
-            "value": "nv",
-            "color": "#FFFFFF"
-        },
-        {
-            "value": "default",
-            "color": "#FFFFFF"
-        }
-    ]
+    {
+        "table": [
+            {
+                "value": 55.578792572021484,
+                "color": "#00BFBF"
+            },
+            {
+                "value": 75.729006957999999,
+                "color": "#00FF00"
+            },
+            {
+                "value": 95.879221344000001,
+                "color": "#FFFF00"
+            },
+            {
+                "value": 116.02943573,
+                "color": "#FF7F00"
+            },
+            {
+                "value": 136.179650116,
+                "color": "#BF7F3F"
+            },
+            {
+                "value": 156.32986450195312,
+                "color": "#141414"
+            }
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF"
+    }
     ```
 
 ## SEE ALSO

--- a/raster/r.colors.out/r3.colors.out.md
+++ b/raster/r.colors.out/r3.colors.out.md
@@ -46,28 +46,24 @@ which includes the following options:
     The JSON output looks like:
 
     ```json
-    [
-        {
-            "value": 1,
-            "color": "#00FF00"
-        },
-        {
-            "value": 2.5,
-            "color": "#FFFF00"
-        },
-        {
-            "value": 4,
-            "color": "#FF0000"
-        },
-        {
-            "value": "nv",
-            "color": "#FFFFFF"
-        },
-        {
-            "value": "default",
-            "color": "#FFFFFF"
-        }
-    ]
+    {
+        "table": [
+            {
+                "value": 1,
+                "color": "#00FF00"
+            },
+            {
+                "value": 2.5,
+                "color": "#FFFF00"
+            },
+            {
+                "value": 4,
+                "color": "#FF0000"
+            }
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF"
+    }
     ```
 
 ## SEE ALSO

--- a/raster/r.colors.out/tests/r3_colors_out_test.py
+++ b/raster/r.colors.out/tests/r3_colors_out_test.py
@@ -59,10 +59,14 @@ def test_r3_colors_out_with_p_flag(raster3_color_dataset):
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
-    assert isinstance(data, list), "Output data should be a list of entries."
-    assert len(data) == 8, (
-        "The length of the output JSON does not match the expected value of 8."
+    assert isinstance(data, dict), "Output data should be a dictionary."
+    assert "table" in data, "Missing 'table' key in output JSON."
+    assert isinstance(data["table"], list), "'table' should contain a list of entries."
+    assert len(data["table"]) == 6, (
+        "The length of the output JSON table does not match the expected value of 6."
     )
+    assert "nv" in data, "Expected 'nv' key in JSON output."
+    assert "default" in data, "Expected 'default' key in JSON output."
 
 
 def test_r3_colors_out_json_with_default_option(raster3_color_dataset):
@@ -70,16 +74,18 @@ def test_r3_colors_out_json_with_default_option(raster3_color_dataset):
     session = raster3_color_dataset
     data = gs.parse_command("r3.colors.out", map="b", format="json", env=session.env)
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 1.8, "color": "#00FF00"},
-        {"value": 2.6, "color": "#FFFF00"},
-        {"value": 3.4, "color": "#FF7F00"},
-        {"value": 4.2, "color": "#BF7F3F"},
-        {"value": 5, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 1.8, "color": "#00FF00"},
+            {"value": 2.6, "color": "#FFFF00"},
+            {"value": 3.4, "color": "#FF7F00"},
+            {"value": 4.2, "color": "#BF7F3F"},
+            {"value": 5, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -90,16 +96,18 @@ def test_r3_colors_out_json_with_triplet_option(raster3_color_dataset):
         "r3.colors.out", map="b", format="json", color_format="triplet", env=session.env
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "0:191:191"},
-        {"value": 1.8, "color": "0:255:0"},
-        {"value": 2.6, "color": "255:255:0"},
-        {"value": 3.4, "color": "255:127:0"},
-        {"value": 4.2, "color": "191:127:63"},
-        {"value": 5, "color": "200:200:200"},
-        {"value": "nv", "color": "255:255:255"},
-        {"value": "default", "color": "255:255:255"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "0:191:191"},
+            {"value": 1.8, "color": "0:255:0"},
+            {"value": 2.6, "color": "255:255:0"},
+            {"value": 3.4, "color": "255:127:0"},
+            {"value": 4.2, "color": "191:127:63"},
+            {"value": 5, "color": "200:200:200"},
+        ],
+        "nv": "255:255:255",
+        "default": "255:255:255",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -114,16 +122,18 @@ def test_r3_colors_out_json_with_rgb_option(raster3_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "rgb(0, 191, 191)"},
-        {"value": 1.8, "color": "rgb(0, 255, 0)"},
-        {"value": 2.6, "color": "rgb(255, 255, 0)"},
-        {"value": 3.4, "color": "rgb(255, 127, 0)"},
-        {"value": 4.2, "color": "rgb(191, 127, 63)"},
-        {"value": 5, "color": "rgb(200, 200, 200)"},
-        {"value": "nv", "color": "rgb(255, 255, 255)"},
-        {"value": "default", "color": "rgb(255, 255, 255)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "rgb(0, 191, 191)"},
+            {"value": 1.8, "color": "rgb(0, 255, 0)"},
+            {"value": 2.6, "color": "rgb(255, 255, 0)"},
+            {"value": 3.4, "color": "rgb(255, 127, 0)"},
+            {"value": 4.2, "color": "rgb(191, 127, 63)"},
+            {"value": 5, "color": "rgb(200, 200, 200)"},
+        ],
+        "nv": "rgb(255, 255, 255)",
+        "default": "rgb(255, 255, 255)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -138,16 +148,18 @@ def test_r3_colors_out_json_with_hex_option(raster3_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 1.8, "color": "#00FF00"},
-        {"value": 2.6, "color": "#FFFF00"},
-        {"value": 3.4, "color": "#FF7F00"},
-        {"value": 4.2, "color": "#BF7F3F"},
-        {"value": 5, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 1.8, "color": "#00FF00"},
+            {"value": 2.6, "color": "#FFFF00"},
+            {"value": 3.4, "color": "#FF7F00"},
+            {"value": 4.2, "color": "#BF7F3F"},
+            {"value": 5, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -162,14 +174,16 @@ def test_r3_colors_out_json_with_hsv_option(raster3_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "hsv(180, 100, 74)"},
-        {"value": 1.8, "color": "hsv(120, 100, 100)"},
-        {"value": 2.6, "color": "hsv(60, 100, 100)"},
-        {"value": 3.4, "color": "hsv(29, 100, 100)"},
-        {"value": 4.2, "color": "hsv(30, 67, 74)"},
-        {"value": 5, "color": "hsv(0, 0, 78)"},
-        {"value": "nv", "color": "hsv(0, 0, 100)"},
-        {"value": "default", "color": "hsv(0, 0, 100)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "hsv(180, 100, 74)"},
+            {"value": 1.8, "color": "hsv(120, 100, 100)"},
+            {"value": 2.6, "color": "hsv(60, 100, 100)"},
+            {"value": 3.4, "color": "hsv(29, 100, 100)"},
+            {"value": 4.2, "color": "hsv(30, 67, 74)"},
+            {"value": 5, "color": "hsv(0, 0, 78)"},
+        ],
+        "nv": "hsv(0, 0, 100)",
+        "default": "hsv(0, 0, 100)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"

--- a/raster/r.colors.out/tests/r_colors_out_test.py
+++ b/raster/r.colors.out/tests/r_colors_out_test.py
@@ -59,10 +59,14 @@ def test_r_colors_out_with_p_flag(raster_color_dataset):
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
-    assert isinstance(data, list), "Output data should be a list of entries."
-    assert len(data) == 8, (
-        "The length of the output JSON does not match the expected value of 8."
+    assert isinstance(data, dict), "Output data should be a dictionary."
+    assert "table" in data, "Missing 'table' key in output JSON."
+    assert isinstance(data["table"], list), "'table' should contain a list of entries."
+    assert len(data["table"]) == 6, (
+        "The length of the output JSON table does not match the expected value of 6."
     )
+    assert "nv" in data, "Expected 'nv' key in JSON output."
+    assert "default" in data, "Expected 'default' key in JSON output."
 
 
 def test_r_colors_out_json_with_default_option(raster_color_dataset):
@@ -70,16 +74,18 @@ def test_r_colors_out_json_with_default_option(raster_color_dataset):
     session = raster_color_dataset
     data = gs.parse_command("r.colors.out", map="a", format="json", env=session.env)
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 1.4, "color": "#00FF00"},
-        {"value": 1.8, "color": "#FFFF00"},
-        {"value": 2.2, "color": "#FF7F00"},
-        {"value": 2.6, "color": "#BF7F3F"},
-        {"value": 3, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 1.4, "color": "#00FF00"},
+            {"value": 1.8, "color": "#FFFF00"},
+            {"value": 2.2, "color": "#FF7F00"},
+            {"value": 2.6, "color": "#BF7F3F"},
+            {"value": 3, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -90,16 +96,18 @@ def test_r_colors_out_json_with_triplet_option(raster_color_dataset):
         "r.colors.out", map="a", format="json", color_format="triplet", env=session.env
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "0:191:191"},
-        {"value": 1.4, "color": "0:255:0"},
-        {"value": 1.8, "color": "255:255:0"},
-        {"value": 2.2, "color": "255:127:0"},
-        {"value": 2.6, "color": "191:127:63"},
-        {"value": 3, "color": "200:200:200"},
-        {"value": "nv", "color": "255:255:255"},
-        {"value": "default", "color": "255:255:255"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "0:191:191"},
+            {"value": 1.4, "color": "0:255:0"},
+            {"value": 1.8, "color": "255:255:0"},
+            {"value": 2.2, "color": "255:127:0"},
+            {"value": 2.6, "color": "191:127:63"},
+            {"value": 3, "color": "200:200:200"},
+        ],
+        "nv": "255:255:255",
+        "default": "255:255:255",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -114,16 +122,18 @@ def test_r_colors_out_json_with_rgb_option(raster_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "rgb(0, 191, 191)"},
-        {"value": 1.4, "color": "rgb(0, 255, 0)"},
-        {"value": 1.8, "color": "rgb(255, 255, 0)"},
-        {"value": 2.2, "color": "rgb(255, 127, 0)"},
-        {"value": 2.6, "color": "rgb(191, 127, 63)"},
-        {"value": 3, "color": "rgb(200, 200, 200)"},
-        {"value": "nv", "color": "rgb(255, 255, 255)"},
-        {"value": "default", "color": "rgb(255, 255, 255)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "rgb(0, 191, 191)"},
+            {"value": 1.4, "color": "rgb(0, 255, 0)"},
+            {"value": 1.8, "color": "rgb(255, 255, 0)"},
+            {"value": 2.2, "color": "rgb(255, 127, 0)"},
+            {"value": 2.6, "color": "rgb(191, 127, 63)"},
+            {"value": 3, "color": "rgb(200, 200, 200)"},
+        ],
+        "nv": "rgb(255, 255, 255)",
+        "default": "rgb(255, 255, 255)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -138,16 +148,18 @@ def test_r_colors_out_json_with_hex_option(raster_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 1.4, "color": "#00FF00"},
-        {"value": 1.8, "color": "#FFFF00"},
-        {"value": 2.2, "color": "#FF7F00"},
-        {"value": 2.6, "color": "#BF7F3F"},
-        {"value": 3, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 1.4, "color": "#00FF00"},
+            {"value": 1.8, "color": "#FFFF00"},
+            {"value": 2.2, "color": "#FF7F00"},
+            {"value": 2.6, "color": "#BF7F3F"},
+            {"value": 3, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -162,14 +174,16 @@ def test_r_colors_out_json_with_hsv_option(raster_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "hsv(180, 100, 74)"},
-        {"value": 1.4, "color": "hsv(120, 100, 100)"},
-        {"value": 1.8, "color": "hsv(60, 100, 100)"},
-        {"value": 2.2, "color": "hsv(29, 100, 100)"},
-        {"value": 2.6, "color": "hsv(30, 67, 74)"},
-        {"value": 3, "color": "hsv(0, 0, 78)"},
-        {"value": "nv", "color": "hsv(0, 0, 100)"},
-        {"value": "default", "color": "hsv(0, 0, 100)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "hsv(180, 100, 74)"},
+            {"value": 1.4, "color": "hsv(120, 100, 100)"},
+            {"value": 1.8, "color": "hsv(60, 100, 100)"},
+            {"value": 2.2, "color": "hsv(29, 100, 100)"},
+            {"value": 2.6, "color": "hsv(30, 67, 74)"},
+            {"value": 3, "color": "hsv(0, 0, 78)"},
+        ],
+        "nv": "hsv(0, 0, 100)",
+        "default": "hsv(0, 0, 100)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"

--- a/vector/v.colors.out/tests/v_colors_out_test.py
+++ b/vector/v.colors.out/tests/v_colors_out_test.py
@@ -59,10 +59,14 @@ def test_v_colors_out_with_p_flag(vector_color_dataset):
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
-    assert isinstance(data, list), "Output data should be a list of entries."
-    assert len(data) == 8, (
-        "The length of the output JSON does not match the expected value of 8."
+    assert isinstance(data, dict), "Output data should be a dictionary."
+    assert "table" in data, "Expected 'table' key in JSON output."
+    assert isinstance(data["table"], list), "'table' should be a list of entries."
+    assert len(data["table"]) == 6, (
+        "The 'table' list length does not match the expected value of 6."
     )
+    assert "nv" in data, "Expected 'nv' key in JSON output."
+    assert "default" in data, "Expected 'default' key in JSON output."
 
 
 def test_v_colors_out_json_with_default_option(vector_color_dataset):
@@ -70,16 +74,18 @@ def test_v_colors_out_json_with_default_option(vector_color_dataset):
     session = vector_color_dataset
     data = gs.parse_command("v.colors.out", map="a", format="json", env=session.env)
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 20.8, "color": "#00FF00"},
-        {"value": 40.6, "color": "#FFFF00"},
-        {"value": 60.4, "color": "#FF7F00"},
-        {"value": 80.2, "color": "#BF7F3F"},
-        {"value": 100, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 20.8, "color": "#00FF00"},
+            {"value": 40.6, "color": "#FFFF00"},
+            {"value": 60.4, "color": "#FF7F00"},
+            {"value": 80.2, "color": "#BF7F3F"},
+            {"value": 100, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -90,16 +96,18 @@ def test_v_colors_out_json_with_triplet_option(vector_color_dataset):
         "v.colors.out", map="a", format="json", color_format="triplet", env=session.env
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "0:191:191"},
-        {"value": 20.8, "color": "0:255:0"},
-        {"value": 40.6, "color": "255:255:0"},
-        {"value": 60.4, "color": "255:127:0"},
-        {"value": 80.2, "color": "191:127:63"},
-        {"value": 100, "color": "200:200:200"},
-        {"value": "nv", "color": "255:255:255"},
-        {"value": "default", "color": "255:255:255"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "0:191:191"},
+            {"value": 20.8, "color": "0:255:0"},
+            {"value": 40.6, "color": "255:255:0"},
+            {"value": 60.4, "color": "255:127:0"},
+            {"value": 80.2, "color": "191:127:63"},
+            {"value": 100, "color": "200:200:200"},
+        ],
+        "nv": "255:255:255",
+        "default": "255:255:255",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -114,16 +122,18 @@ def test_v_colors_out_json_with_rgb_option(vector_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "rgb(0, 191, 191)"},
-        {"value": 20.8, "color": "rgb(0, 255, 0)"},
-        {"value": 40.6, "color": "rgb(255, 255, 0)"},
-        {"value": 60.4, "color": "rgb(255, 127, 0)"},
-        {"value": 80.2, "color": "rgb(191, 127, 63)"},
-        {"value": 100, "color": "rgb(200, 200, 200)"},
-        {"value": "nv", "color": "rgb(255, 255, 255)"},
-        {"value": "default", "color": "rgb(255, 255, 255)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "rgb(0, 191, 191)"},
+            {"value": 20.8, "color": "rgb(0, 255, 0)"},
+            {"value": 40.6, "color": "rgb(255, 255, 0)"},
+            {"value": 60.4, "color": "rgb(255, 127, 0)"},
+            {"value": 80.2, "color": "rgb(191, 127, 63)"},
+            {"value": 100, "color": "rgb(200, 200, 200)"},
+        ],
+        "nv": "rgb(255, 255, 255)",
+        "default": "rgb(255, 255, 255)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -138,16 +148,18 @@ def test_v_colors_out_json_with_hex_option(vector_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "#00BFBF"},
-        {"value": 20.8, "color": "#00FF00"},
-        {"value": 40.6, "color": "#FFFF00"},
-        {"value": 60.4, "color": "#FF7F00"},
-        {"value": 80.2, "color": "#BF7F3F"},
-        {"value": 100, "color": "#C8C8C8"},
-        {"value": "nv", "color": "#FFFFFF"},
-        {"value": "default", "color": "#FFFFFF"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "#00BFBF"},
+            {"value": 20.8, "color": "#00FF00"},
+            {"value": 40.6, "color": "#FFFF00"},
+            {"value": 60.4, "color": "#FF7F00"},
+            {"value": 80.2, "color": "#BF7F3F"},
+            {"value": 100, "color": "#C8C8C8"},
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"
 
 
@@ -162,14 +174,16 @@ def test_v_colors_out_json_with_hsv_option(vector_color_dataset):
         env=session.env,
     )
     validate_common_json_structure(data)
-    expected = [
-        {"value": 1, "color": "hsv(180, 100, 74)"},
-        {"value": 20.8, "color": "hsv(120, 100, 100)"},
-        {"value": 40.6, "color": "hsv(60, 100, 100)"},
-        {"value": 60.4, "color": "hsv(29, 100, 100)"},
-        {"value": 80.2, "color": "hsv(30, 67, 74)"},
-        {"value": 100, "color": "hsv(0, 0, 78)"},
-        {"value": "nv", "color": "hsv(0, 0, 100)"},
-        {"value": "default", "color": "hsv(0, 0, 100)"},
-    ]
+    expected = {
+        "table": [
+            {"value": 1, "color": "hsv(180, 100, 74)"},
+            {"value": 20.8, "color": "hsv(120, 100, 100)"},
+            {"value": 40.6, "color": "hsv(60, 100, 100)"},
+            {"value": 60.4, "color": "hsv(29, 100, 100)"},
+            {"value": 80.2, "color": "hsv(30, 67, 74)"},
+            {"value": 100, "color": "hsv(0, 0, 78)"},
+        ],
+        "nv": "hsv(0, 0, 100)",
+        "default": "hsv(0, 0, 100)",
+    }
     assert expected == data, f"test failed: expected {expected} but got {data}"

--- a/vector/v.colors.out/v.colors.out.md
+++ b/vector/v.colors.out/v.colors.out.md
@@ -50,25 +50,29 @@ which includes the following options:
     The shortened JSON output looks like:
 
     ```json
-    [
-        {
-            "value": 6388,
-            "color": "#0D0887"
-        },
-        {
-            "value": 662,
-            "color": "#4F02A2"
-        },
-        {
-            "value": 9097,
-            "color": "#5E01A6"
-        },
-        {
-            "value": 20,
-            "color": "#6200A7"
-        },
-        ...
-    ]
+    {
+        "table": [
+            {
+                "value": 6388,
+                "color": "#0D0887"
+            },
+            {
+                "value": 662,
+                "color": "#4F02A2"
+            },
+            {
+                "value": 9097,
+                "color": "#5E01A6"
+            },
+            {
+                "value": 20,
+                "color": "#6200A7"
+            },
+            ...
+        ],
+        "nv": "#FFFFFF",
+        "default": "#FFFFFF"
+    }
     ```
 
 ## SEE ALSO

--- a/vector/v.colors/tests/test_v_colors.py
+++ b/vector/v.colors/tests/test_v_colors.py
@@ -56,21 +56,20 @@ def test_color_by_category(simple_vector_map):
     tools.v_colors(map=mapname, use="cat", color="blues")
     rules = tools.v_colors_out(map=mapname, format="json")
 
-    values = [rule["value"] for rule in rules]
-    assert any(isinstance(v, int) for v in values), (
-        "Expected at least one numeric category in color rules, found none."
-    )
-    assert "default" in values, (
-        "Expected 'default' category in color rules, but not found."
-    )
-    assert "nv" in values, (
-        "Expected 'nv' (null value) category in color rules, but not found."
-    )
+    assert len(rules["table"])
+    assert "default" in rules
+    assert "nv" in rules
 
-    for c in [rule["color"] for rule in rules]:
+    for c in [rule["color"] for rule in rules["table"]]:
         assert re.match(r"^#[0-9A-Fa-f]{6}$", c), (
             f"Invalid hex RGB color format detected: {c}"
         )
+    assert re.match(r"^#[0-9A-Fa-f]{6}$", rules["nv"]), (
+        f"Invalid hex RGB color format detected: {rules['nv']}"
+    )
+    assert re.match(r"^#[0-9A-Fa-f]{6}$", rules["default"]), (
+        f"Invalid hex RGB color format detected: {rules['default']}"
+    )
 
 
 def test_color_by_attr_column(simple_vector_map):
@@ -86,12 +85,9 @@ def test_color_by_attr_column(simple_vector_map):
 
     tools.v_colors(map=mapname, use="attr", column="val", color="ryg")
     rules = tools.v_colors_out(map=mapname, format="json")
-    filtered = [r for r in rules if str(r["value"]) not in {"nv", "default"}]
 
-    assert len(filtered) >= 3, (
-        f"Expected at least 3 color rules for attributes, found {len(filtered)}."
-    )
-    colors = [r["color"] for r in filtered]
+    assert len(rules["table"]) >= 3
+    colors = [r["color"] for r in rules["table"]]
     assert len(set(colors)) == len(colors), (
         "Duplicate color values found in color rules."
     )


### PR DESCRIPTION
Closes: #6236 

Updated the JSON structure in `r|r3|v.colors.out`. The new JSON structure looks like:

```json
{
        "table": [
            {
                "value": 6388,
                "color": "#0D0887"
            },
            {
                "value": 662,
                "color": "#4F02A2"
            },
            {
                "value": 9097,
                "color": "#5E01A6"
            },
            {
                "value": 20,
                "color": "#6200A7"
            },
            ...
        ],
        "nv": "#FFFFFF",
        "default": "#FFFFFF"
}
```

This change is accompanied by updates to the tests and documentation.