### PR TITLE
CMake: Avoid relative paths

### DIFF
--- a/lib/gis/CMakeLists.txt
+++ b/lib/gis/CMakeLists.txt
@@ -7,8 +7,8 @@ endif()
 set(grass_gis_DEFS "-DGRASS_VERSION_DATE=\"${GRASS_VERSION_DATE}\"")
 if(MSVC)
   set(grass_gis_DEFS "${grass_gis_DEFS};-D_USE_MATH_DEFINES=1")
-  set(gislib_INCLUDES "../../msvc")
-  list(APPEND gislib_SRCS "../../msvc/dirent.c;../../msvc/fcntl.c")
+  set(gislib_INCLUDES "${PROJECT_SOURCE_DIR}/msvc")
+  list(APPEND gislib_SRCS "${PROJECT_SOURCE_DIR}/msvc/dirent.c;${PROJECT_SOURCE_DIR}/msvc/fcntl.c")
 endif()
 
 build_module(


### PR DESCRIPTION
This PR fixes
```
CMake Error in .../CMakeLists.txt:
  Target "grass_gis" contains relative path in its
  INTERFACE_INCLUDE_DIRECTORIES:

    "../../msvc"
```
by replacing `../..` with `${PROJECT_SOURCE_DIR}`.