### PR TITLE
CQ: Start enforcing I001: Import sorting

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -70,18 +70,18 @@ jobs:
       - name: Install Ruff
         run: pip install --break-system-packages "ruff==${RUFF_VERSION}"
       - name: Run Ruff (output annotations on fixable errors)
-        run: ruff check --output-format=github . --preview --unsafe-fixes
+        run: ruff check --output-format=github . --preview --unsafe-fixes -v
         continue-on-error: true
       - name: Run Ruff (apply fixes for suggestions)
-        run: ruff check . --preview --fix --unsafe-fixes
+        run: ruff check . --preview --fix --unsafe-fixes -v
       - name: Run `ruff format` showing diff without failing
         continue-on-error: true
         if: ${{ !cancelled() }}
-        run: ruff format --diff
+        run: ruff format --diff -v
       - name: Run `ruff format` fixing files
         # Run `ruff format` even when `ruff check` fixed files: fixes can require formatting
         if: ${{ !cancelled() }}
-        run: ruff format
+        run: ruff format -v
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -70,18 +70,18 @@ jobs:
       - name: Install Ruff
         run: pip install --break-system-packages "ruff==${RUFF_VERSION}"
       - name: Run Ruff (output annotations on fixable errors)
-        run: ruff check --output-format=github . --preview --unsafe-fixes -v
+        run: ruff check --output-format=github . --preview --unsafe-fixes
         continue-on-error: true
       - name: Run Ruff (apply fixes for suggestions)
-        run: ruff check . --preview --fix --unsafe-fixes -v
+        run: ruff check . --preview --fix --unsafe-fixes
       - name: Run `ruff format` showing diff without failing
         continue-on-error: true
         if: ${{ !cancelled() }}
-        run: ruff format --diff -v
+        run: ruff format --diff
       - name: Run `ruff format` fixing files
         # Run `ruff format` even when `ruff check` fixed files: fixes can require formatting
         if: ${{ !cancelled() }}
-        run: ruff format -v
+        run: ruff format
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff

--- a/db/db.columns/testsuite/test_dbcolumns.py
+++ b/db/db.columns/testsuite/test_dbcolumns.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.script.core import read_command, parse_command
+from grass.script.core import parse_command, read_command
 
 output_plain = """cat
 OBJECTID

--- a/db/db.connect/testsuite/test_db_connect.py
+++ b/db/db.connect/testsuite/test_db_connect.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.script.core import read_command, parse_command
+from grass.script.core import parse_command, read_command
 
 
 class TestDbConnect(TestCase):

--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
+import glob
 import os
 import sys
-import glob
 import tempfile
 from pathlib import Path
 
+from grass.exceptions import CalledModuleError
 from grass.script import core as grass
 from grass.script import task as gtask
-from grass.exceptions import CalledModuleError
 
 non_rendering_modules = (
     "d.colorlist",

--- a/display/d.text/test.py
+++ b/display/d.text/test.py
@@ -2,8 +2,8 @@
 # Author: Owen Smith - Rewritten from test.pl by Huidae Cho
 # Run: d.mon start=wx0 && ./test.py | d.text at=0,100
 import math
-from pathlib import Path
 import re
+from pathlib import Path
 
 # Quiet black syntax checking for fonts and colors to keep the code printed to
 # the display vertically short.

--- a/general/g.findfile/tests/test_g_findfile.py
+++ b/general/g.findfile/tests/test_g_findfile.py
@@ -1,8 +1,8 @@
 import os
-import pytest
 from pathlib import Path
 
 import grass.script as gs
+import pytest
 
 
 @pytest.fixture(scope="module")

--- a/lib/gis/tests/conftest.py
+++ b/lib/gis/tests/conftest.py
@@ -1,8 +1,7 @@
 import os
 
-import pytest
-
 import grass.script as gs
+import pytest
 from grass.tools import Tools
 
 

--- a/lib/gis/tests/conftest.py
+++ b/lib/gis/tests/conftest.py
@@ -1,7 +1,8 @@
 import os
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 from grass.tools import Tools
 
 

--- a/lib/gis/tests/lib_gis_env_test.py
+++ b/lib/gis/tests/lib_gis_env_test.py
@@ -6,8 +6,9 @@ import subprocess
 import sys
 from textwrap import dedent
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 
 
 def run_in_subprocess(code, tmp_path, env):

--- a/lib/gis/tests/lib_gis_env_test.py
+++ b/lib/gis/tests/lib_gis_env_test.py
@@ -1,14 +1,13 @@
 """Test environment and GIS environment functions"""
 
+import json
 import os
 import subprocess
 import sys
-import json
 from textwrap import dedent
 
-import pytest
-
 import grass.script as gs
+import pytest
 
 
 def run_in_subprocess(code, tmp_path, env):

--- a/lib/gis/tests/lib_gis_parser_json_test.py
+++ b/lib/gis/tests/lib_gis_parser_json_test.py
@@ -1,6 +1,7 @@
 """Tests of --json CLI"""
 
 import pytest
+
 from grass.exceptions import CalledModuleError
 
 

--- a/lib/gis/tests/lib_gis_parser_json_test.py
+++ b/lib/gis/tests/lib_gis_parser_json_test.py
@@ -1,8 +1,6 @@
 """Tests of --json CLI"""
 
 import pytest
-
-
 from grass.exceptions import CalledModuleError
 
 

--- a/lib/gis/testsuite/gis_lib_env_test.py
+++ b/lib/gis/testsuite/gis_lib_env_test.py
@@ -3,8 +3,8 @@
 @author Soeren Gebbert
 """
 
