### PR TITLE
grass.pygrass: Set r.mapcalc nprocs in ParallelModuleQueue example

### DIFF
--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -50,11 +50,15 @@ class ParallelModuleQueue:
         >>> from grass.pygrass.modules import Module, MultiModule, ParallelModuleQueue
         >>> mapcalc_list = []
 
-      Setting ``run_`` to False is important, otherwise a parallel processing is not possible
+      Since r.mapcalc can itself run multithreaded, setting ``nprocs`` for the
+      *r.mapcalc* call (and not just the *ParallelModuleQueue*) is needed to determine
+      the number of threads each *r.mapcalc* will use. With 3 processes for the
+      *ParallelModuleQueue*, the computation will use 6 core total (``3 * 2 = 6``).
+      Setting ``run_`` to False is important, otherwise a parallel processing is not possible.
 
       .. code-block:: pycon
 
-        >>> mapcalc = Module("r.mapcalc", overwrite=True, run_=False)
+        >>> mapcalc = Module("r.mapcalc", nprocs=2, overwrite=True, run_=False)
         >>> queue = ParallelModuleQueue(nprocs=3)
         >>> for i in range(5):
         ...     new_mapcalc = copy.deepcopy(mapcalc)


### PR DESCRIPTION
Example of _ParallelModuleQueue_ from _pygrass_ uses _r.mapcalc_. With r.mapcalc being parallel itself, we need to deal with number of processing units for the r.mapcalc tool itself, especially when the default currently is all cores. The new example presents the advanced, but realistic, scenario when we combine the two parallelizations together. Readers can always go with the hopefully obvious solution of setting nprocs=1, so having a more complete example in place seems justified as it covers the full spectrum of choices.
