### PR TITLE
v.profile: Fix compilation error when GEOS is not installed

### DIFF
--- a/vector/v.profile/main.c
+++ b/vector/v.profile/main.c
@@ -37,6 +37,8 @@
 #include <grass/gjson.h>
 #include "local_proto.h"
 
+enum OutputFormat { PLAIN, CSV, JSON };
+
 #if HAVE_GEOS
 #include <float.h>
 
@@ -47,7 +49,6 @@
  * or so as there's nothing more permanent than a temporary solution.)
  * 2017-11-19
  */
-enum OutputFormat { PLAIN, CSV, JSON };
 
 static int ring2pts(const GEOSGeometry *geom, struct line_pnts *Points)
 {


### PR DESCRIPTION
This PR addresses the issue mentioned at the end of #6875 

## Problem

When building GRASS without GEOS support, v.profile fails to compile with the following error:

```shell
main.c: In function 'main':
main.c:152:23: error: storage size of 'format' isn't known
  152 |     enum OutputFormat format;
      |                       ^~~~~~
main.c:292:18: error: 'JSON' undeclared (first use in this function)
  292 |         format = JSON;
      |                  ^~~~
```
This occurs because the enum OutputFormat declaration was incorrectly placed inside the #if HAVE_GEOS preprocessor block (around line 40-50), making it unavailable when GEOS is not installed.

**Solution:**
Moving the enum OutputFormat { PLAIN, CSV, JSON }; declaration to global scope (after includes, before the #if HAVE_GEOS block).

**Result**
- Before this fix: Compilation fails with "storage size of 'format' isn't known"

- After this fix: Compilation succeeds, and the module provides a clear runtime error message:

```text
ERROR: GRASS native buffering functions are known to return incorrect results.
       Till those errors are fixed, this module requires GRASS to be compiled 
       with GEOS support.
```
This allows developers to build the module even without GEOS, while maintaining the intentional runtime check that prevents incorrect results.