### PR TITLE
configure: remove HAVE_PROJ_H macro

### DIFF
--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -247,7 +247,6 @@ if(Python3_FOUND)
   #]]
 endif()
 
-check_target(PROJ::proj HAVE_PROJ_H)
 check_target(ZLIB::ZLIB HAVE_ZLIB_H)
 check_target(Iconv::Iconv HAVE_ICONV_H)
 check_target(PNG::PNG HAVE_PNG_H)

--- a/configure
+++ b/configure
@@ -9193,26 +9193,18 @@ if test -n "$with_proj_includes" ; then
 fi
 
 
-
 ac_save_cppflags="$CPPFLAGS"
 CPPFLAGS="$PROJINC $CPPFLAGS"
-       for ac_header in proj.h
-do :
-  ac_fn_c_check_header_compile "$LINENO" "proj.h" "ac_cv_header_proj_h" "$ac_includes_default"
+ac_fn_c_check_header_compile "$LINENO" "proj.h" "ac_cv_header_proj_h" "$ac_includes_default"
 if test "x$ac_cv_header_proj_h" = xyes
 then :
-  printf "%s\n" "#define HAVE_PROJ_H 1" >>confdefs.h
 
 else case e in #(
-  e)
-    as_fn_error $? "*** Unable to locate PROJ includes." "$LINENO" 5
- ;;
+  e) as_fn_error $? "*** Unable to locate <proj.h>." "$LINENO" 5 ;;
 esac
 fi
 
-done
 CPPFLAGS=$ac_save_cppflags
-
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking PROJ major version" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -751,7 +751,10 @@ PROJSHARE=
 
 LOC_CHECK_INC_PATH(proj,PROJ,PROJINC)
 
-LOC_CHECK_INCLUDES(proj.h,PROJ,$PROJINC)
+ac_save_cppflags="$CPPFLAGS"
+CPPFLAGS="$PROJINC $CPPFLAGS"
+AC_CHECK_HEADER([proj.h],[],AC_MSG_ERROR([*** Unable to locate <proj.h>.]),[])
+CPPFLAGS=$ac_save_cppflags
 
 LOC_CHECK_VERSION_INT(proj.h,PROJ_VERSION_MAJOR,PROJ major,proj_ver_major,$PROJINC,0)
 LOC_CHECK_VERSION_INT(proj.h,PROJ_VERSION_MINOR,PROJ minor,proj_ver_minor,$PROJINC,0)

--- a/include/config.h.cmake.in
+++ b/include/config.h.cmake.in
@@ -158,9 +158,6 @@
 /* Define to 1 if PostgreSQL is to be used. */
 #cmakedefine HAVE_POSTGRES ${HAVE_POSTGRES}
 
-/* Define to 1 if you have the <proj.h> header file. */
-#cmakedefine HAVE_PROJ_H ${HAVE_PROJ_H}
-
 /* Define to 1 if you have the <pthread.h> header file. */
 #cmakedefine HAVE_PTHREAD_H ${HAVE_PTHREAD_H}
 

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -153,9 +153,6 @@
 /* Define to 1 if PQcmdTuples in lpq. */
 #undef HAVE_PQCMDTUPLES
 
-/* Define to 1 if you have the <proj.h> header file. */
-#undef HAVE_PROJ_H
-
 /* Define to 1 if POSIX threads are available. */
 #undef HAVE_PTHREAD
 

--- a/include/grass/gprojects.h
+++ b/include/grass/gprojects.h
@@ -21,7 +21,6 @@
 #include <ogr_srs_api.h>
 
 /* TODO: clean up support for PROJ 5+ */
-#ifdef HAVE_PROJ_H
 #include <proj.h>
 #define RAD_TO_DEG 57.295779513082321
 #define DEG_TO_RAD .017453292519943296
@@ -30,7 +29,6 @@
 /* update if new PROJ versions support new WKT2 standards */
 #define PJ_WKT2_LATEST PJ_WKT2_2019
 #endif
-#endif // HAVE_PROJ_H
 
 /* Data Files */
 #define ELLIPSOIDTABLE      "/etc/proj/ellipse.table"

--- a/mswindows/osgeo4w/config.h.vc
+++ b/mswindows/osgeo4w/config.h.vc
@@ -289,5 +289,4 @@
 /* define if langinfo.h exists */
 /* #undef HAVE_LANGINFO_H */
 
-#define HAVE_PROJ_H 1
 #endif /* _config_h */


### PR DESCRIPTION
Remove the HAVE_PROJ_H macro as it is always true, given PROJ is a requirement and configuration will fail if <proj.h> is not found.