### PR TITLE
grass.app: Always set path to script addons

### DIFF
--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -200,10 +200,12 @@ def append_left_addon_paths(paths, config_dir, env):
         addon_base = os.path.join(config_dir, name)
         env["GRASS_ADDON_BASE"] = addon_base
 
+    # Adding the paths is platform-dependent, but we add them regardless of their
+    # existence, because they might be created later after the setup is done
+    # when installing addons.
     if not WINDOWS:
         script_path = os.path.join(addon_base, "scripts")
-        if Path(script_path).exists():
-            paths.appendleft(script_path)
+        paths.appendleft(script_path)
     paths.appendleft(os.path.join(addon_base, "bin"))
 
     # addons (path)

--- a/scripts/g.extension/tests/conftest.py
+++ b/scripts/g.extension/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Test g.extension"""
+
+import os
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
+
+
+# Using module-scoped fixture to avoid overhead of downloading addons repo.
+@pytest.fixture(scope="module")
+def tools(tmp_path_factory):
+    """Tools with modified addon base directory (scope: module)"""
+    tmp_path = tmp_path_factory.mktemp("g_extension_tests")
+    gs.create_project(tmp_path / "test")
+    env = os.environ.copy()
+    env["GRASS_ADDON_BASE"] = str(tmp_path / "addons")
+    with (
+        gs.setup.init(tmp_path / "test", env=env) as session,
+        Tools(session=session, consistent_return_value=True) as tools,
+    ):
+        yield tools

--- a/scripts/g.extension/tests/g_extension_test.py
+++ b/scripts/g.extension/tests/g_extension_test.py
@@ -1,0 +1,11 @@
+"""Test g.extension"""
+
+import pytest
+
+
+# This should cover both C and Python tools.
+@pytest.mark.parametrize("name", ["r.stream.distance", "r.lake.series"])
+def test_install(tools, name):
+    """Test that a tools installs and gives help message"""
+    tools.g_extension(extension=name)
+    assert tools.call_cmd([name, "--help"]).stderr


### PR DESCRIPTION
For relevant platforms (currently all except Windows), add the scripts directory for addons to path even if the directory does not exist. When installing into a fresh install, the directory may not exist, so it is not added and the addon tool does not run.

The new test fails for the Python tool with the old code, but works with the new code.
