### PR TITLE
configure: Fix file existence checks for cross-compilation

### DIFF
--- a/configure
+++ b/configure
@@ -4981,10 +4981,10 @@ GRASS_BIN="${DSTDIR}/bin.${ARCH}"
 
 GRASS_VERSION_FILE=include/VERSION
 GRASS_VERSION_GIT_FILE=include/VERSION_GIT
-GRASS_VERSION_MAJOR=`sed -n 1p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_MINOR=`sed -n 2p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_RELEASE=`sed -n 3p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_DATE=`sed -n 4p "${GRASS_VERSION_FILE}"`
+GRASS_VERSION_MAJOR=`sed -n 1p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_MINOR=`sed -n 2p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_RELEASE=`sed -n 3p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_DATE=`sed -n 4p "${SRCDIR}/${GRASS_VERSION_FILE}"`
 GRASS_VERSION_NUMBER=`echo ${GRASS_VERSION_MAJOR}.${GRASS_VERSION_MINOR}.${GRASS_VERSION_RELEASE}`
 NAME_VER=`echo ${GRASS_VERSION_NUMBER} | sed 's/\..*//'`
 
@@ -5038,25 +5038,13 @@ printf "%s\n" "no" >&6; }
 fi
 
 
-as_ac_File=`printf "%s\n" "ac_cv_file_$GRASS_VERSION_GIT_FILE" | sed "$as_sed_sh"`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $GRASS_VERSION_GIT_FILE" >&5
-printf %s "checking for $GRASS_VERSION_GIT_FILE... " >&6; }
-
-test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$GRASS_VERSION_GIT_FILE"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-eval ac_res=\$$as_ac_File
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"
+if test -f "${SRCDIR}/${GRASS_VERSION_GIT_FILE}"
 then :
-
+  ac_cv_file_include_VERSION_GIT=yes
+else case e in #(
+  e) ac_cv_file_include_VERSION_GIT=no ;;
+esac
 fi
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GRASS headers commit date" >&5
 printf %s "checking for GRASS headers commit date... " >&6; }
 if test "$GIT" != "no" ; then
@@ -5076,9 +5064,9 @@ if test "$GIT" != "no" ; then
 fi
 if test $GRASS_VERSION_GIT == "exported" && \
    test "$ac_cv_file_include_VERSION_GIT" == "yes"; then
-      GRASS_HEADERS_GIT_HASH=$(sed -n 1p "${GRASS_VERSION_GIT_FILE}")
+      GRASS_HEADERS_GIT_HASH=$(sed -n 1p "${SRCDIR}/${GRASS_VERSION_GIT_FILE}")
       GRASS_VERSION_GIT=$GRASS_HEADERS_GIT_HASH
-      GRASS_HEADERS_GIT_DATE=$(sed -n 2p "${GRASS_VERSION_GIT_FILE}")
+      GRASS_HEADERS_GIT_DATE=$(sed -n 2p "${SRCDIR}/${GRASS_VERSION_GIT_FILE}")
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $GRASS_HEADERS_GIT_DATE" >&5
 printf "%s\n" "$GRASS_HEADERS_GIT_DATE" >&6; }
@@ -5160,30 +5148,13 @@ if test -z "$with_macosx_sdk" ; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 else
-  as_ac_File=`printf "%s\n" "ac_cv_file_$with_macosx_sdk/SDKSettings.plist" | sed "$as_sed_sh"`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $with_macosx_sdk/SDKSettings.plist" >&5
-printf %s "checking for $with_macosx_sdk/SDKSettings.plist... " >&6; }
-
-test "$cross_compiling" = yes &&
-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$with_macosx_sdk/SDKSettings.plist"; then
-  eval "$as_ac_File=yes"
-else
-  eval "$as_ac_File=no"
-fi
-eval ac_res=\$$as_ac_File
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
-if eval test \"x\$"$as_ac_File"\" = x"yes"
+  if test -f "$with_macosx_sdk/SDKSettings.plist"
 then :
-
-    MACOSX_SDK="-isysroot $with_macosx_sdk"
+  MACOSX_SDK="-isysroot $with_macosx_sdk"
 else case e in #(
-  e)
-    as_fn_error $? "*** specified SDK does not exist or is not a SDK" "$LINENO" 5 ;;
+  e) as_fn_error $? "*** specified SDK does not exist or is not a SDK" "$LINENO" 5 ;;
 esac
 fi
-
   LDFLAGS="$LDFLAGS $MACOSX_SDK"
   CFLAGS="$CFLAGS $MACOSX_SDK"
   CXXFLAGS="$CXXFLAGS $MACOSX_SDK"