-from grass.gunittest.case import TestCase
 import grass.lib.gis as libgis
+from grass.gunittest.case import TestCase
 
 
 class GisLibraryTestEnv(TestCase):

--- a/lib/gis/testsuite/gis_lib_str_color.py
+++ b/lib/gis/testsuite/gis_lib_str_color.py
@@ -5,10 +5,9 @@
 
 from ctypes import byref, c_int
 
+import grass.lib.gis as libgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.gis as libgis
 
 
 class StringToColorTestCase(TestCase):

--- a/lib/gis/testsuite/gis_lib_tokenize.py
+++ b/lib/gis/testsuite/gis_lib_tokenize.py
@@ -3,10 +3,9 @@
 @author Vaclav Petras
 """
 
+import grass.lib.gis as libgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.gis as libgis
 
 # TODO: add tests for content (now testing only number of items)
 

--- a/lib/gis/testsuite/test_gis_lib_getl.py
+++ b/lib/gis/testsuite/test_gis_lib_getl.py
@@ -3,8 +3,8 @@
 @author Vaclav Petras
 """
 
-import os
 import ctypes
+import os
 import unittest
 from pathlib import Path
 

--- a/lib/gis/testsuite/test_parser_json.py
+++ b/lib/gis/testsuite/test_parser_json.py
@@ -8,11 +8,12 @@ for details.
 @author Soeren Gebbert
 """
 
+import json
 import subprocess
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.utils import xfail_windows
 from grass.script import decode
-import json
 
 
 class TestParserJson(TestCase):

--- a/lib/imagery/testsuite/test_imagery_find.py
+++ b/lib/imagery/testsuite/test_imagery_find.py
@@ -14,19 +14,17 @@ import shutil
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
 from grass.lib.imagery import (
+    I_SIGFILE_TYPE_LIBSVM,
     I_SIGFILE_TYPE_SIG,
     I_SIGFILE_TYPE_SIGSET,
-    I_SIGFILE_TYPE_LIBSVM,
     I_find_signature,
     I_find_signature2,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class FindSignatureTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_sigfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigfile.py
@@ -9,36 +9,34 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import stat
 import ctypes
 import os
 import shutil
+import stat
 from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    Signature,
-    Ref,
-    I_init_signatures,
-    I_new_signature,
+    I_add_file_to_group_ref,
     I_fopen_signature_file_new,
-    I_write_signatures,
     I_fopen_signature_file_old,
-    I_read_signatures,
-    I_sort_signatures_by_semantic_label,
+    I_free_group_ref,
     I_free_signatures,
     I_init_group_ref,
-    I_add_file_to_group_ref,
-    I_free_group_ref,
+    I_init_signatures,
+    I_new_signature,
+    I_read_signatures,
+    I_sort_signatures_by_semantic_label,
+    I_write_signatures,
+    Ref,
+    Signature,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SignatureFileTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -9,40 +9,38 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
+import ctypes
 import os
 import shutil
-import ctypes
+from pathlib import Path
 
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import xfail_windows
-
-from grass.script.core import tempname
-import grass.script as gs
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset, make_mapset
-from pathlib import Path
-
 from grass.lib.gis import (
-    G_mapset_path,
-    G_make_mapset,
-    G_reset_mapsets,
     GNAME_MAX,
     HOST_DIRSEP,
+    G_make_mapset,
+    G_mapset_path,
+    G_reset_mapsets,
 )
 from grass.lib.imagery import (
+    I_SIGFILE_TYPE_LIBSVM,
     I_SIGFILE_TYPE_SIG,
     I_SIGFILE_TYPE_SIGSET,
-    I_SIGFILE_TYPE_LIBSVM,
     I_find_signature,
-    I_signatures_remove,
-    I_signatures_copy,
-    I_signatures_rename,
-    I_signatures_list_by_type,
     I_free_signatures_list,
     I_get_signatures_dir,
     I_make_signatures_dir,
+    I_signatures_copy,
+    I_signatures_list_by_type,
+    I_signatures_remove,
+    I_signatures_rename,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset, make_mapset
+from grass.script.core import tempname
 
 
 class GetSignaturesDirTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_sigsetfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigsetfile.py
@@ -9,37 +9,35 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import stat
 import ctypes
 import os
 import shutil
+import stat
 from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    SigSet,
+    I_add_file_to_group_ref,
+    I_fopen_sigset_file_new,
+    I_fopen_sigset_file_old,
+    I_free_group_ref,
+    I_init_group_ref,
     I_InitSigSet,
     I_NewClassSig,
     I_NewSubSig,
-    I_WriteSigSet,
     I_ReadSigSet,
     I_SortSigSetBySemanticLabel,
-    I_fopen_sigset_file_new,
-    I_fopen_sigset_file_old,
+    I_WriteSigSet,
     Ref,
-    I_init_group_ref,
-    I_add_file_to_group_ref,
-    I_free_group_ref,
     ReturnString,
+    SigSet,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SigSetFileTestCase(TestCase):

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -57,7 +57,6 @@ import sys
 import tempfile
 import unicodedata
 import uuid
-
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NoReturn
 

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -14,11 +14,10 @@ License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 """
 
