### PR TITLE
make: pass GDAL include dirs to proj

### DIFF
--- a/python/libgrass_interface_generator/Makefile
+++ b/python/libgrass_interface_generator/Makefile
@@ -52,7 +52,7 @@ segment_HDRS    = segment.h defs/segment.h
 rowio_HDRS      = rowio.h defs/rowio.h
 temporal_HDRS   = temporal.h
 
-proj_INC        = $(PROJINC)
+proj_INC        = $(PROJINC) $(GDALCFLAGS)
 vector_INC      = $(VECT_INC) $(VECT_CFLAGS)
 vedit_INC       = $(VECT_INC) $(VECT_CFLAGS)
 


### PR DESCRIPTION
vector_inc and vedit_inc don't need this treatment as VECT_CFLAGS has it
added already. This would conform to how its done in the CMakeLists.txt
as well.

Oddly enough this isn't a fatal error though. So if anyone hit a build
failure and thought this was the issue should look further into their
builds logs for the actual cause.

Bug: https://github.com/OSGeo/grass/issues/4258

Why did I look at this? Because r.geomorphon actually segfaulted and while trying to find the error I ended up spending some time at this red herring.
https://github.com/OSGeo/grass/issues/3731#issuecomment-3539570013