### PR TITLE
i.smap: disable test_with_goodness_map test

### DIFF
--- a/imagery/i.smap/testsuite/test_i_smap.py
+++ b/imagery/i.smap/testsuite/test_i_smap.py
@@ -99,7 +99,7 @@ class TestISmap(TestCase):
             unique_classes, 3, f"Expected 3 classes in output, found {unique_classes}"
         )
 
-    @unittest.expectedFailure
+    @unittest.skip("known to fail at random")
     def test_with_goodness_map(self):
         """
         Validate goodness of fit map generation and


### PR DESCRIPTION
It fails repeatedly, but not always, on CI Ubuntu runner.

Temporary addresses #6982.