### PR TITLE
doc: Enable MathJax rendering for equations in MkDocs documentation

### DIFF
--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -79,8 +79,7 @@ extra_css:
   - grassdocs.css
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js
 
 # Plugins
 plugins:


### PR DESCRIPTION
Solves #6610, Hi I am a new contributor to grass! Excited to contribute more...

This PR enables proper rendering of mathematical expressions in the GRASS MkDocs documentation.
Some manual pages such as `r.runoff` contain LaTeX formulas, but these were previously shown as raw `$...$` text. This update integrates MathJax and the required Markdown extension so that equations render correctly both inline and in block form.

---
Testing
```md
## Math test

Inline: $x^2 + y^2 = z^2$.

Block:

$$
E = mc^2
$$
```

Its Output:
<img width="855" height="303" alt="image" src="https://github.com/user-attachments/assets/2469392a-0c8b-4434-a9ff-20be18c9df8e" />


---

### Notes from local build experience

While testing this change locally, I found it non-obvious how to build and preview the documentation.
At first, addon manual pages like `r.runoff` were missing, and changes in `index.md` had no visible effect.
Eventually I realized that MkDocs serves content from the generated directory:

```
dist.x86_64-pc-linux-gnu/docs/mkdocs/
```

and not directly from files under `man/`.
After updating the correct `mkdocs.yml` and the generated `source/index.md` inside the `dist` folder, MathJax worked as expected.
The final changes in this PR are applied to `man/mkdocs/mkdocs.yml`
