### PR TITLE
grass.temporal: add explicit timestamp converter and adapters for sqlite3 and Python >= 3.12

### DIFF
--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -69,7 +69,8 @@ else:
 def adapt_datetime_iso(value: datetime) -> str:
     """Adapt datetime object to timezone-naive ISO 8601 string, assuming UTC.
 
-    Backwards compatibility with datetime storage in the temporal database.
+    Output strftime format ensures backwards compatibility with datetime
+    storage in the temporal database.
     """
     return value.strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
This PR adds explicit timestamp converters for SQLite3 and Python 3.12 in TGIS as default converters and adapters were deprecated as of that version of Python..
Not sure if it should be backported ...

Fix #5795