### PR TITLE
configure: fix detection of AGL framework for macOS

### DIFF
--- a/configure
+++ b/configure
@@ -13037,7 +13037,7 @@ case "$with_opengl" in
 		USE_OPENGL=1
 		OPENGL_X11=1
 		;;
-	aqua|mac|osx|macosx|agl)
+	aqua|mac|osx|macosx)
 		OPENGL_TYPE=Aqua
 		USE_OPENGL=1
 		OPENGL_AQUA=1
@@ -13660,9 +13660,6 @@ OPENGLLIBPATH="$OPENGLPATH"
 
 
 printf "%s\n" "#define OPENGL_AQUA 1" >>confdefs.h
-
-
-printf "%s\n" "#define OPENGL_AGL 1" >>confdefs.h
 
 
 fi # $OPENGL_AQUA

--- a/configure.ac
+++ b/configure.ac
@@ -1417,7 +1417,7 @@ case "$with_opengl" in
 		USE_OPENGL=1
 		OPENGL_X11=1
 		;;
-	aqua|mac|osx|macosx|agl)
+	aqua|mac|osx|macosx)
 		OPENGL_TYPE=Aqua
 		USE_OPENGL=1
 		OPENGL_AQUA=1
@@ -1482,7 +1482,6 @@ OPENGLINC="$OPENGLPATH"
 OPENGLLIBPATH="$OPENGLPATH"
 
 AC_DEFINE(OPENGL_AQUA, 1, [Define to 1 if OpenGL uses Aqua (MacOS X).])
-AC_DEFINE(OPENGL_AGL, 1, [Define to 1 if OpenGL uses AGL (MacOS X).])
 
 fi # $OPENGL_AQUA
 


### PR DESCRIPTION
The AGL framework is no longer available on macOS 26.

This is for main, forward port of #6560.