### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/po/grasslibs_sv.po
+++ b/locale/po/grasslibs_sv.po
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# Daniel Nylander <daniel@danielnylander.se>, 2025.
+# Daniel Nylander <daniel@danielnylander.se>, 2025, 2026.
 # Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>, 2025.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-03 15:41+0000\n"
-"PO-Revision-Date: 2025-10-26 23:01+0000\n"
+"PO-Revision-Date: 2026-01-08 02:38+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
 "Language-Team: Swedish <https://weblate.osgeo.org/projects/grass-gis/grasslibs/sv/>\n"
 "Language: sv\n"
@@ -3991,7 +3991,7 @@ msgstr "Välkommen till GRASS %s"
 
 #: ../lib/init/grass.py:1475
 msgid "GRASS homepage:"
-msgstr "GRASS hemsida:"
+msgstr "GRASS webbsida:"
 
 #. GTC Running through: SHELL NAME
 #: ../lib/init/grass.py:1477

--- a/locale/po/grassmods_fr.po
+++ b/locale/po/grassmods_fr.po
@@ -14,7 +14,7 @@ msgstr ""
 "Project-Id-Version: grassmods_fr\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-03 15:41+0000\n"
-"PO-Revision-Date: 2026-01-03 04:37+0000\n"
+"PO-Revision-Date: 2026-01-04 20:50+0000\n"
 "Last-Translator: Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>\n"
 "Language-Team: French <https://weblate.osgeo.org/projects/grass-gis/grassmods/fr/>\n"
 "Language: fr\n"
@@ -820,10 +820,8 @@ msgid "Column names are always included"
 msgstr ""
 
 #: ../db/db.select/main.c:550
-#, fuzzy
-#| msgid "Flag 't' is deprecated and will be removed in a future release. Please use format=csv instead."
 msgid "Flag 'v' is deprecated and will be removed in a future release. Please use format=vertical instead."
-msgstr "L'option 't' est obsolète et sera retirée dans une prochaine version. Utiliser plutôt format=csv."
+msgstr "L'option 'v' est obsolète et sera retirée dans une prochaine version. Utiliser plutôt format=vertical."
 
 #: ../db/db.select/main.c:553
 msgid "Flag 'v' is only allowed with format=vertical."

--- a/locale/po/grassmods_sv.po
+++ b/locale/po/grassmods_sv.po
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# Daniel Nylander <daniel@danielnylander.se>, 2025.
+# Daniel Nylander <daniel@danielnylander.se>, 2025, 2026.
 # Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>, 2025.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-03 15:41+0000\n"
-"PO-Revision-Date: 2025-12-22 12:47+0000\n"
+"PO-Revision-Date: 2026-01-08 02:38+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
 "Language-Team: Swedish <https://weblate.osgeo.org/projects/grass-gis/grassmods/sv/>\n"
 "Language: sv\n"
@@ -776,7 +776,7 @@ msgstr "Vertikal utmatning (istället för horisontell)"
 
 #: ../db/db.select/main.c:455
 msgid "Use format=vertical instead."
-msgstr ""
+msgstr "Använd format=vertical istället."
 
 #: ../db/db.select/main.c:460
 msgid "Only test query, do not execute"


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GRASS GIS/grasslibs](https://weblate.osgeo.org/projects/grass-gis/grasslibs/).


It also includes following components:

* [GRASS GIS/grassmods](https://weblate.osgeo.org/projects/grass-gis/grassmods/)

* [GRASS GIS/grasswxpy](https://weblate.osgeo.org/projects/grass-gis/grasswxpy/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/grass-gis/grasslibs/horizontal-auto.svg)