### PR TITLE
r.geomorphon: Add tests for parameter validation, outputs, flags, and comparison modes

### DIFF
--- a/raster/r.geomorphon/testsuite/test_r_geom.py
+++ b/raster/r.geomorphon/testsuite/test_r_geom.py
@@ -144,6 +144,8 @@ class TestMultipleOutputs(TestCase):
 
 
 class TestFlags(TestCase):
+    """Test flags"""
+
     inele = "elevation"
 
     @classmethod
@@ -156,7 +158,7 @@ class TestFlags(TestCase):
         cls.del_temp_region()
 
     def tearDown(self):
-        outputs = ["test_extended"]
+        outputs = ["test_extended", "test_meters"]
         existing = [o for o in outputs if gs.find_file(name=o, element="cell")["file"]]
         if existing:
             self.runModule("g.remove", flags="f", type="raster", name=existing)
@@ -171,6 +173,71 @@ class TestFlags(TestCase):
             search=10,
         )
         self.assertRasterExists("test_extended")
+
+    def test_meter_units_flag(self):
+        """Test using meters instead of cells for search units"""
+        self.assertModule(
+            "r.geomorphon",
+            flags="m",
+            elevation=self.inele,
+            forms="test_meters",
+            search=30,  # 30 meters
+        )
+        self.assertRasterExists("test_meters")
+
+
+class TestComparisonModes(TestCase):
+    """Test different comparison modes for zenith/nadir line-of-sight"""
+
+    inele = "elevation"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule("g.region", raster=cls.inele)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+
+    def tearDown(self):
+        outputs = ["test_anglev1", "test_anglev2", "test_anglev2_dist"]
+        existing = [o for o in outputs if gs.find_file(name=o, element="cell")["file"]]
+        if existing:
+            self.runModule("g.remove", flags="f", type="raster", name=existing)
+
+    def test_anglev1_mode(self):
+        """Test anglev1 comparison mode (default)"""
+        self.assertModule(
+            "r.geomorphon",
+            elevation=self.inele,
+            forms="test_anglev1",
+            search=10,
+            comparison="anglev1",
+        )
+        self.assertRasterExists("test_anglev1")
+
+    def test_anglev2_mode(self):
+        """Test anglev2 comparison mode"""
+        self.assertModule(
+            "r.geomorphon",
+            elevation=self.inele,
+            forms="test_anglev2",
+            search=10,
+            comparison="anglev2",
+        )
+        self.assertRasterExists("test_anglev2")
+
+    def test_anglev2_distance_mode(self):
+        """Test anglev2_distance comparison mode"""
+        self.assertModule(
+            "r.geomorphon",
+            elevation=self.inele,
+            forms="test_anglev2_dist",
+            search=10,
+            comparison="anglev2_distance",
+        )
+        self.assertRasterExists("test_anglev2_dist")
 
 
 if __name__ == "__main__":

--- a/raster/r.geomorphon/testsuite/test_r_geom.py
+++ b/raster/r.geomorphon/testsuite/test_r_geom.py
@@ -10,13 +10,16 @@ Licence:    This program is free software under the GNU General Public
             for details.
 """
 
+import json
+
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script.core import read_command
-import grass.script as gs
-import unittest
-import os
-import json
+
+# Reference statistics were computed with the nc_spm_full_v2beta1 dataset.
+# The elevation raster in nc_spm_08_grass7 classifies a small number of
+# cells differently, so precisions are chosen to accept both datasets.
 
 synth_out = """1	flat
 3	ridge
@@ -25,6 +28,7 @@ synth_out = """1	flat
 8	footslope
 9	valley
 """
