### PR TITLE
r.path: restrict start_points vector input to point type only

### DIFF
--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -342,6 +342,9 @@ int main(int argc, char **argv)
                 else if (type == -2) {
                     break;
                 }
+                else if (!(type & GV_POINT)) {
+                    continue;
+                }
                 if (!Vect_point_in_box(Points->x[0], Points->y[0], 0, &box))
                     continue;
 


### PR DESCRIPTION
I ran into an issue when my vector of input points had points and boundaries (without category), resulting in strange error messages from r.path (`ERROR: Unable to read from temp file`). This PR makes sure the input are points only and ignores the rest.
