### PR TITLE
cmake: enable experimental FHS build, skip failing parts

### DIFF
--- a/general/CMakeLists.txt
+++ b/general/CMakeLists.txt
@@ -11,13 +11,15 @@ build_program_in_subdir(g.message DEPENDS grass_gis)
 build_program_in_subdir(g.mkfontcap DEPENDS grass_gis PRIMARY_DEPENDS
                         Freetype::Freetype)
 add_dependencies(g.mkfontcap fonts)
+
+# TODO(FHS): revert GRASS_INSTALL_ETCBINDIR to GRASS_INSTALL_ETCDIR
 add_custom_command(
   TARGET g.mkfontcap
   POST_BUILD
   COMMAND ${grass_env_command} ${OUTDIR}/${GRASS_INSTALL_BINDIR}/g.mkfontcap -s
-          > ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/fontcap)
-install(FILES ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/fontcap
-        DESTINATION ${GRASS_INSTALL_ETCDIR})
+          > ${OUTDIR}/${GRASS_INSTALL_ETCBINDIR}/fontcap)
+install(FILES ${OUTDIR}/${GRASS_INSTALL_ETCBINDIR}/fontcap
+        DESTINATION ${GRASS_INSTALL_ETCBINDIR})
 build_program_in_subdir(g.parser DEPENDS grass_gis)
 build_program_in_subdir(g.pnmcomp DEPENDS grass_gis)
 build_program_in_subdir(g.ppmtopng DEPENDS grass_gis PRIMARY_DEPENDS PNG::PNG)

--- a/gui/wxpython/CMakeLists.txt
+++ b/gui/wxpython/CMakeLists.txt
@@ -89,6 +89,9 @@ add_custom_target(build_modules_items_xml
 add_dependencies(build_modules_items_xml copy_wxpython_xml grass_interface_dtd
                  compile_python_files ${g_gui_targets})
 
+# TODO(FHS): remove this if condition
+if(NOT WITH_FHS)
+
 add_custom_target(
   build_xml_menudata
   COMMAND
@@ -135,5 +138,7 @@ add_custom_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/core/menutree.py "psmap" >>
     ${CMAKE_CURRENT_SOURCE_DIR}/menustrings.py
   DEPENDS build_module_tree_menudata gui_images)
+
+endif() # NOT WITH_FHS
 
 install(DIRECTORY "${OUTDIR}/${WXPYTHON_DIR}/xml" DESTINATION "${WXPYTHON_DIR}")

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -172,5 +172,10 @@ add_custom_command(
 install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/
         DESTINATION ${GRASS_INSTALL_LOCALEDIR})
 
+# TODO(FHS): remove this if condition
+if(NOT WITH_FHS)
+
 install(FILES ${OUTDIR}/${GRASS_INSTALL_MISCDIR}/translation_status.json
         DESTINATION ${GRASS_INSTALL_MISCDIR})
+
+endif() # NOT WITH_FHS

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,16 +1,3 @@
-string(TIMESTAMP YEAR %Y)
-
-add_custom_target(
-  build_full_index
-  COMMAND
-    ${grass_env_command} ${PYTHON_EXECUTABLE}
-    ${CMAKE_CURRENT_SOURCE_DIR}/build_full_index.py
-    ${YEAR}
-  BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/full_index.html
-  DEPENDS ALL_MODULES LIB_PYTHON GUI_WXPYTHON
-  COMMENT "man generation: build full index")
-set_target_properties(build_full_index PROPERTIES FOLDER man)
-
 set(data_files
     ${CMAKE_CURRENT_SOURCE_DIR}/jquery.fixedheadertable.min.js
     ${CMAKE_CURRENT_SOURCE_DIR}/grassdocs.css
@@ -21,6 +8,21 @@ set(data_files
     ${CMAKE_CURRENT_SOURCE_DIR}/parser_standard_options.css
     ${CMAKE_CURRENT_SOURCE_DIR}/parser_standard_options.js)
 install(FILES ${data_files} DESTINATION ${GRASS_INSTALL_DOCDIR})
+
+# TODO(FHS): remove this if condition
+if(NOT WITH_FHS)
+
+string(TIMESTAMP YEAR %Y)
+add_custom_target(
+  build_full_index
+  COMMAND
+    ${grass_env_command} ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_full_index.py
+    ${YEAR}
+  BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/full_index.html
+  DEPENDS ALL_MODULES LIB_PYTHON GUI_WXPYTHON
+  COMMENT "man generation: build full index")
+set_target_properties(build_full_index PROPERTIES FOLDER man)
 
 add_custom_command(
   TARGET build_full_index
@@ -112,3 +114,5 @@ add_custom_target(
   DEPENDS ${category_targets} build_class_graphical ALL_MODULES LIB_PYTHON GUI_WXPYTHON
   COMMENT "man generation: check output")
 set_target_properties(build_check PROPERTIES FOLDER man)
+
+endif() # NOT WITH_FHS


### PR DESCRIPTION
Recent additions to the CMake legacy build, have rendered the FHS build broken. These additions include foremost GUI menu generation and documentation indexing. Proper fix for this would require changes in code, addressed with #5630.

For the time being, with this PR, those failing parts will be skipped if building with FHS compliance.

This does _not_ affect legacy build with CMake.