### PR TITLE
CMake: grass_env_command requires double escaping on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,13 @@ set(HTML2MAN ${CMAKE_BINARY_DIR}/utils/g.html2man.py)
 set(env_path "$ENV{PATH}")
 
 if(WIN32)
-  set(sep "\;")
+  set(sep "\\\;")
   string(REPLACE ";" "${sep}" env_path "${env_path}")
+  set(env_pythonpath "$ENV{PYTHONPATH}")
+  string(REPLACE ";" "${sep}" env_pythonpath "${env_pythonpath}")
   set(grass_env_command
     ${CMAKE_COMMAND} -E env "PATH=${BIN_DIR}${sep}${SCRIPTS_DIR}${sep}${env_path}${sep}${LIB_DIR}"
-    "PYTHONPATH=${ETC_PYTHON_DIR}${sep}${GUI_WXPYTHON_DIR}${sep}$ENV{PYTHONPATH}"
+    "PYTHONPATH=${ETC_PYTHON_DIR}${sep}${GUI_WXPYTHON_DIR}${sep}${env_pythonpath}"
     "GRASS_PYTHON=${PYTHON_EXECUTABLE}" "GISBASE=${RUN_GISBASE_NATIVE}" "GISRC=${GISRC}" "LC_ALL=C" "LANG=C"
     "ARCH=${BUILD_ARCH}" "ARCH_DISTDIR=${RUN_GISBASE_NATIVE}"
     "LANGUAGE=C" "MODULE_TOPDIR=${MODULE_TOPDIR}" "HTMLDIR=${DOC_DIR}"


### PR DESCRIPTION
This PR escapes `\;` twice on Windows to retain semi-colons in `grass_env_command` when it's used. It fixes `cmake -E env PATH=A B C` to `cmake -E env "PATH=A;B;C"`. See one example:
```
2026-01-31T19:12:53.7441647Z          %BUILD_PREFIX%\Library\bin\cmake.exe -E env PATH=%SRC_DIR%\build\output\lib\grass85\bin %SRC_DIR%\build\output\lib\grass85\scripts %BUILD_PREFIX% %BUILD_PREFIX%\Library\mingw-w64\bin %BUILD_PREFIX%\Library\usr\bin %BUILD_PREFIX%\Library\bin %BUILD_PREFIX%\Scripts %BUILD_PREFIX%\bin %BUILD_PREFIX% %BUILD_PREFIX%\Library\mingw-w64\bin %BUILD_PREFIX%\Library\usr\bin %BUILD_PREFIX%\Library\bin %BUILD_PREFIX%\Scripts %BUILD_PREFIX%\bin %PREFIX% %PREFIX%\Library\mingw-w64\bin %PREFIX%\Library\usr\bin %PREFIX%\Library\bin %PREFIX%\Scripts %PREFIX%\bin %PREFIX% %PREFIX%\Library\mingw-w64\bin %PREFIX%\Library\usr\bin %PREFIX%\Library\bin %PREFIX%\Scripts %PREFIX%\bin C:\Users\runneradmin\micromamba\condabin C:\Users\runneradmin\micromamba-bin "C:\Program Files\Git\usr\bin" "C:\Program Files\MongoDB\Server\7.0\bin" C:\vcpkg C:\tools\zstd C:\hostedtoolcache\windows\stack\3.9.1\x64 C:\cabal\bin C:\ghcup\bin C:\mingw64\bin "C:\Program Files\dotnet" "C:\Program Files\MySQL\MySQL Server 8.0\bin" "C:\Program Files\R\R-4.5.2\bin\x64" C:\SeleniumWebDrivers\GeckoDriver C:\SeleniumWebDrivers\EdgeDriver C:\SeleniumWebDrivers\ChromeDriver "C:\Program Files (x86)\sbt\bin" "C:\Program Files (x86)\GitHub CLI" "C:\Program Files\Git\bin" "C:\Program Files (x86)\pipx_bin" C:\npm\prefix C:\hostedtoolcache\windows\go\1.24.12\x64\bin C:\hostedtoolcache\windows\Python\3.12.10\x64\Scripts C:\hostedtoolcache\windows\Python\3.12.10\x64 C:\hostedtoolcache\windows\Ruby\3.3.10\x64\bin "C:\Program Files\OpenSSL\bin" C:\tools\kotlinc\bin C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.17-10\x64\bin "C:\Program Files\ImageMagick-7.1.2-Q16-HDRI" "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin" C:\ProgramData\kind C:\ProgramData\Chocolatey\bin C:\Windows\system32 C:\Windows C:\Windows\System32\Wbem C:\Windows\System32\WindowsPowerShell\v1.0 C:\Windows\System32\OpenSSH "C:\Program Files\PowerShell\7" "C:\Program Files\Microsoft\Web Platform Installer" "C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn" "C:\Program Files\Microsoft SQL Server\150\Tools\Binn" "C:\Program Files\dotnet" "C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit" "C:\Program Files (x86)\WiX Toolset v3.14\bin" "C:\Program Files\Microsoft SQL Server\130\DTS\Binn" "C:\Program Files\Microsoft SQL Server\140\DTS\Binn" "C:\Program Files\Microsoft SQL Server\150\DTS\Binn" "C:\Program Files\Microsoft SQL Server\160\DTS\Binn" "C:\Program Files\Microsoft SQL Server\170\DTS\Binn" C:\ProgramData\chocolatey\lib\pulumi\tools\Pulumi\bin "C:\Program Files\CMake\bin" C:\Strawberry\c\bin C:\Strawberry\perl\site\bin C:\Strawberry\perl\bin C:\ProgramData\chocolatey\lib\maven\apache-maven-3.9.12\bin "C:\Program Files\Microsoft Service Fabric\bin\Fabric\Fabric.Code" "C:\Program Files\Microsoft SDKs\Service Fabric\Tools\ServiceFabricLocalClusterManager" "C:\Program Files\nodejs" "C:\Program Files\Git\cmd" "C:\Program Files\Git\mingw64\bin" "C:\Program Files\Git\usr\bin" "C:\Program Files\GitHub CLI" c:\tools\php "C:\Program Files (x86)\sbt\bin" "C:\Program Files\Amazon\AWSCLIV2" "C:\Program Files\Amazon\SessionManagerPlugin\bin" "C:\Program Files\Amazon\AWSSAMCLI\bin" "C:\Program Files\Microsoft SQL Server\130\Tools\Binn" "C:\Program Files\mongosh" "C:\Program Files\LLVM\bin" "C:\Program Files (x86)\LLVM\bin" C:\Users\runneradmin\.dotnet\tools C:\Users\runneradmin\.cargo\bin C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps %SRC_DIR%\build\output\lib\grass85\lib PYTHONPATH=%SRC_DIR%\build\output\lib\grass85\etc\python %SRC_DIR%\build\output\lib\grass85\gui\wxpython GRASS_PYTHON=C:/hostedtoolcache/windows/Python/3.14.2/x64/python3.exe GISBASE=%SRC_DIR%\build\output\lib\grass85 GISRC=%SRC_DIR%\build\output\lib\grass85\demolocation\.grassrc85 LC_ALL=C LANG=C ARCH=x86_64 ARCH_DISTDIR=%SRC_DIR%\build\output\lib\grass85 LANGUAGE=C MODULE_TOPDIR=%SRC_DIR% HTMLDIR=%SRC_DIR%\build\output\lib\grass85\docs\html LC_ALL=C LANG=C LANGUAGE=C VERSION_NUMBER="8.5.0dev" VERSION_DATE="2025" C:/hostedtoolcache/windows/Python/3.14.2/x64/python3.exe C:/Users/runneradmin/micromamba/envs/build/conda-bld/grass_1769886330283/work/build/utils/g.html2man.py C:/Users/runneradmin/micromamba/envs/build/conda-bld/grass_1769886330283/work/build/output/lib/grass85/docs/html/databaseintro.html C:/Users/runneradmin/micromamba/envs/build/conda-bld/grass_1769886330283/work/build/output/lib/grass85/docs/man/man1/databaseintro.1
2026-01-31T19:12:53.7466399Z          if %errorlevel% neq 0 goto :cmEnd
2026-01-31T19:12:53.7467216Z          %BUILD_PREFIX%\Library\bin\cmake.exe -E remove C:/Users/runneradmin/micromamba/envs/build/conda-bld/grass_1769886330283/work/build/db/databaseintro.html
2026-01-31T19:12:53.7467940Z          if %errorlevel% neq 0 goto :cmEnd
2026-01-31T19:12:53.7468183Z          :cmEnd
2026-01-31T19:12:53.7468431Z          endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
2026-01-31T19:12:53.7468736Z          :cmErrorLevel
2026-01-31T19:12:53.7469395Z          exit /b %1
2026-01-31T19:12:53.7469702Z          :cmDone
2026-01-31T19:12:53.7470746Z          if %errorlevel% neq 0 goto :VCEnd
2026-01-31T19:12:53.7471174Z          :VCEnd
2026-01-31T19:12:53.7471482Z          no such file or directory
```

We may need to revisit later:
https://github.com/OSGeo/grass/blob/8d558813b5af64dcbbeaaa3a503c63a8ad043506/cmake/modules/build_addon.cmake#L51-L52