### PR TITLE
CQ: Fix Ruff SIM223: Use `False` instead of `False and ...`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,6 @@ ignore = [
     "SIM105",  # suppressible-exception
     "SIM113",  # enumerate-for-loop
     "SIM118",  # in-dict-keys
-    "SIM223",  # expr-and-false
     "SLF001",  # private-member-access
     "TD001",   # invalid-todo-tag
     "TD002",   # missing-todo-author

--- a/raster/r.mapcalc/testsuite/test_nmedian_bug_3296.py
+++ b/raster/r.mapcalc/testsuite/test_nmedian_bug_3296.py
@@ -81,7 +81,7 @@ class TestNmedianBug(TestCase):
 
     def tearDown(self):
         self.del_temp_region()
-        if 0 and self.to_remove:
+        if 0 and self.to_remove:  # noqa: SIM223
             self.runModule(
                 "g.remove",
                 flags="f",

--- a/raster/r.mapcalc/testsuite/test_row_above_below_bug.py
+++ b/raster/r.mapcalc/testsuite/test_row_above_below_bug.py
@@ -73,7 +73,7 @@ class TestRowAboveAndBelowBug(TestCase):
 
     def tearDown(self):
         self.del_temp_region()
-        if 0 and self.to_remove:
+        if 0 and self.to_remove:  # noqa: SIM223
             self.runModule(
                 "g.remove",
                 flags="f",


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/expr-and-false/

Ignored the rule for the two violations in the code, to keep the context of the original condition, but enable checking the rule for the project