### PR TITLE
wxGUI: Fix boolean default for UTM UTM hemisphere selection in Location Wizard

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -965,7 +965,10 @@ class ProjParamsPage(TitledPage):
 
                 # default values
                 if param["type"] == "bool":
-                    param["value"] = 0
+                    if len(paramgrp) > 2:
+                        param["value"] = paramgrp[2]
+                    else:
+                        param["value"] = 0
                 elif param["type"] == "zone":
                     param["value"] = 30
                     param["desc"] += " (1-60)"


### PR DESCRIPTION
the location wizard currently initializes all boolean projection parameters to 0 by default. This causes the wizard to ignore the actual default values defined in the projection metadata tables, forcing projects into the Southern Hemisphere even when the user selects "no." I updated the parameter initialization logic to check for a default_value in the projection metadata group. If a default is defined, the wizard now uses it; otherwise, it falls back to 0.

**# Updated logic in gui/wxpython/location_wizard/wizard.py**
param["value"] = paramgrp[2] if len(paramgrp) > 2 else 0
fixes #5467