### PR TITLE
r.in.ascii: Fix uninitialized memory access and conditional jump

### DIFF
--- a/raster/r.in.ascii/gethead.c
+++ b/raster/r.in.ascii/gethead.c
@@ -90,8 +90,6 @@ int gethead(FILE *fd, struct Cell_head *cellhd, RASTER_MAP_TYPE *d_type,
     char buf[1024];
     int ret;
 
-    G_zero(cellhd, sizeof(struct Cell_head));
-
     /* rsb fix */
     fpos_t p;
 


### PR DESCRIPTION
**Fixes #5769**
This PR fixes uninitialised memory usage in `r.in.ascii` that was detected by Valgrind.
Valgrind reported "Conditional jump or move depends on uninitialised value(s)" errors when running r.in.ascii. The errors were traced back to `gethead.c`, which was later detected in `adj_cellhd.c`

Tested with valgrind using: ```valgrind --track-origins=yes r.in.ascii input=/path/to/test.ascii output=ref_coeff_var --overwrite``` as stated in the original issue description.  

Additionally, This fix improves security as uninitialised memory can lead to security vulnerabilities and other undefined behaviors. The fix eliminates these risks without changing the module's intended behavior.