### PR TITLE
docs: Fixed broken tutorials link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to get GRASS for your platform.
 ## Documentation
 
 See [documentation](https://grass.osgeo.org/grass-devel/manuals/index.html) and
-[tutorials](https://grass.osgeo.org/grass-devel/manuals/tutorials/index.html)
+[tutorials](https://grass-tutorials.osgeo.org/)
 to start learning GRASS.
 
 ## Getting help


### PR DESCRIPTION
Fixes #6718 
This pull request updates the tutorials link in README.md to point to the correct tutorials site at https://grass-tutorials.osgeo.org/. The current link leads to a non-existent page and returns a 404 error, which can confuse or block new users who are trying to access GRASS GIS learning materials.

By updating the link, this change improves the onboarding experience for newcomers and ensures that the documentation reliably directs users to the official tutorials.

This pull request addresses issue #6718 