### PR TITLE
ci: Use build-mode none for CodeQL C/C++ scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,28 +62,18 @@ jobs:
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+        id: init
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
+          # Use build-mode: none for C/C++ to scan all source files without requiring a build
+          # This improves coverage from ~3.01k to all ~3.35k C files in the repository
+          # Generated code (flex/bison) in build directories won't be scanned, which is acceptable
+          # Python and Actions languages ignore build-mode parameter
+          build-mode: ${{ matrix.language == 'c-cpp' && 'none' || '' }}
 
-      - name: Create installation directory
-        run: |
-          mkdir "${HOME}/install"
-
-      - name: Set LD_LIBRARY_PATH for compilation
-        run: |
-          echo "LD_LIBRARY_PATH=${HOME}/install/lib" >> "${GITHUB_ENV}"
-
-      - name: Set number of cores for compilation
-        run: |
-          echo "MAKEFLAGS=-j$(nproc)" >> "${GITHUB_ENV}"
-
-      - name: Build
-        if: ${{ matrix.language == 'c-cpp' }}
-        env:
-          CFLAGS: -std=gnu17
-          CXXFLAGS: -std=c++17
-        run: .github/workflows/build_ubuntu-24.04.sh "${HOME}/install"
+      # Build step removed for C/C++ when using build-mode: none
+      # Dependencies are still installed above to ensure headers are available for analysis
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9


### PR DESCRIPTION
## Motivation

CodeQL C/C++ scanning can now be performed without builds (GA as of Oct 2025). The current setup uses a build step, runs only on Linux, and analyzes ~3.01k out of ~3.35k C files (~340 files missing). This change improves coverage by scanning all source files without requiring a build.

See: https://github.com/OSGeo/grass/issues/6529

## What Changed

- **Added `build-mode: none`** for C/C++ language in CodeQL init step
- **Removed build step** and related setup (installation directory, LD_LIBRARY_PATH, MAKEFLAGS, build script execution)
- **Kept dependency installation** to ensure system headers are available for analysis
- **Python and Actions scanning** remain unchanged

## Why This Approach

1. **Better Coverage**: Scans all ~3.35k C source files instead of only compiled files
2. **Faster CI**: Removes time-consuming build step for CodeQL analysis
3. **Simpler**: Reduces workflow complexity
4. **Safe**: Headers are still available via dependency installation

## Trade-offs

- **Generated code won't be scanned**: Flex/bison generated files (4 files in `lib/db/sqlp` and `raster/r.mapcalc`) are in build directories, not source. This is acceptable as they're generated code.
- **Slightly less accurate for complex macros**: Acceptable given that headers are available and custom macros are in header files.

## Validation

- ✅ YAML syntax validated
- ✅ Workflow structure verified
- ✅ No breaking changes to Python/Actions scanning
- ✅ All pre-commit hooks passed

## How to Verify

After merge, check the CodeQL status page:
- Should show ~3.35k C files analyzed (up from ~3.01k)
- CodeQL job should complete faster (no build step)
- Existing alerts should remain; new files may introduce new alerts

## References

- GitHub announcement: https://github.blog/changelog/2025-10-14-codeql-scanning-rust-and-c-c-without-builds-is-now-generally-available/
- GitHub docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#about-build-mode-none-for-codeql

Addresses #6529