### PR TITLE
doc: Reword and fix syntax in variables doc

### DIFF
--- a/doc/development/style_guide.md
+++ b/doc/development/style_guide.md
@@ -1022,7 +1022,7 @@ programming practice (e.g. always checking if memory was allocated) and/or
 improves portability.
 
 - Memory management: `G_malloc()`, `G_calloc()`, `G_realloc()`, `G_free()`
-- Environmental variables: `G_getenv()`, `G_setenv()`, `G_unsetenv()`
+- Environment variables: `G_getenv()`, `G_setenv()`, `G_unsetenv()`
 - File seek: `G_fseek()`, `G_ftell()`
 - Printing: `G_asprintf()`, `G_vsaprintf()`, `G_vfaprintf()`, ...
 

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -133,7 +133,7 @@ nav:
       - Command line:
           - Command line introduction: command_line_intro.md
           - The grass command: grass.md
-          - Environmental variables: variables.md
+          - Environment variables: variables.md
       - Python: python_intro.md
       - Jupyter notebooks: jupyter_intro.md
       - Graphical user interface:


### PR DESCRIPTION
Some of the Markdown syntax in the variables documentation was broken (interpreted as math). However, the text overall needed some modernization. I removed the emphasis on Csh, added Python. I droped 'shell' from environment variables and used GRASS session variables for g.gisenv ones. I made slight move of some blocks, but refrained from a bigger restructuring.
