### PR TITLE
temporal: support extraction across mapsets

### DIFF
--- a/python/grass/temporal/extract.py
+++ b/python/grass/temporal/extract.py
@@ -415,7 +415,7 @@ def extract_dataset(
 
 
 def run_mapcalc2d(expr: str) -> None:
-    """Run r.mapcalc on single core in quiet mode.
+    """Run r.mapcalc on a single core in quiet mode.
 
     Wrapper function setting nprocs to 1 and verbosity to quiet. It is
     intended to be run in parallel in `extract_dataset`.
@@ -433,15 +433,16 @@ def run_mapcalc2d(expr: str) -> None:
 
 
 def run_mapcalc3d(expr: str) -> None:
-    """Run r3.mapcalc in quiet mode.
+    """Run r3.mapcalc on a single core in quiet mode.
 
-    Wrapper function setting verbosity to quiet. It is intended to be
-    run in parallel in `extract_dataset`.
+    Wrapper function setting nprocs to 1 and verbosity to quiet. It is
+    intended to be run in parallel in `extract_dataset`.
     """
     try:
         gs.run_command(
             "r3.mapcalc",
             expression=expr,
+            nprocs=1,
             overwrite=gs.overwrite(),
             quiet=True,
         )


### PR DESCRIPTION
`t.rast.extract` fails, if the **expression** option is not used and the source _STRDS_ is stored in another mapset.
Then the module throws the following error:
`ERROR: Only a map that was inserted in the temporal database can be registered in a space time dataset` This PR makes sure maps are inserted in the TGIS DB of the current mapset.

Also if the **where** clause did not match any maps in the input STDS, no warning was given and the module returned nothing without informing the user about what happend. So, now a warning is given if no maps are selected to extract.

Finally, more ruff linting-rules are implemented and some code complexity is reduced.