### PR TITLE
r.mapcalc: fix number of expressions counter

### DIFF
--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -386,6 +386,8 @@ void execute(expr_list *ee)
         expression *e = l->exp;
         const char *var;
 
+        num_exprs++;
+
         if (e->type != expr_type_binding && e->type != expr_type_function)
             G_fatal_error("internal error: execute: invalid type: %d", e->type);
 
@@ -398,7 +400,6 @@ void execute(expr_list *ee)
             G_fatal_error(_("output map <%s> exists. To overwrite, "
                             "use the --overwrite flag"),
                           var);
-        num_exprs++;
     }
 
     /* Create a array of expreesion and stored it in heap */


### PR DESCRIPTION
This fixing r.mapcalc after the parallelization changes in #5742, the number of expressions was not counted correctly, resulting in:

```
GRASS nc_spm_08_grass7/user1:r.mapcalc > r.mapcalc --o << EOF
eval(a = 3)
b = 4
EOF
 100%
ERROR: Invalid descriptor: -1

```
This will likely fix issues we have seen in addons https://github.com/OSGeo/grass-addons/issues/1450