### PR TITLE
r.grow.distance: fix scientific notation parsing for minimum and maximum distance (#5521)

### DIFF
--- a/raster/r.grow.distance/main.c
+++ b/raster/r.grow.distance/main.c
@@ -199,25 +199,16 @@ int main(int argc, char **argv)
     val_name = opt.val->answer;
 
     dist_row_max = val_row_max = NULL;
-    mindist = -1;
-    if (opt.min->answer) {
-        if (sscanf(opt.min->answer, "%lf", &mindist) != 1) {
-            G_warning(_("Invalid %s value '%s', ignoring."), opt.min->key,
-                      opt.min->answer);
+   mindist = -1;
+if (opt.min->answer) {
+    mindist = atof(opt.min->answer);
+}
 
-            mindist = -1;
-        }
-    }
 
-    maxdist = -1;
-    if (opt.max->answer) {
-        if (sscanf(opt.max->answer, "%lf", &maxdist) != 1) {
-            G_warning(_("Invalid %s value '%s', ignoring."), opt.max->key,
-                      opt.max->answer);
-
-            maxdist = -1;
-        }
-    }
+maxdist = -1;
+if (opt.max->answer) {
+    maxdist = atof(opt.max->answer);
+}
 
     if (mindist > 0 && maxdist > 0 && mindist >= maxdist) {
         /* GTC error because given minimum_distance is not smaller than


### PR DESCRIPTION
This patch fixes Issue #5521 where r.grow.distance failed to parse 
very small distance values provided in scientific notation (e.g., 1e-06).

The original code used sscanf("%lf") which does not reliably accept 
scientific notation for certain locales and projections. 
The fix replaces sscanf() with atof() for parsing both 
minimum_distance and maximum_distance values.

This ensures correct handling of small distances in long-lat projections 
and improves module robustness.

<img width="490" height="163" alt="Screenshot 2025-12-02 130003" src="https://github.com/user-attachments/assets/9d92f3db-c30f-48f0-99cc-e15176ea457a" />
<img width="528" height="138" alt="Screenshot 2025-12-02 130012" src="https://github.com/user-attachments/assets/ae0f76f4-fb8f-43fc-a64c-382bea5c7f1d" />  #above two photos are of before
<img width="399" height="242" alt="Screenshot 2025-12-02 131347" src="https://github.com/user-attachments/assets/0daad9a5-5c67-43f1-aa9f-cdc0ec879bf3" /> #after making changes