+
 ele_out = """1	flat
 2	peak
 3	ridge
@@ -38,16 +42,15 @@ ele_out = """1	flat
 """
 
 
-@unittest.skipIf(os.getenv("CI") == "true", "Skipping slow tests in CI")
 class TestClipling(TestCase):
     inele = "elevation"
     insint = "synthetic_dem"
     outele = "ele_geomorph"
-    outsint = "synth_geomorph"
+    outsint = "synt_geomorph"
 
     @classmethod
     def setUpClass(cls):
-        """Ensures expected computational region and generated data"""
+        """Ensures expected computational region"""
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.inele)
         cls.runModule(
@@ -55,7 +58,6 @@ class TestClipling(TestCase):
             expression="{ou} = sin(x() / 5.0) + (sin(x() / 5.0) * 100.0 + 200)".format(
                 ou=cls.insint
             ),
-            overwrite=True,
         )
 
     @classmethod
@@ -65,18 +67,17 @@ class TestClipling(TestCase):
             "g.remove",
             flags="f",
             type="raster",
-            name=(cls.insint, cls.outele, cls.outsint),
+            name=(cls.outele, cls.outsint, cls.insint),
         )
         cls.del_temp_region()
 
     def test_ele(self):
-        """Test basic forms output with elevation data against reference"""
+        """Test forms output with elevation data against reference statistics"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.inele,
             forms=self.outele,
             search=10,
