### PR TITLE
wxGUI: fix display of non-imported raster bands

### DIFF
--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -90,6 +90,12 @@
 # % description: Title for resultant raster map
 # % guisection: Metadata
 # %end
+# %option G_OPT_F_OUTPUT
+# % key: map_names_file
+# % required: no
+# % description: Name of the output file that contains the imported map names
+# % guisection: Metadata
+# %end
 # %flag
 # % key: e
 # % description: Estimate resolution only
@@ -202,6 +208,8 @@ def main():
         }
         if bands:
             parameters["band"] = bands
+        if options["map_names_file"]:
+            parameters["map_names_file"] = options["map_names_file"]
         try:
             gs.run_command("r.in.gdal", **parameters)
             gs.verbose(
@@ -249,6 +257,8 @@ def main():
     }
     if bands:
         parameters["band"] = bands
+    if options["map_names_file"]:
+        parameters["map_names_file"] = options["map_names_file"]
     try:
         gs.run_command("r.in.gdal", env=env, **parameters)
     except CalledModuleError:
@@ -284,6 +294,8 @@ def main():
     }
     if bands:
         parameters["band"] = bands
+    if options["map_names_file"]:
+        parameters["map_names_file"] = options["map_names_file"]
     if "r" in region_flag:
         gs.run_command(
             "v.proj",


### PR DESCRIPTION
fixes: #6267

Fix GUI attempting to display non-imported raster bands after r.import when only selected bands are imported.
When `r.import` imports only selected bands from a multiband raster, the GUI incorrectly tries to visualize all bands (1 to nBands) based on the source file's total band count, not the number actually imported. This causes repeated `d.rast` errors for non-existent maps.

Add a defensive check in `AddLayers()` to verify each map exists before adding it to the layer tree. This prevents errors while maintaining backward compatibility when all bands are imported.

Code change:
Check if map exists before adding (fixes issue when only selected bands are imported)
mapInfo = grass.find_file(name, element="cell")
if not mapInfo["name"]:
    name = nameOrig
    continue
