### PR TITLE
v.profile: Fixes incorrect quoting in JSON output

### DIFF
--- a/vector/v.profile/main.c
+++ b/vector/v.profile/main.c
@@ -766,20 +766,15 @@ int main(int argc, char *argv[])
                                 column = db_get_table_column(table, col);
                                 db_convert_column_value_to_string(column,
                                                                   &valstr);
-                                type = db_get_column_sqltype(column);
+                                int ctype = db_sqltype_to_Ctype(
+                                    db_get_column_sqltype(column));
 
-                                /* Those values should be quoted */
-                                if (type == DB_SQL_TYPE_CHARACTER ||
-                                    type == DB_SQL_TYPE_DATE ||
-                                    type == DB_SQL_TYPE_TIME ||
-                                    type == DB_SQL_TYPE_TIMESTAMP ||
-                                    type == DB_SQL_TYPE_INTERVAL ||
-                                    type == DB_SQL_TYPE_TEXT ||
-                                    type == DB_SQL_TYPE_SERIAL)
-                                    fprintf(ascii, "%s\"%s\"", fs,
+                                if (ctype == DB_C_TYPE_INT ||
+                                    ctype == DB_C_TYPE_DOUBLE)
+                                    fprintf(ascii, "%s%s", fs,
                                             db_get_string(&valstr));
                                 else
-                                    fprintf(ascii, "%s%s", fs,
+                                    fprintf(ascii, "%s\"%s\"", fs,
                                             db_get_string(&valstr));
                             }
                         }
@@ -845,7 +840,8 @@ int main(int argc, char *argv[])
                             for (col = 0; col < ncols; col++) {
                                 column = db_get_table_column(table, col);
                                 dbValue *value = db_get_column_value(column);
-                                int ctype = db_get_column_sqltype(column);
+                                int ctype = db_sqltype_to_Ctype(
+                                    db_get_column_sqltype(column));
                                 const char *col_name =
                                     db_get_column_name(column);
 
@@ -853,12 +849,12 @@ int main(int argc, char *argv[])
                                     G_json_object_set_null(attr_object,
                                                            col_name);
                                 }
-                                else if (ctype == DB_SQL_TYPE_INTEGER) {
+                                else if (ctype == DB_C_TYPE_INT) {
                                     G_json_object_set_number(
                                         attr_object, col_name,
                                         db_get_value_int(value));
                                 }
-                                else if (ctype == DB_SQL_TYPE_REAL) {
+                                else if (ctype == DB_C_TYPE_DOUBLE) {
                                     G_json_object_set_number(
                                         attr_object, col_name,
                                         db_get_value_double(value));

--- a/vector/v.profile/v.profile.md
+++ b/vector/v.profile/v.profile.md
@@ -109,7 +109,7 @@ The output looks as follows:
             "PUMPERS": 0,
             "PUMPER_TAN": 1,
             "TANKER": 0,
-            "MINI_PUMPE": "0",
+            "MINI_PUMPE": 0,
             "RESCUE_SER": 0,
             "AERIAL": 1,
             "BRUSH": 0,
@@ -119,9 +119,9 @@ The output looks as follows:
             "BLDGCODE": "298",
             "AGENCY": "FD",
             "STATIONID": "MF2A",
-            "RECNO": "62",
+            "RECNO": 62,
             "CV_SID2": "MF2A",
-            "CVLAG": "1.4"
+            "CVLAG": 1.3999999999999999
         }
     },
     {
@@ -137,7 +137,7 @@ The output looks as follows:
             "PUMPERS": 0,
             "PUMPER_TAN": 1,
             "TANKER": 0,
-            "MINI_PUMPE": "0",
+            "MINI_PUMPE": 0,
             "RESCUE_SER": 1,
             "AERIAL": 0,
             "BRUSH": 1,
@@ -147,9 +147,9 @@ The output looks as follows:
             "BLDGCODE": "241",
             "AGENCY": "FD",
             "STATIONID": "MF1A",
-            "RECNO": "2",
+            "RECNO": 2,
             "CV_SID2": "MF1A",
-            "CVLAG": "1.4"
+            "CVLAG": 1.3999999999999999
         }
     }
 ]


### PR DESCRIPTION
Some numeric values in JSON output of v.profile were being quoted. This is most likely because the data type was DOUBLE PRECISION and therefore did not fall under the existing Integer or Real checks. This PR fixes that issue.
This new code uses `DB_C_TYPE_INT` and `DB_C_TYPE_DOUBLE` checks instead of `DB_SQL_TYPE_INTEGER` etc.

**Note for Maintainers:** Kindly check why `type == DB_SQL_TYPE_SERIAL` was previously included in the CSV quoting check. I’m not fully sure of the original reason, but I believe SERIAL values are generally expected to be unquoted. If it was intentional then we can use old style check like this 
```c
                                if (type == DB_SQL_TYPE_CHARACTER ||
                                    type == DB_SQL_TYPE_DATE ||
                                    type == DB_SQL_TYPE_TIME ||
                                    type == DB_SQL_TYPE_TIMESTAMP ||
                                    type == DB_SQL_TYPE_INTERVAL ||
                                    type == DB_SQL_TYPE_TEXT ||
                                    type == DB_SQL_TYPE_SERIAL)
                              /* Those values should be quoted */
                                else 
                              /* Don't quote*/
```
Otherwise, this code is ready to be merged :)