-            overwrite=True,
         )
 
         reference = {
@@ -91,20 +92,19 @@ class TestClipling(TestCase):
         self.assertRasterFitsUnivar(
             self.outele,
             reference=reference,
-            precision=0.001,
+            precision=0.002,
         )
 
         category = read_command("r.category", map=self.outele)
         self.assertEqual(first=ele_out, second=category)
 
     def test_sint(self):
-        """Test r.geomorphon with synthetic data against reference"""
+        """Test forms output with synthetic data against reference statistics"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.insint,
             forms=self.outsint,
             search=10,
-            overwrite=True,
         )
 
         reference = {
@@ -119,7 +119,7 @@ class TestClipling(TestCase):
         self.assertRasterFitsUnivar(
             self.outsint,
             reference=reference,
-            precision=0.001,
+            precision=0.002,
         )
 
         category = read_command("r.category", map=self.outsint)
@@ -173,18 +173,20 @@ class TestMultipleOutputs(TestCase):
 
     def tearDown(self):
         """Remove test outputs"""
-        outputs = [
-            "test_forms_multi",
-            "test_ternary_multi",
-            "test_intensity_multi",
-            "test_elongation_multi",
-        ]
-        existing = [o for o in outputs if gs.find_file(name=o, element="cell")["file"]]
-        if existing:
-            self.runModule("g.remove", flags="f", type="raster", name=existing)
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=(
+                "test_forms_multi",
+                "test_ternary_multi",
+                "test_intensity_multi",
+                "test_elongation_multi",
+            ),
+        )
 
     def test_multiple_outputs_combined(self):
-        """Test multiple outputs in a single call against reference"""
+        """Test multiple outputs in a single call against reference statistics"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.inele,
@@ -193,7 +195,6 @@ class TestMultipleOutputs(TestCase):
             intensity="test_intensity_multi",
             elongation="test_elongation_multi",
             search=15,
-            overwrite=True,
         )
 
         reference_forms = {
@@ -208,7 +209,7 @@ class TestMultipleOutputs(TestCase):
         self.assertRasterFitsUnivar(
             "test_forms_multi",
             reference=reference_forms,
-            precision=0.001,
+            precision=0.002,
         )
 
         reference_ternary = {
@@ -223,7 +224,7 @@ class TestMultipleOutputs(TestCase):
         self.assertRasterFitsUnivar(
             "test_ternary_multi",
             reference=reference_ternary,
-            precision=0.001,
+            precision=1,
         )
 
         reference_intensity = {
@@ -241,9 +242,10 @@ class TestMultipleOutputs(TestCase):
             precision=0.001,
         )
 
+        # Cell counts are omitted because the number of null (not applicable)
+        # cells depends on the form classification which slightly differs
+        # between the dataset versions.
         reference_elongation = {
-            "n": 2017213,
-            "null_cells": 7787,
             "min": 0.999999940395355,
             "max": 30,
             "mean": 2.07217229639214,
@@ -257,7 +259,6 @@ class TestMultipleOutputs(TestCase):
         )
 
 
-@unittest.skipIf(os.getenv("CI") == "true", "Skipping slow tests in CI")
 class TestFlags(TestCase):
     """Test flags"""
 
@@ -273,25 +274,27 @@ class TestFlags(TestCase):
         cls.del_temp_region()
 
     def tearDown(self):
-        outputs = [
-            "test_extended",
-            "test_meters",
-            "test_basic",
-            "test_cells",
-            "test_diff",
-        ]
-        existing = [o for o in outputs if gs.find_file(name=o, element="cell")["file"]]
-        if existing:
-            self.runModule("g.remove", flags="f", type="raster", name=existing)
+        """Remove test outputs"""
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=(
+                "test_extended",
+                "test_meters",
+                "test_basic",
+                "test_cells",
+                "test_diff",
+            ),
+        )
 
     def test_extended_flag(self):
-        """Test extended form correction flag against reference"""
+        """Test extended form correction flag against reference statistics"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.inele,
             forms="test_basic",
             search=20,
-            overwrite=True,
         )
 
         reference_basic = {
@@ -306,7 +309,7 @@ class TestFlags(TestCase):
         self.assertRasterFitsUnivar(
             "test_basic",
             reference=reference_basic,
-            precision=0.001,
+            precision=0.002,
         )
 
         self.assertModule(
@@ -315,7 +318,6 @@ class TestFlags(TestCase):
             elevation=self.inele,
             forms="test_extended",
             search=20,
-            overwrite=True,
         )
 
         reference_extended = {
@@ -330,13 +332,12 @@ class TestFlags(TestCase):
         self.assertRasterFitsUnivar(
             "test_extended",
             reference=reference_extended,
-            precision=0.001,
+            precision=0.002,
         )
 
         self.runModule(
             "r.mapcalc",
             expression="test_diff = if(test_basic != test_extended, 1, null())",
-            overwrite=True,
         )
 
         stats_diff = gs.parse_command("r.univar", flags="g", map="test_diff")
@@ -349,7 +350,6 @@ class TestFlags(TestCase):
             elevation=self.inele,
             forms="test_cells",
             search=30,
-            overwrite=True,
         )
 
         self.assertModule(
@@ -358,7 +358,6 @@ class TestFlags(TestCase):
             elevation=self.inele,
             forms="test_meters",
             search=30,
-            overwrite=True,
         )
 
         reference_meters = {
@@ -373,19 +372,17 @@ class TestFlags(TestCase):
         self.assertRasterFitsUnivar(
             "test_meters",
             reference=reference_meters,
-            precision=0.001,
+            precision=0.002,
         )
 
         self.runModule(
             "r.mapcalc",
             expression="test_diff = if(test_cells != test_meters, 1, null())",
-            overwrite=True,
         )
         stats_diff = gs.parse_command("r.univar", flags="g", map="test_diff")
         self.assertGreater(float(stats_diff["n"]), 0)
 
 
-@unittest.skipIf(os.getenv("CI") == "true", "Skipping slow tests in CI")
 class TestComparisonModes(TestCase):
     """Test different comparison modes for zenith/nadir line-of-sight"""
 
@@ -393,30 +390,33 @@ class TestComparisonModes(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Compute the anglev1 map once for use as a baseline in all tests"""
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.inele)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.del_temp_region()
-
-    def tearDown(self):
-        outputs = ["test_anglev1", "test_anglev2", "test_anglev2_dist", "test_diff"]
-        existing = [o for o in outputs if gs.find_file(name=o, element="cell")["file"]]
-        if existing:
-            self.runModule("g.remove", flags="f", type="raster", name=existing)
-
-    def test_anglev1_mode(self):
-        """Test anglev1 comparison mode (default) against reference"""
-        self.assertModule(
+        cls.runModule(
             "r.geomorphon",
-            elevation=self.inele,
+            elevation=cls.inele,
             forms="test_anglev1",
             search=10,
             comparison="anglev1",
-            overwrite=True,
         )
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.runModule("g.remove", flags="f", type="raster", name="test_anglev1")
+        cls.del_temp_region()
+
+    def tearDown(self):
+        """Remove test outputs"""
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=("test_anglev2", "test_anglev2_dist", "test_diff"),
+        )
+
+    def test_anglev1_mode(self):
+        """Test anglev1 comparison mode (default) against reference statistics"""
         reference = {
             "n": 2019304,
             "null_cells": 5696,
@@ -429,27 +429,17 @@ class TestComparisonModes(TestCase):
         self.assertRasterFitsUnivar(
             "test_anglev1",
             reference=reference,
-            precision=0.001,
+            precision=0.002,
         )
 
     def test_anglev2_mode(self):
-        """Test anglev2 comparison mode against reference"""
-        self.assertModule(
-            "r.geomorphon",
-            elevation=self.inele,
-            forms="test_anglev1",
-            search=10,
-            comparison="anglev1",
-            overwrite=True,
-        )
-
+        """Test that anglev2 comparison mode differs from anglev1"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.inele,
             forms="test_anglev2",
             search=10,
             comparison="anglev2",
-            overwrite=True,
         )
 
         reference_anglev2 = {
@@ -464,38 +454,29 @@ class TestComparisonModes(TestCase):
         self.assertRasterFitsUnivar(
             "test_anglev2",
             reference=reference_anglev2,
-            precision=0.001,
+            precision=0.002,
         )
 
         self.runModule(
             "r.mapcalc",
             expression="test_diff = if(test_anglev1 != test_anglev2, 1, null())",
-            overwrite=True,
         )
 
         stats = gs.parse_command("r.univar", flags="g", map="test_diff")
         self.assertGreater(float(stats["n"]), 0)
 
     def test_anglev2_distance_mode(self):
-        """Test anglev2_distance comparison mode against reference"""
-        self.assertModule(
-            "r.geomorphon",
-            elevation=self.inele,
-            forms="test_anglev1",
-            search=10,
-            comparison="anglev1",
-            overwrite=True,
-        )
-
+        """Test that anglev2_distance comparison mode differs from anglev1"""
         self.assertModule(
             "r.geomorphon",
             elevation=self.inele,
             forms="test_anglev2_dist",
             search=10,
             comparison="anglev2_distance",
-            overwrite=True,
         )
 
+        # On this dataset, anglev2_distance produces the same result
+        # as anglev2, but both differ from anglev1.
         reference_anglev2_dist = {
             "n": 2019304,
             "null_cells": 5696,
@@ -508,13 +489,12 @@ class TestComparisonModes(TestCase):
         self.assertRasterFitsUnivar(
             "test_anglev2_dist",
             reference=reference_anglev2_dist,
-            precision=0.001,
+            precision=0.002,
         )
 
         self.runModule(
             "r.mapcalc",
             expression="test_diff = if(test_anglev1 != test_anglev2_dist, 1, null())",
-            overwrite=True,
         )
 
         stats = gs.parse_command("r.univar", flags="g", map="test_diff")
@@ -552,7 +532,6 @@ class TestProfileFormat(TestCase):
                 coordinates=(self.test_easting, self.test_northing),
                 profiledata=profile_file,
                 profileformat="json",
-                overwrite=True,
             )
 
             with open(profile_file) as f:

--- a/raster/r.geomorphon/testsuite/test_r_geom.py
+++ b/raster/r.geomorphon/testsuite/test_r_geom.py
@@ -17,9 +17,14 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script.core import read_command
 
-# Reference statistics were computed with the nc_spm_full_v2beta1 dataset.
-# The elevation raster in nc_spm_08_grass7 classifies a small number of
-# cells differently, so precisions are chosen to accept both datasets.
+# A 400 x 400 cell subregion of the elevation raster which contains all
+# ten landforms and keeps the tests fast.
+region = {"n": 224000, "s": 220000, "w": 635000, "e": 639000, "res": 10}
+
+# Reference statistics were computed with the nc_spm_08_grass7 dataset.
+# The elevation raster in nc_spm_full_v2beta1 (used in CI) classifies a
+# small number of cells differently, so precisions are chosen to accept
+# both datasets.
 
 synth_out = """1	flat
 3	ridge
@@ -52,7 +57,7 @@ class TestClipling(TestCase):
     def setUpClass(cls):
         """Ensures expected computational region"""
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
+        cls.runModule("g.region", **region)
         cls.runModule(
             "r.mapcalc",
             expression="{ou} = sin(x() / 5.0) + (sin(x() / 5.0) * 100.0 + 200)".format(
@@ -81,12 +86,12 @@ class TestClipling(TestCase):
         )
 
         reference = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.82088828626101,
-            "stddev": 1.7495396954895,
+            "mean": 5.81124214034999,
+            "stddev": 1.77419698170854,
         }
 
         self.assertRasterFitsUnivar(
@@ -108,12 +113,12 @@ class TestClipling(TestCase):
         )
 
         reference = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 9,
-            "mean": 5.99331056641298,
-            "stddev": 0.624993270568342,
+            "mean": 5.99981061084316,
+            "stddev": 0.600696938302586,
         }
 
         self.assertRasterFitsUnivar(
@@ -134,7 +139,7 @@ class TestParameterValidation(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
+        cls.runModule("g.region", **region)
 
     @classmethod
     def tearDownClass(cls):
@@ -165,7 +170,7 @@ class TestMultipleOutputs(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
+        cls.runModule("g.region", **region)
 
     @classmethod
     def tearDownClass(cls):
@@ -198,12 +203,12 @@ class TestMultipleOutputs(TestCase):
         )
 
         reference_forms = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.81997163379065,
-            "stddev": 1.80462751945005,
+            "mean": 5.81710057826823,
+            "stddev": 1.821438283467,
         }
 
         self.assertRasterFitsUnivar(
@@ -213,49 +218,49 @@ class TestMultipleOutputs(TestCase):
         )
 
         reference_ternary = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 0,
             "max": 6560,
-            "mean": 461.729427565141,
-            "stddev": 1035.85787176981,
+            "mean": 465.214786242772,
+            "stddev": 1038.84517618805,
         }
 
         self.assertRasterFitsUnivar(
             "test_ternary_multi",
             reference=reference_ternary,
-            precision=1,
+            precision=5,
         )
 
         reference_intensity = {
-            "n": 2019304,
-            "null_cells": 5696,
-            "min": -14.2301387786865,
-            "max": 19.7351875305176,
-            "mean": 0.401472390593266,
-            "stddev": 2.46468990424033,
+            "n": 158404,
+            "null_cells": 1596,
+            "min": -12.1759548187256,
+            "max": 13.1019992828369,
+            "mean": 0.506680904574651,
+            "stddev": 2.72539083939135,
         }
 
         self.assertRasterFitsUnivar(
             "test_intensity_multi",
             reference=reference_intensity,
-            precision=0.001,
+            precision=0.002,
         )
 
