### PR TITLE
cmake: use proper OpenMP target

### DIFF
--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -196,7 +196,7 @@ if(WITH_OPENMP)
   if(OpenMP_FOUND AND MSVC AND CMAKE_VERSION VERSION_LESS "3.30")
     # CMake < 3.30 doesn't support OpenMP_RUNTIME_MSVC
     # for min/max reduction
-    add_compile_options(-openmp:llvm)
+    target_compile_options(OpenMP::OpenMP_C PRIVATE -openmp:llvm)
   endif()
 endif()
 

--- a/cmake/modules/build_module.cmake
+++ b/cmake/modules/build_module.cmake
@@ -210,8 +210,6 @@ function(build_module)
         target_compile_definitions(${G_NAME} PRIVATE "${interface_def}")
       endif()
       target_link_libraries(${G_NAME} PRIVATE ${dep})
-    elseif(OpenMP_C_FOUND)
-      target_link_libraries(${G_NAME} PRIVATE OpenMP::OpenMP_C)
     endif()
   endforeach()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,7 +32,7 @@ build_library_in_subdir(
   grass_gproj
   grass_parson
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 if(TARGET LAPACKE)
   target_link_libraries(grass_raster PRIVATE LAPACKE)
@@ -62,7 +62,7 @@ build_library_in_subdir(
   CBLAS::CBLAS
   FFTW
   LAPACKE::LAPACKE
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_library_in_subdir(linkm)
 
@@ -201,7 +201,7 @@ build_library_in_subdir(
   grass_gmath
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_library_in_subdir(dspf DEPENDS grass_gis)
 

--- a/lib/gis/CMakeLists.txt
+++ b/lib/gis/CMakeLists.txt
@@ -27,7 +27,7 @@ build_module(
   Intl::Intl
   PostgreSQL::PostgreSQL
   Threads::Threads
-  OPENMP
+  OpenMP::OpenMP_C
   ZSTD
   DEFS
   "${grass_gis_DEFS}")

--- a/lib/rst/CMakeLists.txt
+++ b/lib/rst/CMakeLists.txt
@@ -33,7 +33,7 @@ build_library_in_subdir(
   grass_interpdata
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP
+  OpenMP::OpenMP_C
   HEADERS
   "interpf.h")
 

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -337,7 +337,7 @@ build_program_in_subdir(
   grass_raster
   grass_rowio
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.mode DEPENDS grass_gis grass_raster)
 
@@ -349,7 +349,7 @@ build_program_in_subdir(
   grass_stats
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.null DEPENDS grass_gis grass_raster)
 
@@ -411,7 +411,7 @@ build_program_in_subdir(
   ${LIBM})
 
 build_program_in_subdir(r.patch DEPENDS grass_gis grass_raster OPTIONAL_DEPENDS
-                        OPENMP)
+                        OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.path DEPENDS grass_gis grass_raster grass_vector
                         ${LIBM})
@@ -428,7 +428,7 @@ build_program_in_subdir(
   grass_parson
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.quant DEPENDS grass_gis grass_raster)
 
@@ -481,7 +481,7 @@ build_program_in_subdir(
   grass_raster
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   r.resamp.interp
@@ -490,7 +490,7 @@ build_program_in_subdir(
   grass_raster
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   r.resamp.rst
@@ -520,7 +520,7 @@ build_program_in_subdir(
   grass_raster
   grass_stats
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   r.series.accumulate
@@ -529,7 +529,7 @@ build_program_in_subdir(
   grass_raster
   grass_stats
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.series.interp DEPENDS grass_gis grass_raster
                         grass_stats)
@@ -545,7 +545,7 @@ build_program_in_subdir(
   grass_raster
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   r.smooth.edgepreserve
@@ -555,7 +555,7 @@ build_program_in_subdir(
   grass_rowio
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   r.solute.transport
@@ -600,7 +600,7 @@ build_program_in_subdir(
   grass_gproj
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(r.sunhours DEPENDS grass_gis grass_raster grass_gproj
                         ${LIBM})

--- a/raster/r.mapcalc/CMakeLists.txt
+++ b/raster/r.mapcalc/CMakeLists.txt
@@ -31,7 +31,7 @@ build_program(
   Readline::Readline
   Readline::History
   Threads::Threads
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program(
   NAME

--- a/raster/r.sim/CMakeLists.txt
+++ b/raster/r.sim/CMakeLists.txt
@@ -10,7 +10,7 @@ build_library_in_subdir(
   grass_gmath
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP
+  OpenMP::OpenMP_C
   HEADERS
   "simlib.h")
 
@@ -23,7 +23,7 @@ build_program_in_subdir(
   grass_sim
   grass_vector
   OPTIONAL_DEPENDS
-  OPENMP
+  OpenMP::OpenMP_C
   INCLUDES
   "${CMAKE_CURRENT_SOURCE_DIR}/../simlib")
 
@@ -36,6 +36,6 @@ build_program_in_subdir(
   grass_sim
   grass_vector
   OPTIONAL_DEPENDS
-  OPENMP
+  OpenMP::OpenMP_C
   INCLUDES
   "${CMAKE_CURRENT_SOURCE_DIR}/../simlib")

--- a/raster/r.univar/CMakeLists.txt
+++ b/raster/r.univar/CMakeLists.txt
@@ -12,7 +12,7 @@ build_program(
   grass_parson
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program(
   NAME
@@ -26,4 +26,4 @@ build_program(
   grass_parson
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -712,7 +712,7 @@ build_program_in_subdir(
   grass_raster
   ${LIBM}
   OPTIONAL_DEPENDS
-  OPENMP)
+  OpenMP::OpenMP_C)
 
 build_program_in_subdir(
   v.transform


### PR DESCRIPTION
Make use of the real target `OpenMP::OpenMP_C`, instead of a stand-in `OPENMP`.

Removes this hack:
https://github.com/OSGeo/grass/blob/7fbcfc9201ad79fbc939700d3be81b78e384be60/cmake/modules/build_module.cmake#L213-L215