### PR TITLE
CI: Apply zizmor safe fixes in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,10 @@ repos:
     rev: v1.19.0
     hooks:
       - id: zizmor
+        args:
+          - "--fix"
+          # https://github.com/zizmorcore/zizmor-pre-commit/blob/120fe9ac3c965ab7decf67e8b9ca24b274230eed/.pre-commit-hooks.yaml#L10
+          - "--no-progress"
   - repo: https://github.com/editorconfig-checker/editorconfig-checker
     rev: v3.6.0
     hooks:


### PR DESCRIPTION
zizmor has fixes available since about version v1.10.0 (useful since v1.15.0). See https://docs.zizmor.sh/usage/#auto-fixing-results

Update the pre-commit configuration to apply the safe fixes, by adding the "--fix" arg to the args defined in their .pre-commit-hooks.yaml definition, here https://github.com/zizmorcore/zizmor-pre-commit/blob/120fe9ac3c965ab7decf67e8b9ca24b274230eed/.pre-commit-hooks.yaml#L10