### PR TITLE
v.db.select: rewrite JSON output using parson library

### DIFF
--- a/lib/external/parson/gjson.c
+++ b/lib/external/parson/gjson.c
@@ -205,14 +205,14 @@ void G_json_set_float_serialization_format(const char *format)
     json_set_float_serialization_format(format);
 }
 
-char *G_json_serialize_to_string(const G_JSON_Value *value)
-{
-    return json_serialize_to_string((const JSON_Value *)value);
-}
-
 char *G_json_serialize_to_string_pretty(const G_JSON_Value *value)
 {
     return json_serialize_to_string_pretty((const JSON_Value *)value);
+}
+
+char *G_json_serialize_to_string(const G_JSON_Value *value)
+{
+    return json_serialize_to_string((const JSON_Value *)value);
 }
 
 void G_json_free_serialized_string(char *string)

--- a/lib/external/parson/gjson.h
+++ b/lib/external/parson/gjson.h
@@ -73,8 +73,8 @@ extern G_JSON_Status G_json_array_append_boolean(G_JSON_Array *, int);
 extern G_JSON_Status G_json_array_append_null(G_JSON_Array *);
 
 extern void G_json_set_float_serialization_format(const char *format);
-extern char *G_json_serialize_to_string(const G_JSON_Value *);
 extern char *G_json_serialize_to_string_pretty(const G_JSON_Value *);
+extern char *G_json_serialize_to_string(const G_JSON_Value *);
 extern void G_json_free_serialized_string(char *);
 extern void G_json_value_free(G_JSON_Value *);
 

--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -605,7 +605,7 @@ int main(int argc, char **argv)
     }
 
     if (format == JSON) {
-        char *json_string = G_json_serialize_to_string(root_json_value);
+        char *json_string = G_json_serialize_to_string_pretty(root_json_value);
         if (json_string == NULL)
             G_fatal_error(_("Failed to serialize JSON. Out of memory?"));
         fputs(json_string, stdout);


### PR DESCRIPTION
Replaces the manual fprintf-based JSON construction in v.db.select with the
gjson (parson) API already used elsewhere in GRASS.

The JSON output is unchanged: same structure, same keys, same value types.
NULL values are emitted as JSON null, numbers remain unquoted.

This is a mechanical refactor to improve maintainability and consistency with
other modules.