-import unittest
 import os
 import shutil
 import subprocess
-
+import unittest
 
 # Note that unlike rest of GRASS, here we are using unittest package
 # directly. The grass.gunittest machinery for mapsets is not needed here.

--- a/lib/raster/tests/conftest.py
+++ b/lib/raster/tests/conftest.py
@@ -1,8 +1,7 @@
 import os
 
-import pytest
-
 import grass.script as gs
+import pytest
 from grass.experimental import TemporaryMapsetSession
 from grass.tools import Tools
 

--- a/lib/raster/tests/conftest.py
+++ b/lib/raster/tests/conftest.py
@@ -1,7 +1,8 @@
 import os
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 from grass.experimental import TemporaryMapsetSession
 from grass.tools import Tools
 

--- a/lib/raster/tests/lib_raster_reclass_test.py
+++ b/lib/raster/tests/lib_raster_reclass_test.py
@@ -3,6 +3,7 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
+
 from grass.exceptions import CalledModuleError
 from grass.experimental import MapsetSession
 from grass.script import MaskManager

--- a/lib/raster/tests/lib_raster_reclass_test.py
+++ b/lib/raster/tests/lib_raster_reclass_test.py
@@ -1,13 +1,12 @@
 import os
-from pathlib import Path
 from io import StringIO
+from pathlib import Path
 
 import pytest
-
-from grass.script import MaskManager
-from grass.tools import Tools
 from grass.exceptions import CalledModuleError
 from grass.experimental import MapsetSession
+from grass.script import MaskManager
+from grass.tools import Tools
 
 
 def test_reclass_as_mask_correct_state(session):

--- a/lib/raster/testsuite/rast_parse_color_rule.py
+++ b/lib/raster/testsuite/rast_parse_color_rule.py
@@ -10,11 +10,10 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-from ctypes import byref, c_int, c_double
+from ctypes import byref, c_double, c_int
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.lib.raster import Rast_parse_color_rule, Rast_parse_color_rule_error
 
 

