### PR TITLE
cmake: fix some various minor issues

### DIFF
--- a/gui/icons/CMakeLists.txt
+++ b/gui/icons/CMakeLists.txt
@@ -75,12 +75,12 @@ foreach(
   192)
   set(icon_size "${icon_type}x${icon_type}")
   install(
-    FILES grass-${icon_size}.png
-    DESTINATION ${GRASS_INSTALL_SHAREDIR}/icons/hicolor/${icon_size}/apps
-    RENAME grass.svg)
+    FILES grass-${icon_size}.png RENAME grass.png
+    DESTINATION ${GRASS_INSTALL_SHAREDIR}/icons/hicolor/${icon_size}/apps)
 endforeach()
 
 install(FILES grass.svg
         DESTINATION ${GRASS_INSTALL_SHAREDIR}/icons/hicolor/scalable/apps)
 
-install(FILES grass.appdata.xml DESTINATION ${GRASS_INSTALL_SHAREDIR}/metainfo)
+install(FILES grass.appdata.xml RENAME org.osgeo.grass.appdata.xml
+        DESTINATION ${GRASS_INSTALL_SHAREDIR}/metainfo)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,7 +19,7 @@ build_library_in_subdir(
 
 add_subdirectory(proj)
 
-build_library_in_subdir(external/parson NAME grass_parson HEADERS "gjson.h" "parson.h")
+build_library_in_subdir(external/parson NAME grass_parson HEADERS "gjson.h")
 build_program_in_subdir(external/parson/test NAME test.gjson.lib DEPENDS grass_gis grass_parson)
 
 build_library_in_subdir(

--- a/lib/proj/CMakeLists.txt
+++ b/lib/proj/CMakeLists.txt
@@ -1,6 +1,5 @@
-file(COPY desc.table DESTINATION etc/proj)
-file(COPY parms.table DESTINATION etc/proj)
-file(COPY units.table DESTINATION etc/proj)
+install(FILES desc.table parms.table units.table
+        DESTINATION ${GRASS_INSTALL_ETCDIR}/proj)
 
 set(grass_gproj_SOURCES convert.c datum.c do_proj.c ellipse.c get_proj.c)
 if(MINGW)

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -3,7 +3,103 @@
   TODO: implement update and creation
 #]===========================================================================]
 
-file(GLOB po_files "${CMAKE_CURRENT_SOURCE_DIR}/po/*.po")
+set(po_file_names
+  grasslibs_ar.po
+  grasslibs_bn.po
+  grasslibs_cs.po
+  grasslibs_de.po
+  grasslibs_el.po
+  grasslibs_es.po
+  grasslibs_fi.po
+  grasslibs_fr.po
+  grasslibs_hu.po
+  grasslibs_id_ID.po
+  grasslibs_it.po
+  grasslibs_ja.po
+  grasslibs_ko.po
+  grasslibs_lv.po
+  grasslibs_ml.po
+  grasslibs_pl.po
+  grasslibs_pt_BR.po
+  grasslibs_pt.po
+  grasslibs_ro.po
+  grasslibs_ru.po
+  grasslibs_si.po
+  grasslibs_sl.po
+  grasslibs_sv.po
+  grasslibs_ta.po
+  grasslibs_th.po
+  grasslibs_tr.po
+  grasslibs_uk.po
+  grasslibs_vi.po
+  grasslibs_zh_CN.po
+  grasslibs_zh.po
+  grassmods_ar.po
+  grassmods_bn.po
+  grassmods_cs.po
+  grassmods_de.po
+  grassmods_el.po
+  grassmods_es.po
+  grassmods_fi.po
+  grassmods_fr.po
+  grassmods_hu.po
+  grassmods_id_ID.po
+  grassmods_it.po
+  grassmods_ja.po
+  grassmods_ko.po
+  grassmods_lv.po
+  grassmods_ml.po
+  grassmods_pl.po
+  grassmods_pt_BR.po
+  grassmods_pt.po
+  grassmods_ro.po
+  grassmods_ru.po
+  grassmods_si.po
+  grassmods_sl.po
+  grassmods_sv.po
+  grassmods_ta.po
+  grassmods_th.po
+  grassmods_tr.po
+  grassmods_uk.po
+  grassmods_vi.po
+  grassmods_zh_CN.po
+  grassmods_zh.po
+  grasswxpy_ar.po
+  grasswxpy_bn.po
+  grasswxpy_cs.po
+  grasswxpy_de.po
+  grasswxpy_el.po
+  grasswxpy_es.po
+  grasswxpy_fi.po
+  grasswxpy_fr.po
+  grasswxpy_hu.po
+  grasswxpy_id_ID.po
+  grasswxpy_it.po
+  grasswxpy_ja.po
+  grasswxpy_ko.po
+  grasswxpy_lv.po
+  grasswxpy_ml.po
+  grasswxpy_pl.po
+  grasswxpy_pt_BR.po
+  grasswxpy_pt.po
+  grasswxpy_ro.po
+  grasswxpy_ru.po
+  grasswxpy_si.po
+  grasswxpy_sl.po
+  grasswxpy_sv.po
+  grasswxpy_ta.po
+  grasswxpy_th.po
+  grasswxpy_tr.po
+  grasswxpy_uk.po
+  grasswxpy_vi.po
+  grasswxpy_zh_CN.po
+  grasswxpy_zh.po
+)
+
+set(po_files ${po_file_names})
+list(TRANSFORM po_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/po/")
+set(generate_mo_file_targets ${po_file_names})
+list(TRANSFORM generate_mo_file_targets PREPEND "generate_mo_files_")
 
 add_custom_target(generate_mo_files_dir ALL COMMENT "Create locale directory")
 set_target_properties(generate_mo_files_dir PROPERTIES FOLDER locale)
@@ -62,5 +158,19 @@ foreach(po_file ${po_files})
     BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file})
 endforeach()
 
+add_custom_target(translation_statistics ALL
+  DEPENDS ${generate_mo_file_targets}
+  COMMENT "Create translation statistics")
+add_custom_command(
+  TARGET translation_statistics
+  PRE_BUILD
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/grass_po_stats.py
+  BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_MISCDIR}/translation_status.json)
+
 install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/
         DESTINATION ${GRASS_INSTALL_LOCALEDIR})
+
+install(FILES ${OUTDIR}/${GRASS_INSTALL_MISCDIR}/translation_status.json
+        DESTINATION ${GRASS_INSTALL_MISCDIR})

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -66,9 +66,6 @@ add_custom_target(
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
   COMMAND
     ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/mkmarkdown.py
-    ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
-  COMMAND
-    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/mkrest.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR})
 
 install(
@@ -80,5 +77,4 @@ install(
         ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkhtml.py
         ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkdocs.py
         ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkmarkdown.py
-        ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkrest.py
   DESTINATION ${GRASS_INSTALL_UTILSDIR})


### PR DESCRIPTION
Fix some various minor CMake issues:

- install icon files with correct file extension (png)
- install grass.appdata.xml with correct name
- do not install the "parson.h" file
- fix installation of desc.table parms.table units.table
- generate and install translation_status.json
- do not install mkrest.py