### PR TITLE
grass.utils: Fix typo in download.py response header variable names

### DIFF
--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -24,8 +24,10 @@ from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
 
-reponse_content_type_header_pattern = re.compile(r"application/(zip|octet-stream)")
-reponse_content_disposition_header_pattern = re.compile(r"attachment; filename=.*.zip$")
+response_content_type_header_pattern = re.compile(r"application/(zip|octet-stream)")
+response_content_disposition_header_pattern = re.compile(
+    r"attachment; filename=.*.zip$"
+)
 
 
 def debug(*args, **kwargs):
@@ -176,9 +178,9 @@ def download_and_extract(source, reporthook=None):
             raise DownloadError(url_error_message.format(url=source))
 
         if not re.search(
-            reponse_content_type_header_pattern, headers.get("content-type", "")
+            response_content_type_header_pattern, headers.get("content-type", "")
         ) and not re.search(
-            reponse_content_disposition_header_pattern,
+            response_content_disposition_header_pattern,
             headers.get("content-disposition", ""),
         ):
             raise DownloadError(


### PR DESCRIPTION
## Description

Fixed a typo in variable names in `python/grass/utils/download.py` where "reponse" was misspelled as "response". This improves code readability and follows proper naming conventions.

## Motivation and context

The variable names `reponse_content_type_header_pattern` and `reponse_content_disposition_header_pattern` contained a typo ("reponse" instead of "response"). This was a simple spelling error that didn't affect functionality but reduced code clarity.

## Changes made

- Fixed typo: `reponse_content_type_header_pattern` → `response_content_type_header_pattern`
- Fixed typo: `reponse_content_disposition_header_pattern` → `response_content_disposition_header_pattern`
- Updated all usages of these variables (lines 179 and 181)

## How has this been tested?

- ✅ Pre-commit hooks passed (ruff format, ruff check, flake8)
- ✅ Python syntax verified: variables import successfully
- ✅ Pattern compilation verified: both regex patterns compile correctly
- ✅ No functional changes: this is purely a naming correction

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

**Note:** No documentation or tests needed as this is a simple typo fix with no functional changes.