--- a/lib/raster/testsuite/test_raster_metadata.py
+++ b/lib/raster/testsuite/test_raster_metadata.py
@@ -14,18 +14,16 @@ import string
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass.gis import Mapset
-from grass.pygrass import utils
-
 from grass.lib.gis import G_remove_misc
 from grass.lib.raster import (
+    Rast_get_semantic_label_or_name,
     Rast_legal_semantic_label,
     Rast_read_semantic_label,
-    Rast_get_semantic_label_or_name,
     Rast_write_semantic_label,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class RastLegalBandIdTestCase(TestCase):

--- a/lib/vector/Vlib/testsuite/test_vlib_box.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_box.py
@@ -13,8 +13,8 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
 """
 
 import ctypes
-import grass.lib.vector as libvect
 
+import grass.lib.vector as libvect
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -13,7 +13,6 @@ COPYRIGHT: (C) 2022 Maris Nartiss, and by the GRASS Development Team
 """
 
 import grass.lib.vector as libvect
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -22,7 +22,6 @@ import json
 import os
 import subprocess
 import sys
-
 from pathlib import Path
 
 

--- a/man/build.py
+++ b/man/build.py
@@ -103,7 +103,7 @@ def get_files(man_dir, cls=None, ignore_gui=True, extension: str = "html"):
 
 def write_header(f: IO, title, ismain=False, body_width="99%", template: str = "html"):
     if template == "html":
-        from build_html import header1_tmpl, macosx_tmpl, header2_tmpl
+        from build_html import header1_tmpl, header2_tmpl, macosx_tmpl
     else:
         from build_md import header1_tmpl, header2_tmpl
     f.write(header1_tmpl.substitute(title=title))

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -6,11 +6,12 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
-from build import message_tmpl, get_files, read_file
 from build_html import man_dir
+
+from build import get_files, message_tmpl, read_file
 
 os.chdir(man_dir)
 

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -9,9 +9,8 @@
 import os
 import sys
 
-from build_html import man_dir
-
 from build import get_files, message_tmpl, read_file
+from build_html import man_dir
 
 os.chdir(man_dir)
 

--- a/man/build_check_rest.py
+++ b/man/build_check_rest.py
@@ -6,10 +6,10 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
-from build_rest import rest_dir, message_tmpl, rest_files, read_file
+from build_rest import message_tmpl, read_file, rest_dir, rest_files
 
 os.chdir(rest_dir)
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 no_intro_page_classes = ["display", "general", "miscellaneous", "postscript"]
 
@@ -15,19 +15,19 @@ no_intro_page_classes = ["display", "general", "miscellaneous", "postscript"]
 def build_class(ext):
     if ext == "html":
         from build_html import (
-            modclass_tmpl,
-            get_desc,
             desc2_tmpl,
-            modclass_intro_tmpl,
+            get_desc,
             man_dir,
+            modclass_intro_tmpl,
+            modclass_tmpl,
         )
     else:
         from build_md import (
-            modclass_tmpl,
-            get_desc,
             desc2_tmpl,
-            modclass_intro_tmpl,
+            get_desc,
             man_dir,
+            modclass_intro_tmpl,
+            modclass_tmpl,
         )
 
     os.chdir(man_dir)
@@ -74,12 +74,12 @@ if __name__ == "__main__":
         year = sys.argv[3]
 
     from build import (
-        to_title,
         check_for_desc_override,
-        replace_file,
         get_files,
-        write_header,
+        replace_file,
+        to_title,
         write_footer,
+        write_header,
     )
 
     build_class("html")

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -13,29 +13,27 @@
 #
 #############################################################################
 
-import sys
-import os
 import fnmatch
-
-from build import (
-    default_year,
-    grass_version,
-    to_title,
-    get_files,
-    check_for_desc_override,
-    write_footer,
-    replace_file,
-)
-
-from build_html import (
-    header1_tmpl,
-    modclass_intro_tmpl,
-    get_desc,
-    man_dir,
-)
+import os
+import sys
 
 import build_md
+from build_html import (
+    get_desc,
+    header1_tmpl,
+    man_dir,
+    modclass_intro_tmpl,
+)
 
+from build import (
+    check_for_desc_override,
+    default_year,
+    get_files,
+    grass_version,
+    replace_file,
+    to_title,
+    write_footer,
+)
 
 graphical_index_style = """\
 <style>

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -18,13 +18,6 @@ import os
 import sys
 
 import build_md
-from build_html import (
-    get_desc,
-    header1_tmpl,
-    man_dir,
-    modclass_intro_tmpl,
-)
-
 from build import (
     check_for_desc_override,
     default_year,
@@ -33,6 +26,12 @@ from build import (
     replace_file,
     to_title,
     write_footer,
+)
+from build_html import (
+    get_desc,
+    header1_tmpl,
+    man_dir,
+    modclass_intro_tmpl,
 )
 
 graphical_index_style = """\

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -6,21 +6,21 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_rest import (
-    rest_dir,
+    check_for_desc_override,
+    desc2_tmpl,
+    get_desc,
     grass_version,
     modclass_intro_tmpl,
     modclass_tmpl,
-    desc2_tmpl,
-    write_rest_header,
-    write_rest_footer,
-    rest_files,
-    check_for_desc_override,
-    get_desc,
     replace_file,
+    rest_dir,
+    rest_files,
+    write_rest_footer,
+    write_rest_header,
 )
 
 os.chdir(rest_dir)

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -6,21 +6,20 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
-
+import sys
 from datetime import date
 from operator import itemgetter
 
 from build import (
+    check_for_desc_override,
     get_files,
-    write_footer,
-    write_header,
     grass_version,
     grass_version_major,
     grass_version_minor,
-    check_for_desc_override,
     replace_file,
+    write_footer,
+    write_header,
 )
 
 CORE_TEXT = """\
@@ -75,19 +74,19 @@ def build_full_index(ext, index_name, source_dir, year, text_type):
     """Generate index with all tools"""
     if ext == "html":
         from build_html import (
-            man_dir,
-            full_index_header,
             cmd2_tmpl,
             desc1_tmpl,
+            full_index_header,
             get_desc,
+            man_dir,
             toc,
         )
     else:
         from build_md import (
-            man_dir,
             cmd2_tmpl,
             desc1_tmpl,
             get_desc,
+            man_dir,
         )
 
     if source_dir is None:

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -9,18 +9,18 @@
 import os
 
 from build_rest import (
+    check_for_desc_override,
+    cmd2_tmpl,
+    desc1_tmpl,
+    full_index_header,
+    get_desc,
+    grass_version,
+    replace_file,
     rest_dir,
     rest_files,
-    write_rest_header,
-    grass_version,
-    full_index_header,
     sections,
-    cmd2_tmpl,
-    check_for_desc_override,
-    get_desc,
-    desc1_tmpl,
     write_rest_footer,
-    replace_file,
+    write_rest_header,
 )
 
 os.chdir(rest_dir)

--- a/man/build_graphical_index.py
+++ b/man/build_graphical_index.py
@@ -98,8 +98,8 @@ def main(ext):
 
 if __name__ == "__main__":
     from build import (
-        write_footer,
         grass_version,
+        write_footer,
     )
 
     main("html")

--- a/man/build_index.py
+++ b/man/build_index.py
@@ -6,15 +6,15 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build import (
-    write_header,
+    grass_version,
+    replace_file,
     write_cmd_overview,
     write_footer,
-    replace_file,
-    grass_version,
+    write_header,
 )
 
 year = None

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -10,12 +10,12 @@
 import os
 
 from build_rest import (
-    rest_dir,
     grass_version,
-    write_rest_header,
+    replace_file,
+    rest_dir,
     write_rest_cmd_overview,
     write_rest_footer,
-    replace_file,
+    write_rest_header,
 )
 
 os.chdir(rest_dir)

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -27,10 +27,10 @@ the variable is ignored, but it must be set regardless.
 @author Martin Landa - Markdown support
 """
 
+import glob
 import os
 import re
 import sys
-import glob
 
 from build import (
     grass_version,

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -14,12 +14,12 @@
 #############################################################################
 from __future__ import annotations
 
-import os
-from pathlib import Path
 import fnmatch
-import re
-from typing import TYPE_CHECKING
 import operator
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -225,8 +225,8 @@ def main(ext):
 
 if __name__ == "__main__":
     from build import (
-        write_footer,
         grass_version,
+        write_footer,
     )
 
     img_files_html = main("html")

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -3,10 +3,10 @@
 # generates topics.html and topic_*.html
 # (c) 2012-2025 by the GRASS Development Team
 
+import glob
 import os
 import re
 import sys
-import glob
 from pathlib import Path
 
 year = os.getenv("VERSION_DATE")
@@ -17,21 +17,21 @@ min_num_modules_for_topic = 3
 def build_topics(ext):
     if ext == "html":
         from build_html import (
-            header1_tmpl,
-            headertopics_tmpl,
-            headerkey_tmpl,
             desc1_tmpl,
-            moduletopics_tmpl,
+            header1_tmpl,
+            headerkey_tmpl,
+            headertopics_tmpl,
             man_dir,
+            moduletopics_tmpl,
         )
     else:
         from build_md import (
-            header1_tmpl,
-            headertopics_tmpl,
-            headerkey_tmpl,
             desc1_tmpl,
-            moduletopics_tmpl,
+            header1_tmpl,
+            headerkey_tmpl,
+            headertopics_tmpl,
             man_dir,
+            moduletopics_tmpl,
         )
 
     keywords = {}

--- a/man/mkdocs/scripts/hook_list_scripts.py
+++ b/man/mkdocs/scripts/hook_list_scripts.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import re
+from pathlib import Path
+
 from jinja2 import Environment
 
 

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -12,9 +12,8 @@ import contextlib
 import os
 import re
 import sys
-
-from typing import IO, TYPE_CHECKING
 from collections import defaultdict
+from typing import IO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/misc/m.measure/testsuite/test_m_measure.py
+++ b/misc/m.measure/testsuite/test_m_measure.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.script.core import read_command, parse_command
+from grass.script.core import parse_command, read_command
 
 
 class TestMMeasure(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -555,7 +555,7 @@ py-version = "3.10"
 # source root is an absolute path or a path relative to the current working
 # directory used to determine a package namespace for modules located under the
 # source root.
-source-roots = ["python", "gui/wxpython"]
+source-roots = ["python", "gui/wxpython", "man"]
 
 
 [tool.pylint.design]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,8 @@ ignore = [
     "UP032",   # f-string
 ]
 
+[tool.ruff.lint.isort]
+known-first-party = ["grass"]
 
 [tool.ruff.lint.per-file-ignores]
 # See https://docs.astral.sh/ruff/settings/#lint_per-file-ignores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,7 +335,6 @@ ignore = [
 "gui/wxpython/wxplot/profile.py" = ["A005", "PLW1514", "SIM115"]
 "imagery/**.py" = ["I001"]
 "imagery/i.atcorr/create_iwave.py" = ["PLW1514"]
-"lib/**.py" = ["I001"]
 "lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]
 "lib/init/grass.py" = ["PLW1514", "SIM115"]
 "lib/init/testsuite/test_grass_tmp_mapset.py" = ["PTH208"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,7 +458,6 @@ ignore = [
 "temporal/t.rast.what/t.rast.what.py" = ["PLW1514"]
 "temporal/t.remove/t.remove.py" = ["PLW1514"]
 "temporal/t.unregister/t.unregister.py" = ["PLW1514"]
-"utils/**.py" = ["I001"]
 "utils/*.py" = ["PLW1514"]
 "vector/**.py" = ["I001"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,6 @@ ignore = [
     "FBT001",  # boolean-type-hint-positional-argument
     "FBT002",  # boolean-default-value-positional-argument
     "FBT003",  # boolean-positional-value-in-call
-    "I001",    # unsorted-imports
     "INP001",  # implicit-namespace-package
     "N801",    # invalid-class-name
     "N802",    # invalid-function-name
@@ -285,10 +284,14 @@ ignore = [
 # Ignored after reverting:
 "gui/**" = ["PLW0108"] # See https://github.com/OSGeo/grass/issues/4124
 # Other ignores:
+"**.ipynb" = ["I001"]
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027", "PLW1514"]
 "display/d.mon/render_cmd.py" = ["PLW1514"]
 "display/d.text/test.py" = ["PLW1514"]
+"doc/**.py" = ["I001"]
+"general/**.py" = ["I001"]
+"gui/**.py" = ["I001"]
 "gui/wxpython/animation/temporal_manager.py" = ["PLW1514"]
 "gui/wxpython/core/gconsole.py" = ["PLW1514"]
 "gui/wxpython/core/render.py" = ["PLW1514"]
@@ -330,11 +333,14 @@ ignore = [
 "gui/wxpython/vnet/vnet_data.py" = ["PLW1514"]
 "gui/wxpython/web_services/dialogs.py" = ["PLW1514"]
 "gui/wxpython/wxplot/profile.py" = ["A005", "PLW1514", "SIM115"]
+"imagery/**.py" = ["I001"]
 "imagery/i.atcorr/create_iwave.py" = ["PLW1514"]
+"lib/**.py" = ["I001"]
 "lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]
 "lib/init/grass.py" = ["PLW1514", "SIM115"]
 "lib/init/testsuite/test_grass_tmp_mapset.py" = ["PTH208"]
 "locale/grass_po_stats.py" = ["SIM115"]
+"man/**.py" = ["I001"]
 "man/build.py" = ["PLW1514", "PTH208"]
 "man/build_class.py" = ["PLW1514"]
 "man/build_class_graphical.py" = ["PLW1514", "PTH208"]
@@ -349,6 +355,7 @@ ignore = [
 "man/build_rest.py" = ["PLW1514", "PTH208"]
 "man/build_topics.py" = ["PLW1514"]
 "man/parser_standard_options.py" = ["PLW1514"]
+"python/grass/**.py" = ["I001"]
 "python/grass/__init__.py" = ["PTH110", "PYI056"]
 "python/grass/exp*/tests/grass_script_mapset_session_test.py" = ["SIM117"]
 "python/grass/exp*/tests/grass_script_tmp_mapset_session_test.py" = ["SIM117"]
@@ -396,11 +403,13 @@ ignore = [
 "python/grass/temporal/univar_statistics.py" = ["PLW1514", "SIM115"]
 "python/grass/tools/support.py" = ["PLR6201"]
 "python/grass/utils/download.py" = ["PTH208", "SIM115"]
+"raster/**.py" = ["I001"]
 "raster/r.*/testsuite/*.py" = ["SIM115"]
 "raster/r.mfilter/benchmark/benchmark_r_mfilter_nprocs.py" = ["PLW1514"]
 "raster/r.topidx/*.py" = ["SIM115"]
 "raster/r.topidx/arc_to_gridatb.py" = ["PLW1514"]
 "raster/r.topidx/gridatb_to_arc.py" = ["PLW1514"]
+"scripts/**.py" = ["I001"]
 "scripts/d.correlate/d.correlate.py" = ["PLW1514", "SIM115"]
 "scripts/d.frame/d.frame.py" = ["PLW1514", "SIM115"]
 "scripts/d.out.file/d.out.file.py" = ["PLW1514"]
@@ -449,7 +458,9 @@ ignore = [
 "temporal/t.rast.what/t.rast.what.py" = ["PLW1514"]
 "temporal/t.remove/t.remove.py" = ["PLW1514"]
 "temporal/t.unregister/t.unregister.py" = ["PLW1514"]
+"utils/**.py" = ["I001"]
 "utils/*.py" = ["PLW1514"]
+"vector/**.py" = ["I001"]
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 # Declare a custom aliases, checked with rule ICN001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,6 @@ ignore = [
 "lib/init/grass.py" = ["PLW1514", "SIM115"]
 "lib/init/testsuite/test_grass_tmp_mapset.py" = ["PTH208"]
 "locale/grass_po_stats.py" = ["SIM115"]
-"man/**.py" = ["I001"]
 "man/build.py" = ["PLW1514", "PTH208"]
 "man/build_class.py" = ["PLW1514"]
 "man/build_class_graphical.py" = ["PLW1514", "PTH208"]

--- a/raster3d/r3.flow/testsuite/r3flow_test.py
+++ b/raster3d/r3.flow/testsuite/r3flow_test.py
@@ -5,6 +5,7 @@ Test of r3.flow
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster3d/r3.gradient/testsuite/r3gradient_test.py
+++ b/raster3d/r3.gradient/testsuite/r3gradient_test.py
@@ -7,7 +7,6 @@ Test of r3.gradient
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 r3univar_test_grad_x = """
 n=600
 null_cells=0

--- a/raster3d/r3.info/testsuite/test_r3_info.py
+++ b/raster3d/r3.info/testsuite/test_r3_info.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.script.core import read_command, parse_command
+from grass.script.core import parse_command, read_command
 
 
 class TestR3Info(TestCase):

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -88,9 +88,9 @@
 # %end
 
 import sys
+from contextlib import nullcontext
 
 import grass.script as gs
-from contextlib import nullcontext
 
 ############################################################################
 

--- a/temporal/t.rast.colors/t.rast.colors.py
+++ b/temporal/t.rast.colors/t.rast.colors.py
@@ -102,9 +102,11 @@
 # % guisection: Define
 # %end
 
+from pathlib import Path
+
 import grass.script as gs
 from grass.exceptions import CalledModuleError
-from pathlib import Path
+
 ############################################################################
 
 

--- a/temporal/t.rast.extract/tests/test_t_rast_extract_pytest.py
+++ b/temporal/t.rast.extract/tests/test_t_rast_extract_pytest.py
@@ -18,8 +18,9 @@ import os
 import shutil
 from pathlib import Path
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 from grass.tools import Tools
 
 

--- a/temporal/t.rast.list/tests/conftest.py
+++ b/temporal/t.rast.list/tests/conftest.py
@@ -4,8 +4,9 @@ import os
 from datetime import datetime
 from types import SimpleNamespace
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 
 
 @pytest.fixture(scope="module")

--- a/temporal/t.rast.list/tests/conftest.py
+++ b/temporal/t.rast.list/tests/conftest.py
@@ -4,9 +4,8 @@ import os
 from datetime import datetime
 from types import SimpleNamespace
 
-import pytest
-
 import grass.script as gs
+import pytest
 
 
 @pytest.fixture(scope="module")

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -5,9 +5,8 @@ import datetime
 import io
 import json
 
-import pytest
-
 import grass.script as gs
+import pytest
 
 yaml = pytest.importorskip("yaml", reason="PyYAML package not available")
 

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -5,8 +5,9 @@ import datetime
 import io
 import json
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 
 yaml = pytest.importorskip("yaml", reason="PyYAML package not available")
 

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -92,9 +92,11 @@
 # % description: Propagate NULLs
 # %end
 
+from pathlib import Path
+
 import grass.script as gs
 from grass.exceptions import CalledModuleError
-from pathlib import Path
+
 ############################################################################
 
 

--- a/utils/create_python_init_file.py
+++ b/utils/create_python_init_file.py
@@ -14,9 +14,9 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com>
 """
 
+import glob
 import os
 import sys
-import glob
 from pathlib import Path
 
 

--- a/utils/g.html2man/g.html2man.py
+++ b/utils/g.html2man/g.html2man.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-from pathlib import Path
-import sys
 import re
-from ghtml import HTMLParser
-from ggroff import Formatter
-
+import sys
 from io import StringIO
+from pathlib import Path
+
+from ggroff import Formatter
+from ghtml import HTMLParser
 
 entities = {"nbsp": " ", "bull": "*"}
 

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -1,6 +1,6 @@
-import sys
 import os
 import re
+import sys
 
 __all__ = ["Formatter"]
 

--- a/utils/generate_last_commit_file.py
+++ b/utils/generate_last_commit_file.py
@@ -24,10 +24,9 @@ python utils/generate_last_commit_file.py .
 
 import json
 import os
-import subprocess
 import shutil
+import subprocess
 import sys
-
 
 # Strict ISO 8601 format
 COMMIT_DATE_FORMAT = "%aI"

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -4,9 +4,9 @@
 # Distributed under the terms of the GNU General Public License v2 or later
 
 import re
-from textwrap import TextWrapper
-import sys
 import subprocess
+import sys
+from textwrap import TextWrapper
 
 rev_range = ""
 

--- a/utils/md_isvalid.py
+++ b/utils/md_isvalid.py
@@ -5,10 +5,10 @@
 #   (on Debian/Ubuntu - apt install markdownlint)
 #   (using Ruby installer - gem install mdl)
 
-import os
-import sys
 import argparse
+import os
 import subprocess
+import sys
 
 import grass.script as gs
 

--- a/utils/merge_sitemaps.py
+++ b/utils/merge_sitemaps.py
@@ -7,9 +7,9 @@ Created on March 11, 2025
 """
 
 import argparse
-from xml.dom import minidom  # noqa: S408
 import urllib.parse
 from pathlib import Path
+from xml.dom import minidom  # noqa: S408
 
 
 def check_url_version(url: str, version: str) -> str:

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -16,16 +16,14 @@
 #
 #############################################################################
 
-import sys
-import os
-import string
-import re
-from datetime import datetime
 import locale
-
-from html.parser import HTMLParser
-
+import os
+import re
+import string
+import sys
 import urllib.parse as urlparse
+from datetime import datetime
+from html.parser import HTMLParser
 from pathlib import Path
 
 try:
@@ -35,12 +33,14 @@ except ImportError:
     gs = None
 
 from mkdocs import (
-    read_file,
-    get_version_branch,
-    get_last_git_commit,
-    top_dir as topdir,
     get_addon_path,
+    get_last_git_commit,
+    get_version_branch,
+    read_file,
     set_proxy,
+)
+from mkdocs import (
+    top_dir as topdir,
 )
 
 grass_version = os.getenv("VERSION_NUMBER", "unknown")

--- a/utils/mkmarkdown.py
+++ b/utils/mkmarkdown.py
@@ -17,9 +17,9 @@
 #############################################################################
 
 import os
-import sys
-import string
 import re
+import string
+import sys
 import urllib.parse as urlparse
 from pathlib import Path
 
@@ -30,12 +30,12 @@ except ImportError:
     gs = None
 
 from mkdocs import (
-    read_file,
-    get_version_branch,
-    get_last_git_commit,
-    top_dir,
     get_addon_path,
+    get_last_git_commit,
+    get_version_branch,
+    read_file,
     set_proxy,
+    top_dir,
 )
 
 

--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -14,10 +14,10 @@
 #
 #############################################################################
 
-import sys
-import string
 import re
+import string
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 

--- a/utils/ppmrotate.py
+++ b/utils/ppmrotate.py
@@ -13,10 +13,10 @@
 #       for details.
 #
 
-import sys
-import os
-import atexit
 import array
+import atexit
+import os
+import sys
 from pathlib import Path
 
 import grass.script as gs

--- a/utils/test_generate_last_commit_file.py
+++ b/utils/test_generate_last_commit_file.py
@@ -17,12 +17,12 @@ pytest utils/test_generate_last_commit_file.py
 @author Tomas Zigo <tomas.zigo slovanet.sk>
 """
 
-import os
 import json
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 
 from .generate_last_commit_file import COMMIT_DATE_FORMAT
 

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -13,13 +13,12 @@
 #       for details.
 #
 
-import os
 import atexit
+import os
 import sys
 from pathlib import Path
 
 import grass.script as gs
-
 
 tmp_grad_abs = None
 tmp_grad_rel = None

--- a/utils/update_version.py
+++ b/utils/update_version.py
@@ -2,12 +2,11 @@
 
 """Update VERSION file to release and development versions"""
 
-import sys
-import datetime
-from types import SimpleNamespace
-from pathlib import Path
-
 import argparse
+import datetime
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 
 def read_version_file():


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/unsorted-imports/

Starts applying to simple cases, and not too big folders, where there shouldn't be issues with import order matters.

Adjusted the configuration of ruff for it to understand what is first party vs third party (using `-v` verbose output to catch what was going on) as there was a difference locally and in CI. 