### PR TITLE
CI(macOS_distribute_app): fix config file creation

### DIFF
--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           echo "Moving directories..."
           sudo mkdir /opt/local-off /opt/homebrew-off
+          sed -i '' '/brew\ shellenv/d' "${HOME}/.bashrc"
           test ! -d /usr/local || /usr/bin/sudo /usr/bin/find /usr/local \
             -mindepth 1 -maxdepth 1 -type d -print -exec /bin/mv {} \
             /opt/local-off/ \;
@@ -111,11 +112,15 @@ jobs:
       - name: Create config file
         shell: bash -el {0}
         env:
-          CONFIG: ${HOME}/.config/grass/configure-build-${{ matrix.name }}.sh
+          CONFIG: configure-build-${{ matrix.name }}.sh
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MATRIX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
         run: |
           mkdir -p "${HOME}/.config/grass"
+          conf_dir="${HOME}/.config/grass"
+          mkdir -p "${conf_dir}"
+          pushd "${conf_dir}"
+          touch "${CONFIG}"
           {
             echo sdk=\""$(xcrun --show-sdk-path)"\"
             echo deployment_target=\""${MATRIX_DEPLOYMENT_TARGET}"\"
@@ -123,6 +128,7 @@ jobs:
             echo cs_keychain_profile=\""${KEYCHAIN_PROFILE}"\"
             echo cs_provisionprofile=\""${RUNNER_TEMP}/embedded.provisionprofile"\"
           } >> "${CONFIG}"
+          popd
 
       - name: Build GRASS app
         run: |


### PR DESCRIPTION
For some reason the config file creation has been failing for some time on `macOS distribute app` workflow. This will at least solve that issue.