### PR TITLE
r.stream.extract: fix stream delineation for binary flow accumulation

### DIFF
--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -594,6 +594,14 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
             G_fatal_error("np_side < 0");
 
         /* set main drainage direction to A* path if possible */
+        if (mfd_cells > 0 && max_side != np_side) {
+            if (fabs(wat_nbr[np_side]) >= max_acc) {
+                max_acc = fabs(wat_nbr[np_side]);
+                r_max = dr;
+                c_max = dc;
+                max_side = np_side;
+            }
+        }
         if (mfd_cells == 0) {
             flat = 0;
             r_max = dr;


### PR DESCRIPTION
Fixes #6541.

This block got removed as part of compiler warnings cleanup #1248 with reasoning that part has been removed from r.watershed. But accumulation in r.stream.extract can be passed externally, so it makes sense the code is different. The actual warning was due to a misplaced parenthesis. 

I tested it in the use case in #6541.

I also tested on NC elevation (there are no tests) and this changes the output vector slightly on several places:

<img width="958" height="648" alt="image" src="https://github.com/user-attachments/assets/43b551ed-d924-4911-852a-66ce710124a8" />
(black with this PR, yellow for current state)

r.watershed stream output (raster) matches the current state.

@metzm any idea?