### PR TITLE
cmake: export package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 project(GRASS)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
+include(CMakePackageConfigHelpers)
+
 set(BUILD_SHARED_LIBS ON)
 # message(FATAL_ERROR "VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
 if(MSVC)
@@ -334,3 +336,25 @@ endif()
 if(WITH_X11)
   build_program_in_subdir(visualization/ximgview DEPENDS grass_gis X11::X11)
 endif()
+
+install(
+  EXPORT GRASSTargets
+  NAMESPACE GRASS::
+  FILE GRASSTargets.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/GRASS")
+
+configure_package_config_file(
+  "${CMAKE_SOURCE_DIR}/cmake/GRASSConfig.cmake.in"
+  "${CMAKE_BINARY_DIR}/cmake/GRASS/GRASSConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/GRASS")
+
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/cmake/GRASS/GRASSConfigVersion.cmake"
+  VERSION "${GRASS_VERSION_NUMBER}"
+  COMPATIBILITY SameMajorVersion)
+
+install(
+  FILES
+    "${CMAKE_BINARY_DIR}/cmake/GRASS/GRASSConfig.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/GRASS/GRASSConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/GRASS")

--- a/cmake/GRASSBuildConfig.cmake.in
+++ b/cmake/GRASSBuildConfig.cmake.in
@@ -1,0 +1,22 @@
+include("${CMAKE_CURRENT_LIST_DIR}/GRASSTargets.cmake")
+
+set(GRASS_VERSION "@GRASS_VERSION_NUMBER@")
+set(GRASS_INCLUDE_DIR "@OUTDIR@/@GRASS_INSTALL_INCLUDEDIR@")
+
+if(TARGET GRASS::grass_gis AND NOT TARGET GRASS::GIS)
+  add_library(GRASS::GIS INTERFACE IMPORTED)
+  set_property(TARGET GRASS::GIS PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_gis)
+endif()
+
+if(TARGET GRASS::grass_raster AND NOT TARGET GRASS::Raster)
+  add_library(GRASS::Raster INTERFACE IMPORTED)
+  set_property(TARGET GRASS::Raster PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_raster)
+endif()
+
+if(TARGET GRASS::grass_vector AND NOT TARGET GRASS::Vector)
+  add_library(GRASS::Vector INTERFACE IMPORTED)
+  set_property(TARGET GRASS::Vector PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_vector)
+endif()

--- a/cmake/GRASSConfig.cmake.in
+++ b/cmake/GRASSConfig.cmake.in
@@ -1,0 +1,24 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/GRASSTargets.cmake")
+
+set(GRASS_VERSION "@GRASS_VERSION_NUMBER@")
+set(GRASS_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@GRASS_INSTALL_INCLUDEDIR@")
+
+if(TARGET GRASS::grass_gis AND NOT TARGET GRASS::GIS)
+  add_library(GRASS::GIS INTERFACE IMPORTED)
+  set_property(TARGET GRASS::GIS PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_gis)
+endif()
+
+if(TARGET GRASS::grass_raster AND NOT TARGET GRASS::Raster)
+  add_library(GRASS::Raster INTERFACE IMPORTED)
+  set_property(TARGET GRASS::Raster PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_raster)
+endif()
+
+if(TARGET GRASS::grass_vector AND NOT TARGET GRASS::Vector)
+  add_library(GRASS::Vector INTERFACE IMPORTED)
+  set_property(TARGET GRASS::Vector PROPERTY INTERFACE_LINK_LIBRARIES
+               GRASS::grass_vector)
+endif()


### PR DESCRIPTION
Exports a cmake package config so grass can be discovered by downstream applications (like QGIS) via `find_package(GRASS CONFIG)` and creates 3 targets `GRASS::GIS`, `GRASS::Raster`, `GRASS::Vector`.

I'm still validating this locally.