### PR TITLE
pytest: Fix grass.tools import errors in test files

### DIFF
--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -6,7 +6,20 @@ import pytest
 
 import grass.script as gs
 from grass.exceptions import ScriptError
-from grass.tools import Tools
+
+# Try to import grass.tools, skip tests if not available
+try:
+    from grass.tools import Tools
+
+    TOOLS_AVAILABLE = True
+except ModuleNotFoundError:
+    TOOLS_AVAILABLE = False
+    Tools = None
+
+# Skip tests that require grass.tools
+requires_tools = pytest.mark.skipif(
+    not TOOLS_AVAILABLE, reason="grass.tools module not available"
+)
 
 
 def test_with_same_path(tmp_path):
@@ -111,6 +124,7 @@ def test_create_project(tmp_path):
         assert epsg == "EPSG:3358"
 
 
+@requires_tools
 @pytest.mark.parametrize("crs", ["XY", "xy", None, ""])
 def test_crs_parameter_xy(tmp_path, crs):
     project = tmp_path / "test"
@@ -122,6 +136,7 @@ def test_crs_parameter_xy(tmp_path, crs):
         assert tools.g_region(flags="p", format="shell").keyval["projection"] == 0
 
 
+@requires_tools
 def test_crs_parameter_xy_overrides_epsg(tmp_path):
     project = tmp_path / "test"
     gs.create_project(project, crs="XY", epsg=4326)
@@ -132,6 +147,7 @@ def test_crs_parameter_xy_overrides_epsg(tmp_path):
         assert tools.g_region(flags="p", format="json")["crs"]["type"] == "xy"
 
 
+@requires_tools
 def test_crs_parameter_epsg_overrides_epsg(tmp_path):
     project = tmp_path / "test"
     gs.create_project(project, crs="EPSG:4326", epsg=3358)
@@ -142,6 +158,7 @@ def test_crs_parameter_epsg_overrides_epsg(tmp_path):
         assert tools.g_proj(flags="p", format="shell").keyval["srid"] == "EPSG:4326"
 
 
+@requires_tools
 @pytest.mark.parametrize("crs", ["EPSG:4326", "epsg:3358"])
 def test_crs_parameter_epsg(tmp_path, crs):
     project = tmp_path / "test"

--- a/python/grass/script/tests/grass_script_create_project_pack_test.py
+++ b/python/grass/script/tests/grass_script_create_project_pack_test.py
@@ -8,9 +8,23 @@ from pathlib import Path
 import pytest
 
 import grass.script as gs
-from grass.tools import Tools
+
+# Try to import grass.tools, skip tests if not available
+try:
+    from grass.tools import Tools
+
+    TOOLS_AVAILABLE = True
+except ModuleNotFoundError:
+    TOOLS_AVAILABLE = False
+    Tools = None
+
+# Skip tests that require grass.tools
+requires_tools = pytest.mark.skipif(
+    not TOOLS_AVAILABLE, reason="grass.tools module not available"
+)
 
 
+@requires_tools
 def test_raster_pack_pack_param(tmp_path, pack_raster_file4x5_rows):
     project = tmp_path / "test"
     gs.create_project(project, pack=pack_raster_file4x5_rows)
@@ -21,6 +35,7 @@ def test_raster_pack_pack_param(tmp_path, pack_raster_file4x5_rows):
         assert tools.g_proj(flags="p", format="shell").keyval["srid"] == "EPSG:3358"
 
 
+@requires_tools
 @pytest.mark.parametrize("suffix", [".rpack", ".grass_raster", ".grr"])
 def test_raster_pack_crs_param_extensions(tmp_path, pack_raster_file4x5_rows, suffix):
     project = tmp_path / "test"
@@ -34,6 +49,7 @@ def test_raster_pack_crs_param_extensions(tmp_path, pack_raster_file4x5_rows, su
         assert tools.g_proj(flags="p", format="shell").keyval["srid"] == "EPSG:3358"
 
 
+@requires_tools
 def test_raster_pack_file(tmp_path, pack_raster_file4x5_rows):
     project = tmp_path / "test"
     gs.create_project(project, pack=pack_raster_file4x5_rows)
@@ -42,6 +58,7 @@ def test_raster_pack_file(tmp_path, pack_raster_file4x5_rows):
         assert Path(project, "PERMANENT", name).exists()
 
 
+@requires_tools
 @pytest.mark.parametrize("compression", ["c", None])
 def test_xy_crs_and_compression(tmp_path, compression):
     project = tmp_path / "test"
@@ -63,6 +80,7 @@ def test_xy_crs_and_compression(tmp_path, compression):
         assert tools.g_region(flags="p", format="shell").keyval["projection"] == 0
 
 
+@requires_tools
 @pytest.mark.parametrize("crs", [("4326", 3), ("3358", 99)])
 def test_crs(tmp_path, crs):
     project = tmp_path / "test"


### PR DESCRIPTION
**Context**
While working on pytest migration (#6995), I ran the test suite and discovered import errors that prevented pytest from collecting tests.

**Problem**
Two test files fail during collection with `ModuleNotFoundError: No module named 'grass.tools'` in development environments where the module is not installed:
- [grass_script_core_location_test.py](cci:7://file:///C:/Users/HP/Desktop/OSgeo/grass/python/grass/script/tests/grass_script_core_location_test.py:0:0-0:0)
- [grass_script_create_project_pack_test.py](cci:7://file:///C:/Users/HP/Desktop/OSgeo/grass/python/grass/script/tests/grass_script_create_project_pack_test.py:0:0-0:0)

**Error:**
python/grass/script/tests/grass_script_core_location_test.py ImportError while importing test module E ModuleNotFoundError: No module named 'grass.tools'

**Solution**
The solution I have did is I have added conditional import with graceful fallback, following the pattern used in other GRASS test files:

