### PR TITLE
r.kappa: fix wrong reference data order in testcase

### DIFF
--- a/raster/r.kappa/testsuite/test_r_kappa.py
+++ b/raster/r.kappa/testsuite/test_r_kappa.py
@@ -474,7 +474,7 @@ class JSONOutputTest(TestCase):
             )
             json_out = json.loads(decode(out))
             self.assertTrue(
-                keyvalue_equals(self.expected_outputs[i], json_out, precision=0.0001)
+                keyvalue_equals(self.expected_outputs[i], json_out, precision=4)
             )
 
     @xfail_windows


### PR DESCRIPTION
While working on the JSON output in r.kappa, I noticed some values in the expected test output were incorrect or mismatched with the actual output. Since this is unrealated with my current PR I'm making this PR for this specific thing.
I think the existing validation:          
 ```python
 self.assertTrue(
        keyvalue_equals(self.expected_outputs[i], json_out, precision=4)
    )
```
only checks the structure and value tolerance, not array elements order. This is why tests were passing despite wrong expected values.

If you are interested feel free to read this full debug output (See Testcase 1):
```bash
=== TEST CASE 0 ===
EXPECTED:
{
  "reference": "tmp_g7pV27inyQ",
  "classification": "tmp_c0ikczDm2e",
  "observations": 18,
  "correct": 11,
  "overall_accuracy": 61.111111,
  "kappa": 0.52091,
  "kappa_variance": 0.016871,
  "cats": [
    1,
    2,
    3,
    4,
    5,
    6
  ],
  "matrix": [
    [
      4,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      1,
      4,
      0,
      0,
      0
    ],
    [
      3,
      0,
      0,
      0,
      0,
      1
    ],
    [
      0,
      0,
      0,
      0,
      1,
      0
    ],
    [
      0,
      2,
      0,
      0,
      0,
      2
    ]
  ],
  "row_sum": [
    4,
    0,
    5,
    4,
    1,
    4
  ],
  "col_sum": [
    7,
    3,
    4,
    0,
    1,
    3
  ],
  "producers_accuracy": [
    57.1429,
    0.0,
    100.0,
    null,
    100.0,
    66.66666
  ],
  "users_accuracy": [
    100.0,
    null,
    80.0,
    0.0,
    100.0,
    50.0
  ],
  "conditional_kappa": [
    1.0,
    null,
    0.742857,
    0.0,
    1.0,
    0.4
  ],
  "mcc": 0.5593
}

ACTUAL:
{
  "reference": "tmp_g7pV27inyQ",
  "classification": "tmp_c0ikczDm2e",
  "observations": 18,
  "correct": 11,
  "overall_accuracy": 61.11111,
  "kappa": 0.52091,
  "kappa_variance": 0.01687,
  "cats": [
    1,
    2,
    3,
    4,
    5,
    6
  ],
  "matrix": [
    [
      4,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      1,
      4,
      0,
      0,
      0
    ],
    [
      3,
      0,
      0,
      0,
      0,
      1
    ],
    [
      0,
      0,
      0,
      0,
      1,
      0
    ],
    [
      0,
      2,
      0,
      0,
      0,
      2
    ]
  ],
  "row_sum": [
    4,
    0,
    5,
    4,
    1,
    4
  ],
  "col_sum": [
    7,
    3,
    4,
    0,
    1,
    3
  ],
  "producers_accuracy": [
    57.14286,
    0.0,
    100.0,
    null,
    100.0,
    66.66667
  ],
  "users_accuracy": [
    100.0,
    null,
    80.0,
    0.0,
    100.0,
    50.0
  ],
  "conditional_kappa": [
    1.0,
    null,
    0.74286,
    0.0,
    1.0,
    0.4
  ],
  "mcc": 0.5593
}



=== TEST CASE 1 ===
EXPECTED:
{
  "reference": "tmp_2gnzM6Cm7i",
  "classification": "tmp_IPjb24kukC",
  "observations": 25,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": 0.0,
  "kappa_variance": 0.0,
  "cats": [
    0,
    1,
    2,
    3,
    4,
    9
  ],
  "matrix": [
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      8,
      8,
      4,
      1,
      4,
      0
    ]
  ],
  "row_sum": [
    0,
    0,
    0,
    0,
    0,
    25
  ],
  "col_sum": [
    8,
    8,
    4,
    1,
    4,
    0
  ],
  "producers_accuracy": [
    0.0,
    0.0,
    0.0,
    0.0,
    0.0,
    null
  ],
  "users_accuracy": [
    null,
    null,
    null,
    null,
    null,
    0.0
  ],
  "conditional_kappa": [
    null,
    null,
    null,
    null,
    null,
    0.0
  ],
  "mcc": null
}

ACTUAL:
{
  "reference": "tmp_2gnzM6Cm7i",
  "classification": "tmp_IPjb24kukC",
  "observations": 25,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": 0.0,
  "kappa_variance": 0.06356,
  "cats": [
    0,
    1,
    2,
    3,
    4,
    9
  ],
  "matrix": [
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      0,
      0,
      0,
      0,
      0,
      0
    ],
    [
      4,
      8,
      8,
      4,
      1,
      0
    ]
  ],
  "row_sum": [
    0,
    0,
    0,
    0,
    0,
    25
  ],
  "col_sum": [
    4,
    8,
    8,
    4,
    1,
    0
  ],
  "producers_accuracy": [
    0.0,
    0.0,
    0.0,
    0.0,
    0.0,
    null
  ],
  "users_accuracy": [
    null,
    null,
    null,
    null,
    null,
    0.0
  ],
  "conditional_kappa": [
    null,
    null,
    null,
    null,
    null,
    0.0
  ],
  "mcc": null
}


WARNING: Both maps have nothing in common. Check the computational region.

=== TEST CASE 2 ===
EXPECTED:
{
  "reference": "tmp_BOcjHLoxHC",
  "classification": "tmp_3ied1xIcfX",
  "observations": 0,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": null,
  "kappa_variance": null,
  "cats": [],
  "matrix": [
    []
  ],
  "row_sum": [],
  "col_sum": [],
  "producers_accuracy": [],
  "users_accuracy": [],
  "conditional_kappa": [],
  "mcc": null
}

ACTUAL:
{
  "reference": "tmp_BOcjHLoxHC",
  "classification": "tmp_3ied1xIcfX",
  "observations": 0,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": null,
  "kappa_variance": null,
  "cats": [],
  "matrix": [
    []
  ],
  "row_sum": [],
  "col_sum": [],
  "producers_accuracy": [],
  "users_accuracy": [],
  "conditional_kappa": [],
  "mcc": null
}


WARNING: Both maps have nothing in common. Check the computational region.

=== TEST CASE 3 ===
EXPECTED:
{
  "reference": "tmp_pvxFycaJ1j",
  "classification": "tmp_aKotJyF5qo",
  "observations": 0,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": null,
  "kappa_variance": null,
  "cats": [],
  "matrix": [
    []
  ],
  "row_sum": [],
  "col_sum": [],
  "producers_accuracy": [],
  "users_accuracy": [],
  "conditional_kappa": [],
  "mcc": null
}

ACTUAL:
{
  "reference": "tmp_pvxFycaJ1j",
  "classification": "tmp_aKotJyF5qo",
  "observations": 0,
  "correct": 0,
  "overall_accuracy": 0.0,
  "kappa": null,
  "kappa_variance": null,
  "cats": [],
  "matrix": [
    []
  ],
  "row_sum": [],
  "col_sum": [],
  "producers_accuracy": [],
  "users_accuracy": [],
  "conditional_kappa": [],
  "mcc": null
}


..OK

----------------------------------------------------------------------
Ran 5 tests in 22.753s

OK
```