### PR TITLE
lib/raster: Add missing include

### DIFF
--- a/include/grass/raster.h
+++ b/include/grass/raster.h
@@ -2,6 +2,7 @@
 #define GRASS_RASTER_H
 
 #include <grass/gis.h>
+#include <grass/colors.h>
 
 /*** defines ***/
 #define RECLASS_TABLE   1


### PR DESCRIPTION
Add this missing include to fix a build error:

```
FAILED: [code=1] lib/gis/CMakeFiles/grass_gis.dir/color_str.c.o 
ccache /usr/bin/cc -DGRASS_VERSION_DATE=\"2025\" -DPACKAGE=\"grasslibs\" -Dgrass_gis_EXPORTS -I/home/lbartoletti/prog/grass/build/output/lib/grass85/include 
-I/home/lbartoletti/prog/grass/lib/gis -isystem /usr/local/include -isystem /usr/local/include/postgresql/server -DGRASS_CMAKE_BUILD=1  -std=gnu11 -fPIC 
-fopenmp=libomp -pthread -MD -MT lib/gis/CMakeFiles/grass_gis.dir/color_str.c.o -MF lib/gis/CMakeFiles/grass_gis.dir/color_str.c.o.d -o 
lib/gis/CMakeFiles/grass_gis.dir/color_str.c.o -c /home/lbartoletti/prog/grass/lib/gis/color_str.c
/home/lbartoletti/prog/grass/lib/gis/color_str.c:210:42: error: unknown type name 'ColorFormat'
  210 | void G_color_to_str(int r, int g, int b, ColorFormat clr_frmt, char *str)
      |                                          ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:215:10: error: use of undeclared identifier 'RGB'
  215 |     case RGB:
      |          ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:216:23: error: use of undeclared identifier 'COLOR_STRING_LENGTH'
  216 |         snprintf(str, COLOR_STRING_LENGTH, "rgb(%d, %d, %d)", r, g, b);
      |                       ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:219:10: error: use of undeclared identifier 'HEX'
  219 |     case HEX:
      |          ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:220:23: error: use of undeclared identifier 'COLOR_STRING_LENGTH'
  220 |         snprintf(str, COLOR_STRING_LENGTH, "#%02X%02X%02X", r, g, b);
      |                       ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:223:10: error: use of undeclared identifier 'HSV'
  223 |     case HSV:
      |          ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:225:23: error: use of undeclared identifier 'COLOR_STRING_LENGTH'
  225 |         snprintf(str, COLOR_STRING_LENGTH, "hsv(%d, %d, %d)", (int)h, (int)s,
      |                       ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:229:10: error: use of undeclared identifier 'TRIPLET'
  229 |     case TRIPLET:
      |          ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:230:23: error: use of undeclared identifier 'COLOR_STRING_LENGTH'
  230 |         snprintf(str, COLOR_STRING_LENGTH, "%d:%d:%d", r, g, b);
      |                       ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:254:1: error: unknown type name 'ColorFormat'
  254 | ColorFormat G_option_to_color_format(const struct Option *option)
      | ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:257:16: error: use of undeclared identifier 'RGB'
  257 |         return RGB;
      |                ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:260:16: error: use of undeclared identifier 'TRIPLET'
  260 |         return TRIPLET;
      |                ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:263:16: error: use of undeclared identifier 'HSV'
  263 |         return HSV;
      |                ^
/home/lbartoletti/prog/grass/lib/gis/color_str.c:266:16: error: use of undeclared identifier 'HEX'
  266 |         return HEX;
      |                ^
14 errors generated.
[82/3735] Building C object lib/gis/CMakeFiles/grass_gis.dir/lz4.c.o 
```