### PR TITLE
v.external{.out}: always build module

### DIFF
--- a/vector/v.external.out/Makefile
+++ b/vector/v.external.out/Makefile
@@ -10,6 +10,4 @@ EXTRA_CFLAGS = $(VECT_CFLAGS)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-ifneq ($(filter 1,$(USE_POSTGRES)),)
 default: cmd
-endif

--- a/vector/v.external/Makefile
+++ b/vector/v.external/Makefile
@@ -11,6 +11,4 @@ EXTRA_LDFLAGS = $(PQLIBPATH)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-ifneq ($(filter 1,$(USE_POSTGRES)),)
 default: cmd
-endif


### PR DESCRIPTION
Fix regression introduced by 8b4d7c3e310ec3122a5e870e724c50bd716f9513

Closes #6709