-        # Cell counts are omitted because the number of null (not applicable)
-        # cells depends on the form classification which slightly differs
-        # between the dataset versions.
+        # Cell counts and the maximum are omitted because the number of
+        # null (not applicable) cells and the single longest form depend
+        # on the classification which slightly differs between the
+        # dataset versions.
         reference_elongation = {
             "min": 0.999999940395355,
-            "max": 30,
-            "mean": 2.07217229639214,
-            "stddev": 1.59757907173383,
+            "mean": 2.09059988401335,
+            "stddev": 1.58855170683853,
         }
 
         self.assertRasterFitsUnivar(
             "test_elongation_multi",
             reference=reference_elongation,
-            precision=0.001,
+            precision=0.002,
         )
 
 
@@ -267,7 +272,7 @@ class TestFlags(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
+        cls.runModule("g.region", **region)
 
     @classmethod
     def tearDownClass(cls):
@@ -298,12 +303,12 @@ class TestFlags(TestCase):
         )
 
         reference_basic = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.81211595678511,
-            "stddev": 1.84913018808328,
+            "mean": 5.82717608141209,
+            "stddev": 1.85255598163426,
         }
 
         self.assertRasterFitsUnivar(
@@ -321,12 +326,12 @@ class TestFlags(TestCase):
         )
 
         reference_extended = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.8660800949238,
