### PR TITLE
grass.script: Add nprocs to raster.mapcalc function

### DIFF
--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -179,6 +179,7 @@ def mapcalc_start(
     verbose=False,
     overwrite=False,
     seed=None,
+    nprocs=None,
     env=None,
     **kwargs,
 ):
@@ -198,6 +199,11 @@ def mapcalc_start(
     1
     >>> run_command("g.remove", flags="f", type="raster", name=output)
 
+    The *nprocs* parameter currently defaults to 1
+    which may change in the future to using all cores.
+    Pass a value explicitly if you have specific requirements on the number of cores.
+    Explicit ``nprocs=0`` uses all cores.
+
     :param str exp: expression
     :param bool quiet: True to run quietly (``--q``)
     :param bool superquiet: True to run extra quietly (``--qq``)
@@ -205,6 +211,7 @@ def mapcalc_start(
     :param bool overwrite: True to enable overwriting the output (``--o``)
     :param seed: an integer used to seed the random-number generator for the
                  rand() function, or 'auto' to generate a random seed
+    :param nprocs: Number of threads for parallel computing
     :param dict env: dictionary of environment variables for child process
     :param kwargs:
 
@@ -217,11 +224,17 @@ def mapcalc_start(
     t = string.Template(exp)
     e = t.substitute(**kwargs)
 
+    # Default to 1 to keep the same behavior in the API even with parallelized r.mapcalc,
+    # but for explicit 0, do pass through.
+    if nprocs is None:
+        nprocs = 1
+
     p = feed_command(
         "r.mapcalc",
         file="-",
         env=env,
         seed=seed,
+        nprocs=nprocs,
         quiet=quiet,
         superquiet=superquiet,
         verbose=verbose,


### PR DESCRIPTION
With this change, callers of gs.mapcalc can now use nprocs to set number of processes for the underlying r.mapcalc. This makes it available to a number of Python tools which use gs.mapcalc to call r.mapcalc (as well as to user scripts).

The default is set to 1. Specifically, the parameter default is None which is translated to 1 as opposed to using r.mapcalc's default. As a result, r.mapcalc's default is now independent from the default of gs.mapcalc. At this point, it makes all the Python calls using gs.mapcalc behave as before, i.e., one core only, while direct usage of r.mapcalc uses the all-cores default as do the other C tools now.

See also #6564 (discussion on default for r.mapcalc), #5731 (default for nprocs in C), and #5742 (r.mapcalc OpenMP version).
