### PR TITLE
wxGUI: Resizable Define new GRASS project wizard

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -197,7 +197,14 @@ class DatabasePage(TitledPage):
         self.bbrowse = self.MakeButton(_("Change"))
 
         # text controls
-        self.tgisdbase = self.MakeLabel(grassdatabase)
+        # Show long paths nicely with middle ellipsis and full value in tooltip
+        self.tgisdbase = StaticText(
+            parent=self,
+            id=wx.ID_ANY,
+            label=grassdatabase,
+            style=wx.ST_ELLIPSIZE_MIDDLE,
+        )
+        self.tgisdbase.SetToolTip(grassdatabase)
         self.tlocation = self.MakeTextCtrl("newProject")
         self.tlocation.SetFocus()
 
@@ -332,6 +339,7 @@ class DatabasePage(TitledPage):
         if dlg.ShowModal() == wx.ID_OK:
             self.grassdatabase = dlg.GetPath()
             self.tgisdbase.SetLabel(self.grassdatabase)
+            self.tgisdbase.SetToolTip(self.grassdatabase)
 
         dlg.Destroy()
 
@@ -2502,6 +2510,14 @@ class LocationWizard(wx.Object):
         self.wizard.FitToPage(self.datumpage)
         size = self.wizard.GetPageSize()
         self.wizard.SetPageSize((size[0], size[1] + 75))
+        # Allow user to resize while keeping sensible minimum size
+        cur_size = self.wizard.GetSize()
+        try:
+            # Set size hints (min size) to current size
+            self.wizard.SetSizeHints(cur_size[0], cur_size[1])
+        except Exception:
+            # Fallback for environments not supporting SetSizeHints
+            self.wizard.SetMinSize(cur_size)
 
         # new location created?
         self.location = None
@@ -2795,9 +2811,20 @@ class WizardWithHelpButton(Wizard):
         if globalvar.wxPythonPhoenix:
             Wizard.__init__(self)
             self.SetExtraStyle(wx.adv.WIZARD_EX_HELPBUTTON)
-            self.Create(parent=parent, id=id, title=title)
+            self.Create(
+                parent=parent,
+                id=id,
+                title=title,
+                style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+            )
         else:
             pre = wiz.PreWizard()
             pre.SetExtraStyle(wx.wizard.WIZARD_EX_HELPBUTTON)
-            pre.Create(parent=parent, id=id, title=title)
+            pre.Create(
+                parent=parent,
+                id=id,
+                title=title,
+                style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+            )
+            self.PostCreate(pre)
             self.PostCreate(pre)


### PR DESCRIPTION
solves #6827 

Summary
What it does:
Makes wizard window resizable (similar to the "Add an existing project") - drag corners or side to widen 

Window never shrinks too small - always shows full paths + buttons

Long paths show middle ellipsis (/home/.../project) + hover tooltip

"Change" button always visible

 key changes:
1. WizardWithHelpButton → Added wx.RESIZE_BORDER + wx.MAXIMIZE_BOX
2. LocationWizard → SetMinSize() after page layout  
3. DatabasePage → wx.ST_ELLIPSIZE_MIDDLE on path label + tooltip
