### PR TITLE
doc: use the correct release tarball, which includes generated content

### DIFF
--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -334,6 +334,9 @@ Fetch a tarball from GitHub we also publish on OSGeo servers:
 ```bash
 wget https://github.com/OSGeo/grass/releases/download/${VERSION}/grass-${VERSION}.tar.gz \
     -O grass-${VERSION}.tar.gz
+wget https://github.com/OSGeo/grass/releases/download/${VERSION}/grass-${VERSION}.tar.gz.sha256 \
+    -O grass-${VERSION}.tar.gz.sha256
+sha256sum -c grass-${VERSION}.tar.gz.sha256
 md5sum grass-${VERSION}.tar.gz > grass-${VERSION}.md5sum
 ```
 


### PR DESCRIPTION
With the 8.4.2 release, the wrong tarball ended up on the server. One that is missing the generated files from this part:

https://github.com/OSGeo/grass/blob/a0b61664ad13688cf3abaf012295b8db9583df48/.github/workflows/create_release_draft.yml#L50-L61

(But for 8.4.2. this is too late, we cannot/mustn't replace the tarball now, that will lead to problems. )