### PR TITLE
r.shade: Prevent GUI console to overwrite color table of output

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -198,10 +198,11 @@ class CmdThread(threading.Thread):
                     group="rasterLayer", key="colorTable", subkey="selection"
                 )
                 mapName = None
-                if args[0][0] == "r.mapcalc":
+                modules_to_excempt = {"r.mapcalc", "r.shade"}
+                if args[0][0] in modules_to_excempt:
                     try:
                         mapName = args[0][1].split("=", 1)[0].strip()
-                    except KeyError:
+                    except (IndexError, AttributeError):
                         pass
                 else:
                     moduleInterface = GUI(show=None).ParseCommand(args[0])

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -198,8 +198,8 @@ class CmdThread(threading.Thread):
                     group="rasterLayer", key="colorTable", subkey="selection"
                 )
                 mapName = None
-                modules_to_excempt = {"r.mapcalc", "r.shade"}
-                if args[0][0] in modules_to_excempt:
+                modules_to_exempt = {"r.mapcalc", "r.shade"}
+                if args[0][0] in modules_to_exempt:
                     try:
                         mapName = args[0][1].split("=", 1)[0].strip()
                     except (IndexError, AttributeError):

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -198,8 +198,7 @@ class CmdThread(threading.Thread):
                     group="rasterLayer", key="colorTable", subkey="selection"
                 )
                 mapName = None
-                modules_to_exempt = {"r.mapcalc", "r.shade"}
-                if args[0][0] in modules_to_exempt:
+                if args[0][0] == "r.mapcalc":
                     try:
                         mapName = args[0][1].split("=", 1)[0].strip()
                     except (IndexError, AttributeError):


### PR DESCRIPTION
Added exception handling for specific modules in gconsole.py to avoid that the GUI console  automatically applies a color table to the output, thereby overwriting the intended RGB colors.

An attempt to solve the issue reported in #6826. I applied the patch, and for me, it seems to work.