### PR TITLE
grass.jupyter: rewrite `get_region` and `get_location_proj_string` funtions in utils.py

### DIFF
--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -24,7 +24,7 @@ from grass.tools import Tools
 
 
 def get_region(env=None):
-    """Returns current computational region as dictionary. """
+    """Returns current computational region as dictionary."""
     tools = Tools(env=env)
     return tools.g_region(flags="p", format="json").json
 


### PR DESCRIPTION
In this PR, as suggested by @petrasovaa , I rewrote the `get_region` and `get_location_proj_string` functions in the `utils.py `file to use the new grass.tools API instead of grass.script.