### PR TITLE
v.to.rast: avoid zero categories metadata when using use=cat

### DIFF
--- a/vector/v.to.rast/support.c
+++ b/vector/v.to.rast/support.c
@@ -573,44 +573,6 @@ int update_labels(const char *rast_name, const char *vector_map, int field,
 
             /* Fast: store a label format instead of writing N category rules */
             Rast_set_cats_fmt("Category $1", 1.0, 0.0, 0.0, 0.0, &rast_cats);
-
-            /* Rast_set_cat() is terribly slow for many categories,
-             * and the added labels are not really informative:
-             * 1:Category 1
-             * 2:Category 2
-             * ...
-             * 100000:Category 100000
-             * -> skip */
-
-#if 0
-                int row, rows, fd;
-                void *rowbuf;
-                struct Cell_stats stats;
-                CELL n;
-                long count;
-
-                fd = Rast_open_old(rast_name, G_mapset());
-                rowbuf = Rast_allocate_buf(map_type);
-                Rast_init_cell_stats(&stats);
-                rows = Rast_window_rows();
-
-                for (row = 0; row < rows; row++) {
-                    Rast_get_row(fd, rowbuf, row, map_type);
-                    Rast_update_cell_stats(rowbuf, Rast_window_cols(),
-                                           &stats);
-                }
-
-                Rast_rewind_cell_stats(&stats);
-
-                while (Rast_next_cell_stat(&n, &count, &stats)) {
-                    char msg[80];
-
-                    sprintf(msg, "Category %d", n);
-                    Rast_set_cat(&n, &n, msg, &rast_cats, map_type);
-                }
-                Rast_close(fd);
-                G_free(rowbuf);
-#endif
         }
     } break;
     case USE_D: {


### PR DESCRIPTION
Fixes #2739

While working with `v.to.rast`, I noticed that rasterizing with `use=cat` results in `r.info` reporting `Number of Categories: 0`, even though the raster clearly contains category values. This is confusing for users and looks like a regression.
The issue seems to come from an earlier change where writing individual category rules was disabled for performance reasons. In the `use=cat` case without labels, this means no category metadata ends up being written at all.

This PR restores meaningful category metadata by using`Rast_set_cats_fmt()` to store a category *format* instead of enumerating all categories. This keeps the fast path intact and avoids the performance cost of writing per-category rules, while ensuring `r.info` no longer reports zero categories.

I also added a small regression test to make sure `use=cat` produces non-zero category metadata going forward.
