### PR TITLE
python: Fix format string mismatch in group_to_dict warning

### DIFF
--- a/python/grass/script/imagery.py
+++ b/python/grass/script/imagery.py
@@ -146,7 +146,7 @@ def group_to_dict(
                 _(
                     "Key {k} from raster map {m} already present in group dictionary."
                     "Overwriting existing entry..."
-                ).format(k=key, r=raster_map)
+                ).format(k=key, m=raster_map)
             )
         group_dict[key] = val
     return group_dict


### PR DESCRIPTION
## Description
Fixed a string formatting bug in `group_to_dict()` function in `python/grass/script/imagery.py`. The warning message when duplicate keys are detected had a format string mismatch that would cause a `KeyError` instead of displaying the warning.

## Motivation and context
When `group_to_dict()` detects a duplicate key in the group dictionary, it attempts to display a warning message. However, the format string used placeholder `{m}` while the `.format()` call provided `r=raster_map`, causing a `KeyError: 'm'` exception instead of showing the warning.

This bug would only manifest when:
1. A duplicate key is detected in the group dictionary (rare scenario)
2. The warning path is executed

The fix changes `r=raster_map` to `m=raster_map` to match the format string placeholder.

## How has this been tested?
- ✅ Syntax validation: `python3 -m py_compile` passed
- ✅ Linter checks: All pre-commit hooks passed (ruff check, ruff format, flake8)
- ✅ Manual verification: Created reproduction script that confirmed the bug and verified the fix resolves the KeyError
- ✅ Code review: Verified all format strings in the file are now consistent

**Note:** The existing test suite in `python/grass/script/testsuite/test_imagery.py` does not cover the duplicate key warning path, as this is an edge case. The fix is minimal and correct, and all existing tests should continue to pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Checklist
- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
  - *Note: The duplicate key scenario is an edge case that would require complex test setup. The fix is straightforward and has been manually verified.*