### PR TITLE
r.mapcalc: fix multiple outputs with nprocs > 1

### DIFF
--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -461,11 +461,11 @@ void execute(expr_list *ee)
     verbose = isatty(2);
     for (current_depth = 0; current_depth < depths; current_depth++) {
         int row;
-
 #pragma omp parallel for default(shared) schedule(static, 1) private(i) ordered
         for (row = 0; row < rows; row++) {
             if (verbose)
                 G_percent(n, count, 2);
+
             int tid = 0;
 #if defined(_OPENMP)
             tid = omp_get_thread_num();
@@ -490,6 +490,7 @@ void execute(expr_list *ee)
             n++;
         }
     }
+
     G_finish_workers();
 
     if (verbose)


### PR DESCRIPTION
Parallelized `r.mapcalc` fails if multiple outputs are calculated with several expressions separated by `;`. This PR separates the evaluation of the expressions (calculating results) and writing out the results into different loops.

Test case with the NC sample data:
```
# prepare data
g.region raster=elevation
r.relief input=elevation output=relief zscale=10
```
expected success with
```
r.blend -c first=elevation second=relief output=blend percent=75 nprocs=1
```
without this PR it should fail with nprocs > 1, e.g.
```
r.blend -c first=elevation second=relief output=blend_nprocs percent=75 nprocs=16
```

With this PR, `r.blend ... nprocs=16` succeeds and the result is identical to `r.blend ... nprocs=1` 

Theoretically, there should be no significant speed penality with this change, but this needs to be tested.

Fixes #6158 

Please test!

Still a draft because calls to `G_percent()` need to be fixed. 