### PR TITLE
docs: update figure description for r.neighbors

### DIFF
--- a/raster/r.neighbors/r.neighbors.html
+++ b/raster/r.neighbors/r.neighbors.html
@@ -13,7 +13,7 @@ layer. Note that the centre cell is also included in the calculation.
 
 <center>
 <img src="r_neighbors.png">
-<p><em>Figure: Illustration for an 3x3 average neighborhood</em></p>
+<p><em>Figure: Illustration for an 3x3 sum neighborhood</em></p>
 </center>
 
 <h3>OPTIONS</h3>

--- a/raster/r.neighbors/r.neighbors.md
+++ b/raster/r.neighbors/r.neighbors.md
@@ -9,8 +9,8 @@ might be assigned a value equal to the average of the values appearing
 in its 3 x 3 cell "neighborhood" in the input layer. Note that the
 centre cell is also included in the calculation.
 
-![Illustration for an 3x3 average neighborhood](r_neighbors.png)  
-*Figure: Illustration for an 3x3 average neighborhood*
+![Illustration for an 3x3 sum neighborhood](r_neighbors.png)  
+*Figure: Illustration for an 3x3 sum neighborhood*
 
 ### OPTIONS
 


### PR DESCRIPTION
The figure in https://grass.osgeo.org/grass-stable/manuals/r.neighbors.html
<img width="584" height="282" alt="image" src="https://github.com/user-attachments/assets/38671e64-cf1a-43af-82cb-04b5bdfdb5f9" />
describes the "sum" method, not the "average" one.