### PR TITLE
cmake: fix warnings and errors with newer CMake and Xcode

### DIFF
--- a/cmake/modules/build_gui_in_subdir.cmake
+++ b/cmake/modules/build_gui_in_subdir.cmake
@@ -98,13 +98,12 @@ function(build_gui_in_subdir dir_name)
         ${HTML_SEARCH_STR} > ${TMP_HTML_FILE}
       COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${MKHTML_PY}
               ${G_TARGET_NAME} ${GRASS_VERSION_DATE} > ${OUT_HTML_FILE}
-      COMMENT "Creating ${OUT_HTML_FILE}"
       COMMAND ${copy_images_command}
       COMMAND ${CMAKE_COMMAND} -E remove ${TMP_HTML_FILE}
               ${CMAKE_CURRENT_BINARY_DIR}/${G_TARGET_NAME}.html
       COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${MKHTML_PY}
               ${G_TARGET_NAME} ${GRASS_VERSION_DATE} > ${GUI_HTML_FILE}
-      COMMENT "Creating ${GUI_HTML_FILE}"
+      COMMENT "Creating ${OUT_HTML_FILE} (and ${GUI_HTML_FILE}))"
       DEPENDS ${OUT_SCRIPT_FILE} GUI_WXPYTHON LIB_PYTHON)
 
 

--- a/gui/wxpython/docs/CMakeLists.txt
+++ b/gui/wxpython/docs/CMakeLists.txt
@@ -7,13 +7,13 @@ set(wxpython_html_files
     wxGUI.toolboxes
     wxGUI.vnet)
 
-add_custom_target(wxpython_docs DEPENDS grass_gis)
+add_custom_target(wxpython_docs DEPENDS grass_gis LIB_PYTHON)
 add_dependencies(GUI_WXPYTHON wxpython_docs)
 
 foreach(html_file ${wxpython_html_files})
   add_custom_command(
     TARGET wxpython_docs
-    PRE_BUILD DEPENDS LIB_PYTHON
+    PRE_BUILD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${MKHTML_PY} ${html_file}
             > ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/${html_file}.html

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -26,10 +26,16 @@ foreach(_locale ${_locales})
     generate_mo_files_dir_${_locale}
     DEPENDS generate_mo_files_dir
     COMMENT "Create locale specific directories")
+  add_custom_target(${_locale}_LC_MESSAGES_dir ALL
+                    COMMENT "Create locale (${_locale}) LC_MESSAGES directory")
   add_custom_command(
-    OUTPUT ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES
+    TARGET ${_locale}_LC_MESSAGES_dir
+    PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory
-            ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES)
+            ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES
+    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES)
+
+  set_target_properties(${_locale}_LC_MESSAGES_dir PROPERTIES FOLDER locale)
   set_target_properties(generate_mo_files_dir_${_locale} PROPERTIES FOLDER
                                                                     locale)
 endforeach()
@@ -44,7 +50,7 @@ foreach(po_file ${po_files})
 
   add_custom_target(
     generate_mo_files_${po_file_name} ALL
-    DEPENDS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES
+    DEPENDS ${_locale}_LC_MESSAGES_dir
     COMMENT "Generate mo files")
   set_target_properties(generate_mo_files_${po_file_name} PROPERTIES FOLDER
                                                                      locale)

--- a/raster/r.mapcalc/CMakeLists.txt
+++ b/raster/r.mapcalc/CMakeLists.txt
@@ -48,3 +48,7 @@ build_program(
   Readline::Readline
   Readline::History
   Threads::Threads)
+
+# mapcalc.yy.c is attached to both targets, work around this with build
+# dependency chain
+add_dependencies(r3.mapcalc r.mapcalc)


### PR DESCRIPTION
This addresses CMake Warning with CMake 3.31 (at least):

- cmake/modules/build_gui_in_subdir.cmake Warning: "COMMENT requres exactly one argument, but multiple values or COMMENT  keywords have been given".
- gui/wxpython/docs/CMakeLists.txt Warning: "The following keywords are not supported when using add_custom_command(TARGET): DEPENDS."

and CMake Error configuring with Xcode generator, both related to a custom command (generating file/directory) that is attached to multiple targets:

- locale/CMakeLists.txt
- raster/r.mapcalc/CMakeLists.txt