### PR TITLE
lib: Add wrapper for JSON output handling

### DIFF
--- a/lib/external/parson/gjson.c
+++ b/lib/external/parson/gjson.c
@@ -210,6 +210,11 @@ char *G_json_serialize_to_string_pretty(const G_JSON_Value *value)
     return json_serialize_to_string_pretty((const JSON_Value *)value);
 }
 
+char *G_json_serialize_to_string(const G_JSON_Value *value)
+{
+    return json_serialize_to_string((const JSON_Value *)value);
+}
+
 void G_json_free_serialized_string(char *string)
 {
     json_free_serialized_string(string);

--- a/lib/external/parson/gjson.h
+++ b/lib/external/parson/gjson.h
@@ -74,6 +74,7 @@ extern G_JSON_Status G_json_array_append_null(G_JSON_Array *);
 
 extern void G_json_set_float_serialization_format(const char *format);
 extern char *G_json_serialize_to_string_pretty(const G_JSON_Value *);
+extern char *G_json_serialize_to_string(const G_JSON_Value *);
 extern void G_json_free_serialized_string(char *);
 extern void G_json_value_free(G_JSON_Value *);
 


### PR DESCRIPTION
This PR adds the `G_json_serialize_to_string` wrapper for future use.