### PR TITLE
CQ: Fix PTH102/PTH103: Replace `os.mkdir()` and `os.makedirs()` with pathlib

### DIFF
--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -904,7 +904,7 @@ def test():
     tempDir = "/tmp/test"
     if Path(tempDir).exists():
         shutil.rmtree(tempDir)
-    os.mkdir(tempDir)
+    Path(tempDir).mkdir()
     # comment this line to keep the directory after program ends
     #    cleanUp = CleanUp(tempDir)
     #    import atexit

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -984,7 +984,7 @@ class Settings:
         dirPath = GetSettingsPath()
         if not Path(dirPath).exists():
             try:
-                os.mkdir(dirPath)
+                Path(dirPath).mkdir()
             except OSError:
                 GError(_("Unable to create settings directory"))
                 return None

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -229,7 +229,7 @@ def _createPath(path):
     """Creates path (for toolboxes) if it doesn't exist'"""
     if not Path(path).exists():
         try:
-            os.mkdir(path)
+            Path(path).mkdir()
         except OSError as e:
             # we cannot use GError or similar because the gui doesn't start at
             # all

--- a/gui/wxpython/core/watchdog.py
+++ b/gui/wxpython/core/watchdog.py
@@ -178,7 +178,7 @@ class MapsetWatchdog:
             path = os.path.join(mapset_path, directory)
             if not Path(path).exists():
                 try:
-                    os.mkdir(path)
+                    Path(path).mkdir()
                 except OSError:
                     pass
             if Path(path).exists():

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -2705,8 +2705,7 @@ class VectGroup(wx.Dialog):
 
         dirname = os.path.dirname(self.vgrpfile)
 
-        if not Path(dirname).exists():
-            os.makedirs(dirname)
+        Path(dirname).mkdir(parents=True, exist_ok=True)
 
         with open(self.vgrpfile, mode="w") as f:
             f.writelines(vect + "\n" for vect in vgrouplist)

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -1067,7 +1067,7 @@ class GRASSStartup(wx.Frame):
         try:
             self.gisdbase = self.tgisdbase.GetValue()
             location = self.listOfLocations[self.lblocations.GetSelection()]
