### PR TITLE
v.db.connect: accept layer number/name without parser warning

### DIFF
--- a/vector/v.db.connect/main.c
+++ b/vector/v.db.connect/main.c
@@ -85,8 +85,14 @@ int main(int argc, char **argv)
     field_opt = G_define_standard_option(G_OPT_V_FIELD);
     field_opt->description =
         _("Layer number or name (format: layer number[/layer name])");
-    /* no gisprompt override: allow layer_number/layer_name without filename
-     * validation */
+    /* Clear gisprompt so the parser does not apply filename-style validation
+     * (G_legal_filename) to the layer option. G_OPT_V_FIELD defaults to
+     * gisprompt "old,layer,layer", which causes values like "1/bridges" to
+     * trigger "Illegal filename ... Character </> not allowed". This module
+     * documents and uses layer number[/layer name] (see -p/-g output and
+     * Vect_open_old2); the C code parses the string (atoi, strchr) and never
+     * treats it as a file path. */
+    field_opt->gisprompt = NULL;
 
     sep_opt = G_define_standard_option(G_OPT_F_SEP);
     sep_opt->answer = NULL;

--- a/vector/v.db.connect/testsuite/test_v_db_connect.py
+++ b/vector/v.db.connect/testsuite/test_v_db_connect.py
@@ -1,3 +1,5 @@
+import re
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script.core import read_command, parse_command
@@ -114,12 +116,56 @@ class TestVDbConnect(TestCase):
         ).splitlines()
         self.assertEqual(actual, expected)
 
-    def test_layer_number_name_syntax_no_warning(self):
-        """layer=number/name should not trigger filename validation warnings"""
-        m = SimpleModule("v.db.connect", map="bridges", layer="1/bridges", flags="c")
+    def _assert_no_layer_filename_warning(self, stderr):
+        """Assert stderr does not contain the parser 'illegal filename' regression."""
+        stderr = stderr or ""
+        self.assertIsNone(
+            re.search(r"illegal filename", stderr, re.IGNORECASE),
+            msg=stderr,
+        )
+        self.assertIsNone(
+            re.search(r"character\s*<\s*/\s*>\s*not allowed", stderr, re.IGNORECASE),
+            msg=stderr,
+        )
+
+    def _columns_output(self, layer_arg=None):
+        """Run v.db.connect -c and return stdout lines (column list)."""
+        args = {"map": "bridges", "flags": "c"}
+        if layer_arg is not None:
+            args["layer"] = layer_arg
+        m = SimpleModule("v.db.connect", **args)
         self.assertModule(m)
-        self.assertNotIn("Illegal filename", m.outputs.stderr)
-        self.assertNotIn("Character </> not allowed", m.outputs.stderr)
+        self._assert_no_layer_filename_warning(m.outputs.stderr)
+        return m.outputs.stdout.strip().splitlines()
+
+    def test_layer_number_only(self):
+        """layer=1 (number only) works and produces column list"""
+        lines = self._columns_output(layer_arg="1")
+        self.assertGreater(len(lines), 0)
+        self.assertIn("INTEGER|cat", lines)
+
+    def test_layer_number_slash_name(self):
+        """layer=1/bridges (number/name) works like layer=1 with no warning"""
+        ref_lines = self._columns_output(layer_arg="1")
+        lines = self._columns_output(layer_arg="1/bridges")
+        self.assertEqual(
+            lines,
+            ref_lines,
+            "layer=1/bridges should produce same columns as layer=1",
+        )
+
+    # -p regression coverage: original warning was triggered during parsing for 1/name
+    def test_layer_number_slash_name_print(self):
+        """layer=1/bridges works with -p (print) without illegal-filename warning"""
+        m = SimpleModule("v.db.connect", map="bridges", layer="1/bridges", flags="p")
+        self.assertModule(m)
+        self._assert_no_layer_filename_warning(m.outputs.stderr)
+
+    def test_layer_name_only(self):
+        """layer=bridges (name only) works and matches layer=1 output"""
+        ref_lines = self._columns_output(layer_arg="1")
+        lines = self._columns_output(layer_arg="bridges")
+        self.assertEqual(lines, ref_lines)
 
     def test_columns_json(self):
         """Test -c flag with JSON format"""


### PR DESCRIPTION
Fixes #6100

v.db.connect advertises and prints the layer number[/layer name] syntax, but using layer=1/name triggered a parser warning:
Illegal filename <1/name>. Character </> not allowed. This was caused by filename validation being enabled for the layer option via field_opt->gisprompt. This PR removes that override so the documented number/name syntax works without warnings, and adds a regression test to ensure no warning is emitted.

@wenzeslaus