### PR TITLE
CI: Enable renovate updates on releasebranch_8_4

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,11 +25,11 @@
         "group:githubArtifactActions",
         "schedule:weekends",
     ],
-    
+
     "baseBranchPatterns" : [
       "$default",
       "releasebranch_8_4",
-    ], 
+    ],
 
     // enable Nix lock file update (flake.lock)
     "nix": {


### PR DESCRIPTION
Closes #6532 

This PR adds a base branch to renovate, that will allow it to scan and send update PRs.
As explained in the issue, let’s try this out as-is, and decide if some more rules/exclusions are needed afterwards.

Since all values in the base branch are patterns that are ORed, it isn’t possible to use a not regex operator correctly (like expected). Since we only want a couple release branches maintained at a time, we will manually change them.

This PR, the contents of the config file, doesn’t have to be backported and present on all the branches we want it applied. Only on main is enough.



Docs here: https://docs.renovatebot.com/configuration-options/#basebranchpatterns