-            os.mkdir(os.path.join(self.gisdbase, location, mapset))
+            Path(os.path.join(self.gisdbase, location, mapset)).mkdir()
             # copy WIND file and its permissions from PERMANENT and set
             # permissions to u+rw,go+r
             shutil.copy(

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2663,7 +2663,7 @@ class LocationWizard(wx.Object):
             if not Path(database).is_dir():
                 # create new directory
                 try:
-                    os.mkdir(database)
+                    Path(database).mkdir()
                 except OSError as error:
                     GError(
                         parent=self.wizard,

--- a/gui/wxpython/rlisetup/functions.py
+++ b/gui/wxpython/rlisetup/functions.py
@@ -61,7 +61,7 @@ def retRLiPath():
     rlipath = os.path.join(grass_config_dir, "r.li")
     if Path(rlipath).exists():
         return rlipath
-    os.mkdir(rlipath)
+    Path(rlipath).mkdir()
     return rlipath
 
 

--- a/imagery/i.rectify/testsuite/test_i_rectify.py
+++ b/imagery/i.rectify/testsuite/test_i_rectify.py
@@ -66,7 +66,7 @@ class TestIRectify(TestCase):
         cls.group_path = os.path.join(
             env["GISDBASE"], env["LOCATION_NAME"], env["MAPSET"], "group", cls.group
         )
-        os.makedirs(cls.group_path, exist_ok=True)
+        Path(cls.group_path).mkdir(exist_ok=True, parents=True)
         cls.points_path = os.path.join(cls.group_path, "POINTS")
         cls.runModule(
             "i.target",

--- a/imagery/i.signatures/testsuite/test_i_signatures.py
+++ b/imagery/i.signatures/testsuite/test_i_signatures.py
@@ -9,9 +9,9 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import os
 import shutil
 import json
+from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -34,27 +34,27 @@ class PrintSignaturesTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
         # Fake signature of sig type
         cls.sig_name1 = tempname(10)
         sig_dir1 = f"{cls.mpath}/signatures/sig/{cls.sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         cls.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         open(sigfile_name1, "a").close()
         # Fake signature of sigset type
         cls.sig_name2 = tempname(10)
         sig_dir2 = f"{cls.mpath}/signatures/sigset/{cls.sig_name2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         cls.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
         open(sigfile_name2, "a").close()
         # Fake signature of libsvm type
         cls.sig_name3 = tempname(10)
         sig_dir3 = f"{cls.mpath}/signatures/libsvm/{cls.sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         cls.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         open(sigfile_name3, "a").close()
@@ -151,48 +151,48 @@ class ManageSignaturesTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
         # sig
         cls.sig_name1 = tempname(10)
         sig_dir1 = f"{cls.mpath}/signatures/sig/{cls.sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         cls.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         open(sigfile_name1, "a").close()
         # sig
         cls.sig_name2 = tempname(10)
         sig_dir2 = f"{cls.mpath}/signatures/sig/{cls.sig_name2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         cls.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
         open(sigfile_name2, "a").close()
         # sigset
         cls.sig_name3 = tempname(10)
         sig_dir3 = f"{cls.mpath}/signatures/sigset/{cls.sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         cls.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         open(sigfile_name3, "a").close()
         # sigset
         cls.sig_name4 = tempname(10)
         sig_dir4 = f"{cls.mpath}/signatures/sigset/{cls.sig_name4}"
-        os.makedirs(sig_dir4)
+        Path(sig_dir4).mkdir(parents=True)
         cls.sigdirs.append(sig_dir4)
         sigfile_name4 = f"{sig_dir4}/sig"
         open(sigfile_name4, "a").close()
         # libsvm
         cls.sig_name5 = tempname(10)
         sig_dir5 = f"{cls.mpath}/signatures/libsvm/{cls.sig_name5}"
-        os.makedirs(sig_dir5)
+        Path(sig_dir5).mkdir(parents=True)
         cls.sigdirs.append(sig_dir5)
         sigfile_name5 = f"{sig_dir5}/sig"
         open(sigfile_name5, "a").close()
         # libsvm
         cls.sig_name6 = tempname(10)
         sig_dir6 = f"{cls.mpath}/signatures/libsvm/{cls.sig_name6}"
-        os.makedirs(sig_dir6)
+        Path(sig_dir6).mkdir(parents=True)
         cls.sigdirs.append(sig_dir6)
         sigfile_name6 = f"{sig_dir6}/sig"
         open(sigfile_name6, "a").close()

--- a/lib/imagery/testsuite/test_imagery_find.py
+++ b/lib/imagery/testsuite/test_imagery_find.py
@@ -9,8 +9,8 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import os
 import shutil
+from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -35,22 +35,22 @@ class FindSignatureTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
         cls.sig_name1 = tempname(10)
         cls.sig_dir1 = f"{cls.mpath}/signatures/sigset/{cls.sig_name1}"
-        os.makedirs(cls.sig_dir1)
+        Path(cls.sig_dir1).mkdir(parents=True)
         cls.sigdirs.append(cls.sig_dir1)
         open(f"{cls.sig_dir1}/sig", "a").close()
         cls.sig_name2 = tempname(10)
         cls.sig_dir2 = f"{cls.mpath}/signatures/sig/{cls.sig_name2}"
-        os.makedirs(cls.sig_dir2)
+        Path(cls.sig_dir2).mkdir(parents=True)
         cls.sigdirs.append(cls.sig_dir2)
         open(f"{cls.sig_dir2}/sig", "a").close()
         cls.sig_name3 = tempname(10)
         cls.sig_dir3 = f"{cls.mpath}/signatures/libsvm/{cls.sig_name3}"
-        os.makedirs(cls.sig_dir3)
+        Path(cls.sig_dir3).mkdir(parents=True)
         cls.sigdirs.append(cls.sig_dir3)
         open(f"{cls.sig_dir3}/sig", "a").close()
 

--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -108,9 +108,9 @@ class SignaturesRemoveTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -122,21 +122,21 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
             pass
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sig/{sig_name2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
         with open(sigfile_name2, "a"):
             pass
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
@@ -172,7 +172,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
@@ -181,7 +181,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Do not create sig_name2 matching file
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
@@ -206,21 +206,21 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
             pass
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sigset/{sig_name2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
         with open(sigfile_name2, "a"):
             pass
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
@@ -256,7 +256,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
@@ -265,7 +265,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Do not create sig_name2 matching file
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
@@ -291,21 +291,21 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/libsvm/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
             pass
         self.sigdirs.append(sig_dir1)
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/libsvm/{sig_name2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         sigfile_name2 = f"{sig_dir2}/sig"
         with open(sigfile_name2, "a"):
             pass
         self.sigdirs.append(sig_dir2)
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
             pass
@@ -341,7 +341,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Set up files and mark for clean-up
         sig_name1 = tempname(10)
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         sigfile_name1 = f"{sig_dir1}/sig"
         with open(sigfile_name1, "a"):
             pass
@@ -350,7 +350,7 @@ class SignaturesRemoveTestCase(TestCase):
         # Do not create sig_name2 matching file
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/libsvm/{sig_name3}"
-        os.makedirs(sig_dir3)
+        Path(sig_dir3).mkdir(parents=True)
         sigfile_name3 = f"{sig_dir3}/sig"
         with open(sigfile_name3, "a"):
             pass
@@ -380,9 +380,9 @@ class SignaturesCopyTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
         # A mapset with a random name
         cls.src_mapset_name = tempname(10)
         G_make_mapset(None, None, cls.src_mapset_name)
@@ -390,22 +390,22 @@ class SignaturesCopyTestCase(TestCase):
             cls.mpath.rsplit("/", maxsplit=1)[0] + "/" + cls.src_mapset_name
         )
         # Create fake signature files
-        os.makedirs(f"{cls.src_mapset_path}/signatures/sig/")
+        Path(f"{cls.src_mapset_path}/signatures/sig/").mkdir(parents=True)
         cls.src_sig = tempname(10)
         cls.src_sig_dir = f"{cls.src_mapset_path}/signatures/sig/{cls.src_sig}"
-        os.makedirs(cls.src_sig_dir)
+        Path(cls.src_sig_dir).mkdir(parents=True)
         cls.sigdirs.append(cls.src_sig_dir)
         Path(f"{cls.src_sig_dir}/sig").write_text("A sig file")
-        os.makedirs(f"{cls.src_mapset_path}/signatures/sigset/")
+        Path(f"{cls.src_mapset_path}/signatures/sigset/").mkdir(parents=True)
         cls.src_sigset = tempname(10)
         cls.src_sigset_dir = f"{cls.src_mapset_path}/signatures/sigset/{cls.src_sigset}"
-        os.makedirs(cls.src_sigset_dir)
+        Path(cls.src_sigset_dir).mkdir(parents=True)
         cls.sigdirs.append(cls.src_sigset_dir)
         Path(f"{cls.src_sigset_dir}/sig").write_text("A sigset file")
-        os.makedirs(f"{cls.src_mapset_path}/signatures/libsvm/")
+        Path(f"{cls.src_mapset_path}/signatures/libsvm/").mkdir(parents=True)
         cls.src_libsvm = tempname(10)
         cls.src_libsvm_dir = f"{cls.src_mapset_path}/signatures/libsvm/{cls.src_libsvm}"
-        os.makedirs(cls.src_libsvm_dir)
+        Path(cls.src_libsvm_dir).mkdir(parents=True)
         cls.sigdirs.append(cls.src_libsvm_dir)
         Path(f"{cls.src_libsvm_dir}/sig").write_text("A libsvm file")
 
@@ -575,9 +575,9 @@ class SignaturesRenameTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -609,7 +609,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_unqualified_sig(self):
         src_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sig/{src_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sig file")
         dst = tempname(10)
@@ -629,7 +629,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_fq_sig(self):
         src_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sig/{src_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sig file")
         dst_name = tempname(10)
@@ -654,7 +654,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_unqualified_sigset(self):
         src_sigset = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sigset/{src_sigset}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sigset file")
         dst = tempname(10)
@@ -674,7 +674,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_fq_sigset(self):
         src_sigset = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sigset/{src_sigset}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sigset file")
         dst_name = tempname(10)
@@ -701,7 +701,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_unqualified_libsvm(self):
         src_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/libsvm/{src_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A libsvm file")
         dst = tempname(10)
@@ -721,7 +721,7 @@ class SignaturesRenameTestCase(TestCase):
     def test_success_fq_libsvm(self):
         src_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/libsvm/{src_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A libsvm file")
         dst = tempname(10)
@@ -754,18 +754,18 @@ class SignaturesListByTypeTestCase(TestCase):
         cls.sigdirs = []
         # As signatures are created directly not via signature creation
         # tools, we must ensure signature directories exist
-        os.makedirs(f"{cls.mpath}/signatures/sig/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/sigset/", exist_ok=True)
-        os.makedirs(f"{cls.mpath}/signatures/libsvm/", exist_ok=True)
+        Path(f"{cls.mpath}/signatures/sig/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/sigset/").mkdir(exist_ok=True, parents=True)
+        Path(f"{cls.mpath}/signatures/libsvm/").mkdir(exist_ok=True, parents=True)
         # A mapset with a random name
         cls.rnd_mapset_name = tempname(10)
         G_make_mapset(None, None, cls.rnd_mapset_name)
         cls.rnd_mapset_path = (
             cls.mpath.rsplit("/", maxsplit=1)[0] + "/" + cls.rnd_mapset_name
         )
-        os.makedirs(f"{cls.rnd_mapset_path}/signatures/sig/")
-        os.makedirs(f"{cls.rnd_mapset_path}/signatures/sigset/")
-        os.makedirs(f"{cls.rnd_mapset_path}/signatures/libsvm/")
+        Path(f"{cls.rnd_mapset_path}/signatures/sig/").mkdir(parents=True)
+        Path(f"{cls.rnd_mapset_path}/signatures/sigset/").mkdir(parents=True)
+        Path(f"{cls.rnd_mapset_path}/signatures/libsvm/").mkdir(parents=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -799,7 +799,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # Sig type
         local_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sig/{local_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
@@ -812,7 +812,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # SigSet type
         local_sigset = tempname(10)
         sig_dir = f"{self.mpath}/signatures/sigset/{local_sigset}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sigset file")
         sig_list = self.list_ptr()
@@ -825,7 +825,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # Libsvm type
         local_sig = tempname(10)
         sig_dir = f"{self.mpath}/signatures/libsvm/{local_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         sig_file = f"{sig_dir}/sig"
         self.sigdirs.append(sig_dir)
         Path(sig_file).write_text("A libsvm file")
@@ -842,7 +842,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # Sig type
         rnd_sig = tempname(10)
         sig_dir = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
@@ -858,7 +858,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # SigSet equals sig. Just testing branching inside.
         rnd_sigset = tempname(10)
         sig_dir = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         self.sigdirs.append(sig_dir)
         Path(f"{sig_dir}/sig").write_text("A sigset file")
         sigset_list = self.list_ptr()
@@ -873,7 +873,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # libsvm type
         rnd_sig = tempname(10)
         sig_dir = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig}"
-        os.makedirs(sig_dir)
+        Path(sig_dir).mkdir(parents=True)
         sig_file = f"{sig_dir}/sig"
         Path(sig_file).write_text("A libsvm file")
         sig_list = self.list_ptr()
@@ -891,12 +891,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # Sig type
         rnd_sig1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         Path(f"{sig_dir1}/sig").write_text("A sig file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         Path(f"{sig_dir2}/sig").write_text("A sig file")
         # POINTER(POINTER(c_char))
@@ -917,12 +917,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # SigSet type
         rnd_sigset1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         Path(f"{sig_dir1}/sig").write_text("A sigset file")
         rnd_sigset2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         Path(f"{sig_dir2}/sig").write_text("A sigset file")
         sigset_list = self.list_ptr()
@@ -942,12 +942,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # libsvm type
         rnd_sig1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         sig_file1 = f"{sig_dir1}/sig"
         Path(sig_file1).write_text("A libsvm file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         sig_file2 = f"{sig_dir2}/sig"
         Path(sig_file2).write_text("A libsvm file")
         # POINTER(POINTER(c_char))
@@ -970,12 +970,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # Test searching in multiple mapsets. Identical to SIGSET case
         rnd_sig1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         Path(f"{sig_dir1}/sig").write_text("A sig file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sig/{rnd_sig2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         Path(f"{sig_dir2}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
@@ -1017,12 +1017,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # Test searching in multiple mapsets. Identical to SIG case
         rnd_sig1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sig1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         self.sigdirs.append(sig_dir1)
         Path(f"{sig_dir1}/sig").write_text("A sigset file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sigset/{rnd_sig2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         self.sigdirs.append(sig_dir2)
         Path(f"{sig_dir2}/sig").write_text("A sigset file")
         sig_list = self.list_ptr()
@@ -1064,12 +1064,12 @@ class SignaturesListByTypeTestCase(TestCase):
         # Test searching in multiple mapsets. Identical to SIG and SIGSET case
         rnd_sig1 = tempname(10)
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig1}"
-        os.makedirs(sig_dir1)
+        Path(sig_dir1).mkdir(parents=True)
         sig_file1 = f"{sig_dir1}/sig"
         Path(sig_file1).write_text("A libsvm file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/libsvm/{rnd_sig2}"
-        os.makedirs(sig_dir2)
+        Path(sig_dir2).mkdir(parents=True)
         sig_file2 = f"{sig_dir2}/sig"
         Path(sig_file2).write_text("A libsvm file")
         self.sigdirs.append(sig_dir2)

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -383,7 +383,7 @@ def create_grass_config_dir() -> str:
 
     if not os.path.isdir(directory):
         try:
-            os.makedirs(directory)
+            Path(directory).mkdir(parents=True)
         except OSError as e:
             # Can happen as a race condition
             if e.errno != errno.EEXIST or not os.path.isdir(directory):
@@ -414,7 +414,7 @@ def create_tmp(user, gis_lock) -> str:
     if tmp:
         tmpdir = os.path.join(tmp, tmpdir_name)
         try:
-            os.mkdir(tmpdir, 0o700)
+            Path(tmpdir).mkdir(mode=0o700)
         except:  # noqa: E722
             tmp = None
 
@@ -423,7 +423,7 @@ def create_tmp(user, gis_lock) -> str:
             tmp = ttmp
             tmpdir = os.path.join(tmp, tmpdir_name)
             try:
-                os.mkdir(tmpdir, 0o700)
+                Path(tmpdir).mkdir(mode=0o700)
             except:  # noqa: E722
                 tmp = None
             if tmp:
@@ -874,7 +874,7 @@ def set_mapset(
                     if not tmp_mapset:
                         message(_("Creating new GRASS mapset <{}>...").format(mapset))
                     # create mapset directory
-                    os.mkdir(path)
+                    Path(path).mkdir()
                     if tmp_mapset:
                         # The tmp location is handled by (re-)using the
                         # tmpdir, but we need to take care of the tmp

--- a/man/build.py
+++ b/man/build.py
@@ -63,7 +63,7 @@ def write_file(name, contents):
 
 def try_mkdir(path):
     try:
-        os.mkdir(path)
+        Path(path).mkdir()
     except OSError:
         pass
 

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -281,7 +281,7 @@ def write_file(name, contents):
 
 def try_mkdir(path):
     try:
-        os.mkdir(path)
+        Path(path).mkdir()
     except OSError:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,8 +209,6 @@ ignore = [
     "PLW3201", # bad-dunder-method-name
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod
-    "PTH102",  # os-mkdir
-    "PTH103",  # os-makedirs
     "PTH104",  # os-rename
     "PTH106",  # os-rmdir
     "PTH107",  # os-remove

--- a/python/grass/app/data.py
+++ b/python/grass/app/data.py
@@ -67,7 +67,7 @@ def create_database_directory():
 
     # Create "grassdata" directory
     try:
-        os.mkdir(path)
+        Path(path).mkdir()
         return path
     except OSError:
         pass
@@ -86,7 +86,7 @@ def create_database_directory():
     if Path(path).exists():
         return path
     try:
-        os.mkdir(path)
+        Path(path).mkdir()
         return path
     except OSError:
         pass

--- a/python/grass/grassdb/create.py
+++ b/python/grass/grassdb/create.py
@@ -111,7 +111,7 @@ def create_mapset(database, location=None, mapset=None):
         mapset,
     )
     # create an empty directory
-    os.mkdir(path)
+    Path(path).mkdir()
     _directory_to_mapset(path)
     # set permissions to u+rw,go+r (disabled; why?)
     # os.chmod(os.path.join(database,location,mapset,'WIND'), 0644)

--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -127,7 +127,7 @@ class GrassTestFilesInvoker:
         mapset_dir = os.path.join(gisdbase, location, mapset)
         if self.clean_before:
             silent_rmtree(mapset_dir)
-        os.mkdir(mapset_dir)
+        Path(mapset_dir).mkdir()
         # TODO: default region in mapset will be what?
         # copy DEFAULT_WIND file from PERMANENT to WIND
         # TODO: this should be a function in grass.script (used also in gis_set.py,

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -12,7 +12,6 @@ for details.
 from __future__ import annotations
 
 import errno
-import os
 import shutil
 import sys
 import warnings
@@ -26,8 +25,7 @@ if TYPE_CHECKING:
 
 def ensure_dir(directory: StrOrBytesPath) -> None:
     """Create all directories in the given path if needed."""
-    if not Path(directory).exists():
-        os.makedirs(directory)
+    Path(directory).mkdir(parents=True, exist_ok=True)
 
 
 def add_gitignore_to_dir(directory: StrPath) -> None:

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -5,6 +5,7 @@ import multiprocessing as mltp
 import subprocess as sub
 import shutil as sht
 from math import ceil
+from pathlib import Path
 
 from grass.script.setup import write_gisrc
 from grass.script import append_node_pid, legalize_vector_name
@@ -94,10 +95,8 @@ def copy_mapset(mapset, path):
     per_new = os.path.join(path, "PERMANENT")
     map_old = mapset.path()
     map_new = os.path.join(path, mapset.name)
-    if not os.path.isdir(per_new):
-        os.makedirs(per_new)
-    if not os.path.isdir(map_new):
-        os.mkdir(map_new)
+    Path(per_new).mkdir(parents=True, exist_ok=True)
+    Path(map_new).mkdir(exist_ok=True)
     copy_special_mapset_files(per_old, per_new)
     copy_special_mapset_files(map_old, map_new)
     gisdbase, location = os.path.split(path)
@@ -141,7 +140,7 @@ def get_mapset(gisrc_src, gisrc_dst):
     path_src = os.path.join(gsrc, lsrc, msrc)
     path_dst = os.path.join(gdst, ldst, mdst)
     if not os.path.isdir(path_dst):
-        os.makedirs(path_dst)
+        Path(path_dst).mkdir(parents=True)
         copy_special_mapset_files(path_src, path_dst)
     src = Mapset(msrc, lsrc, gsrc)
     dst = Mapset(mdst, ldst, gdst)
@@ -719,8 +718,7 @@ class GridModule:
                 par = self.module.outputs[k]
                 if par.typedesc == "raster" and par.value:
                     dirpath = os.path.join(tmpdir, par.name)
-                    if not os.path.isdir(dirpath):
-                        os.makedirs(dirpath)
+                    Path(dirpath).mkdir(parents=True, exist_ok=True)
                     fil = open(os.path.join(dirpath, self.out_prefix + par.value), "w+")
                     fil.close()
 

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -847,8 +847,7 @@ class Link:
                 sqlite3.register_adapter(t, int)
             dbpath = get_path(self.database, self.table_name)
             dbdirpath = os.path.split(dbpath)[0]
-            if not Path(dbdirpath).exists():
-                os.mkdir(dbdirpath)
+            Path(dbdirpath).mkdir(exist_ok=True)
             return sqlite3.connect(dbpath)
         if driver == "pg":
             try:

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1133,7 +1133,7 @@ def tempdir(env=None):
         and :py:func:`~grass.script.core.tempname` functions
     """
     tmp = tempfile(create=False, env=env)
-    os.mkdir(tmp)
+    Path(tmp).mkdir()
 
     return tmp
 
@@ -1986,8 +1986,7 @@ def create_project(
     mapset_path = resolve_mapset_path(path=path, location=name)
 
     # create dbase if not exists
-    if not Path(mapset_path.directory).exists():
-        os.mkdir(mapset_path.directory)
+    Path(mapset_path.directory).mkdir(exist_ok=True)
 
     env = None
     tmp_gisrc = None

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -879,7 +879,7 @@ def create_temporal_database(dbif) -> None:
         tgis_dir = os.path.dirname(tgis_database_string)
         if not Path(tgis_dir).exists():
             try:
-                os.makedirs(tgis_dir)
+                Path(tgis_dir).mkdir(parents=True)
             except Exception as e:
                 msgr.fatal(
                     _(

--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -56,7 +56,7 @@ def extract_tar(name, directory, tmpdir):
     try:
         tar = tarfile.open(name)
         extract_dir = os.path.join(tmpdir, "extract_dir")
-        os.mkdir(extract_dir)
+        Path(extract_dir).mkdir()
 
         # Extraction filters were added in Python 3.12,
         # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
@@ -103,7 +103,7 @@ def extract_zip(name, directory, tmpdir):
         # we suppose we can write to parent of the given dir
         # (supposing a tmp dir)
         extract_dir = os.path.join(tmpdir, "extract_dir")
-        os.mkdir(extract_dir)
+        Path(extract_dir).mkdir()
         for subfile in file_list:
             # this should be safe in Python 2.7.4
             zip_file.extract(subfile, extract_dir)
@@ -132,8 +132,7 @@ def _move_extracted_files(extract_dir, target_dir, files):
         else:
             shutil.copy(actual_path, target_dir)
     else:
-        if not Path(target_dir).exists():
-            os.mkdir(target_dir)
+        Path(target_dir).mkdir(exist_ok=True)
         for file_name in files:
             actual_file = os.path.join(extract_dir, file_name)
             if os.path.isdir(actual_file):

--- a/raster/r.terraflow/testsuite/test_r_terraflow.py
+++ b/raster/r.terraflow/testsuite/test_r_terraflow.py
@@ -26,8 +26,7 @@ class TestTerraflow(TestCase):
 
     def setUp(self):
         """Create input data for steady state groundwater flow computation"""
-        if not Path(self.testdir).exists():
-            os.mkdir(self.testdir)
+        Path(self.testdir).mkdir(exist_ok=True)
 
     def test_univar_mfd(self):
         # compute a steady state groundwater flow

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1748,8 +1748,7 @@ def move_extracted_files(extract_dir, target_dir, files):
     if len(files) == 1:
         shutil.copytree(os.path.join(extract_dir, files[0]), target_dir)
     else:
-        if not Path(target_dir).exists():
-            os.mkdir(target_dir)
+        Path(target_dir).mkdir(exist_ok=True)
         for file_name in files:
             actual_file = os.path.join(extract_dir, file_name)
             if os.path.isdir(actual_file):
@@ -1808,7 +1807,7 @@ def extract_zip(name, directory, tmpdir):
         # we suppose we can write to parent of the given dir
         # (supposing a tmp dir)
         extract_dir = os.path.join(tmpdir, "extract_dir")
-        os.mkdir(extract_dir)
+        Path(extract_dir).mkdir()
         for subfile in file_list:
             if "__pycache__" in subfile:
                 continue
@@ -1833,7 +1832,7 @@ def extract_tar(name, directory, tmpdir):
     try:
         tar = tarfile.open(name)
         extract_dir = os.path.join(tmpdir, "extract_dir")
-        os.mkdir(extract_dir)
+        Path(extract_dir).mkdir()
 
         # Extraction filters were added in Python 3.12,
         # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
@@ -2377,7 +2376,7 @@ def create_dir(path):
         return
 
     try:
-        os.makedirs(path)
+        Path(path).mkdir(parents=True)
     except OSError as error:
         gs.fatal(_("Unable to create '%s': %s") % (path, error))
 

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -193,7 +193,7 @@ def main():
     # make a temporary directory
     tmpdir = gs.tempfile()
     gs.try_remove(tmpdir)
-    os.mkdir(tmpdir)
+    Path(tmpdir).mkdir()
     if is_zip:
         shutil.copyfile(zipfile, os.path.join(tmpdir, f"{tile}{suff}.zip"))
     else:

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -207,8 +207,7 @@ def main():
                 continue
 
             path = os.path.join(mset_dir, element)
-            if not Path(path).exists():
-                os.mkdir(path)
+            Path(path).mkdir(exist_ok=True)
 
             if element == "cell_misc":
                 if index > 0:

--- a/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+++ b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
@@ -54,6 +54,7 @@
 import sys
 import os
 import string
+from pathlib import Path
 
 import grass.script as gs
 from grass.exceptions import CalledModuleError
@@ -82,7 +83,7 @@ def create_db(driver, database):
         # check if destination directory exists
         if not os.path.isdir(path):
             # create dbf database
-            os.makedirs(path)
+            Path(path).mkdir(parents=True)
             return True
         return False
 
@@ -90,7 +91,7 @@ def create_db(driver, database):
         path = os.path.dirname(subst_database)
         # check if destination directory exists
         if not os.path.isdir(path):
-            os.makedirs(path)
+            Path(path).mkdir(parents=True)
 
     if (
         subst_database

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -94,7 +94,7 @@ def main():
     # make a temporary directory
     tmpdir = gcore.tempfile()
     try_remove(tmpdir)
-    os.mkdir(tmpdir)
+    Path(tmpdir).mkdir()
 
     files = glob.glob(e00name + ".e[0-9][0-9]") + glob.glob(e00name + ".E[0-9][0-9]")
     for f in files:

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -218,9 +218,9 @@ def main():
         dbln.close()
         # check if dbf or sqlite directory exists
         if dbconn["driver"] == "dbf" and not Path(mset_dir, "dbf").exists():
-            os.mkdir(os.path.join(mset_dir, "dbf"))
+            Path(mset_dir, "dbf").mkdir()
         elif dbconn["driver"] == "sqlite" and not Path(mset_dir, "sqlite").exists():
-            os.mkdir(os.path.join(mset_dir, "sqlite"))
+            Path(mset_dir, "sqlite").mkdir()
         # for each old connection
         for t in dbnlist:
             # it split the line of each connection, to found layer number and key

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -160,8 +160,7 @@ def main():
     color_dir = os.path.join(os.environ["GISBASE"], "etc", "colors")
     output_dir = sys.argv[1]
 
-    if not Path(output_dir).exists():
-        os.makedirs(output_dir)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     pid = os.getpid()
     tmp_grad_abs = "tmp_grad_abs_%d" % pid


### PR DESCRIPTION
PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`

PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`

Ruff rules: https://docs.astral.sh/ruff/rules/os-mkdir/ https://docs.astral.sh/ruff/rules/os-makedirs/

Try merging #6603 before, there might be some that were already fixed