--- a/configure.ac
+++ b/configure.ac
@@ -149,10 +149,10 @@ AC_SUBST(GRASS_BIN)
 
 GRASS_VERSION_FILE=include/VERSION
 GRASS_VERSION_GIT_FILE=include/VERSION_GIT
-GRASS_VERSION_MAJOR=`sed -n 1p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_MINOR=`sed -n 2p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_RELEASE=`sed -n 3p "${GRASS_VERSION_FILE}"`
-GRASS_VERSION_DATE=`sed -n 4p "${GRASS_VERSION_FILE}"`
+GRASS_VERSION_MAJOR=`sed -n 1p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_MINOR=`sed -n 2p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_RELEASE=`sed -n 3p "${SRCDIR}/${GRASS_VERSION_FILE}"`
+GRASS_VERSION_DATE=`sed -n 4p "${SRCDIR}/${GRASS_VERSION_FILE}"`
 GRASS_VERSION_NUMBER=`echo ${GRASS_VERSION_MAJOR}.${GRASS_VERSION_MINOR}.${GRASS_VERSION_RELEASE}`
 NAME_VER=`echo ${GRASS_VERSION_NUMBER} | sed 's/\..*//'`
 changequote(,)
@@ -165,7 +165,9 @@ GRASS_VERSION_GIT="exported"
 GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
 GRASS_HEADERS_GIT_DATE=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
 AC_PATH_PROG(GIT, git, no)
-AC_CHECK_FILE([$GRASS_VERSION_GIT_FILE])
+AS_IF([test -f "${SRCDIR}/${GRASS_VERSION_GIT_FILE}"],
+      [ac_cv_file_include_VERSION_GIT=yes],
+      [ac_cv_file_include_VERSION_GIT=no])
 AC_MSG_CHECKING(for GRASS headers commit date)
 if test "$GIT" != "no" ; then
    GRASS_VERSION_GIT=`$GIT rev-parse --short HEAD 2>/dev/null`
@@ -184,9 +186,9 @@ if test "$GIT" != "no" ; then
 fi
 if test $GRASS_VERSION_GIT == "exported" && \
    test "$ac_cv_file_include_VERSION_GIT" == "yes"; then
-      GRASS_HEADERS_GIT_HASH=$(sed -n 1p "${GRASS_VERSION_GIT_FILE}")
+      GRASS_HEADERS_GIT_HASH=$(sed -n 1p "${SRCDIR}/${GRASS_VERSION_GIT_FILE}")
       GRASS_VERSION_GIT=$GRASS_HEADERS_GIT_HASH
-      GRASS_HEADERS_GIT_DATE=$(sed -n 2p "${GRASS_VERSION_GIT_FILE}")
+      GRASS_HEADERS_GIT_DATE=$(sed -n 2p "${SRCDIR}/${GRASS_VERSION_GIT_FILE}")
 fi
 AC_MSG_RESULT($GRASS_HEADERS_GIT_DATE)
 
@@ -254,9 +256,9 @@ MACOSX_SDK=
 if test -z "$with_macosx_sdk" ; then
   AC_MSG_RESULT(no)
 else
-  AC_CHECK_FILE($with_macosx_sdk/SDKSettings.plist, [
-    MACOSX_SDK="-isysroot $with_macosx_sdk"],[
-    AC_MSG_ERROR([*** specified SDK does not exist or is not a SDK])])
+  AS_IF([test -f "$with_macosx_sdk/SDKSettings.plist"],
+    [MACOSX_SDK="-isysroot $with_macosx_sdk"],
+    [AC_MSG_ERROR([*** specified SDK does not exist or is not a SDK])])
   LDFLAGS="$LDFLAGS $MACOSX_SDK"
   CFLAGS="$CFLAGS $MACOSX_SDK"
   CXXFLAGS="$CXXFLAGS $MACOSX_SDK"


### PR DESCRIPTION
This PR fixes file existence checks in `configure` for cross-compilation. `AC_CHECK_FILE` refuses to do file checks for cross-compilation ([source](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Files.html)):

> they test a feature of the host machine, and therefore, they die when cross-compiling.

This PR replaces `AC_CHECK_FILE` with `AS_IF([test -f...]...)` and also fixes out-of-`SRCDIR` configure.

See [this log file](https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/1434291/logs/81) from conda cross-compilation for osx-arm64:
```
2026-01-12T05:51:31.1183260Z configure: error: cannot check for file existence when cross compiling
2026-01-12T05:51:31.2186530Z checking for include/VERSION_GIT...
```