-            "stddev": 1.79017370086154,
+            "mean": 5.85362112067877,
+            "stddev": 1.81621087978012,
         }
 
         self.assertRasterFitsUnivar(
@@ -361,12 +366,12 @@ class TestFlags(TestCase):
         )
 
         reference_meters = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.63588295769235,
-            "stddev": 1.75742791972737,
+            "mean": 5.65599353551678,
+            "stddev": 1.73140628723594,
         }
 
         self.assertRasterFitsUnivar(
@@ -392,7 +397,7 @@ class TestComparisonModes(TestCase):
     def setUpClass(cls):
         """Compute the anglev1 map once for use as a baseline in all tests"""
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
+        cls.runModule("g.region", **region)
         cls.runModule(
             "r.geomorphon",
             elevation=cls.inele,
@@ -418,12 +423,12 @@ class TestComparisonModes(TestCase):
     def test_anglev1_mode(self):
         """Test anglev1 comparison mode (default) against reference statistics"""
         reference = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.82088828626101,
-            "stddev": 1.7495396954895,
+            "mean": 5.81124214034999,
+            "stddev": 1.77419698170854,
         }
 
         self.assertRasterFitsUnivar(
@@ -443,12 +448,12 @@ class TestComparisonModes(TestCase):
         )
 
         reference_anglev2 = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.82424092657668,
-            "stddev": 1.75081305759747,
+            "mean": 5.82252973409762,
+            "stddev": 1.78012008833156,
         }
 
         self.assertRasterFitsUnivar(
@@ -478,12 +483,12 @@ class TestComparisonModes(TestCase):
         # On this dataset, anglev2_distance produces the same result
         # as anglev2, but both differ from anglev1.
         reference_anglev2_dist = {
-            "n": 2019304,
-            "null_cells": 5696,
+            "n": 158404,
+            "null_cells": 1596,
             "min": 1,
             "max": 10,
-            "mean": 5.82424092657668,
-            "stddev": 1.75081305759747,
+            "mean": 5.82252973409762,
+            "stddev": 1.78012008833156,
         }
 
         self.assertRasterFitsUnivar(
@@ -509,11 +514,9 @@ class TestProfileFormat(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
-        cls.runModule("g.region", raster=cls.inele)
-
-        info = gs.raster_info(cls.inele)
-        cls.test_easting = (info["east"] + info["west"]) / 2
-        cls.test_northing = (info["north"] + info["south"]) / 2
+        cls.runModule("g.region", **region)
+        cls.test_easting = (region["e"] + region["w"]) / 2
+        cls.test_northing = (region["n"] + region["s"]) / 2
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Description
This PR significantly strengthens the test suite for `r.geomorphon` by adding **_reference-data based validation_** using the NC dataset (nc_spm_full_v2beta1).

Tests now validate algorithm behavior by **comparing outputs against reference data**, improving regression detection and ensuring stability across parameters, flags, and modes.
Earlier smoke-style checks (mean, stddev bounds and consistency checks) have been replaced with reference comparisons.

## Changes
- Algorithm validation using referenced univariate statistics for real and synthetic data
- Parameter validation for search/skip constraints, flatness threshold, and required outputs
- Reference-based validation of multiple outputs (`forms`, `ternary`, `intensity`, `elongation`)
- Flag behavior validation for extended correction (`-e`) and meter units (`-m`)
- Reference validation of comparison modes (`anglev1`, `anglev2`, `anglev2_distance`)
- JSON profile output format validation

## Test Results
Test coverage increased from 2 to 12.
All tests pass successfully.


Notes: 

- The latest commit validates r.geomorphon outputs against fixed reference data from the NC (nc_spm_full_v2beta1) dataset. Earlier commits only used lightweight sanity checks such as mean/stddev bounds and consistency checks. 
- Some slow tests are skipped for CI