### PR TITLE
grass.jupyter: add test for utils.py functions

### DIFF
--- a/python/grass/jupyter/tests/jupyter_utils_test.py
+++ b/python/grass/jupyter/tests/jupyter_utils_test.py
@@ -10,7 +10,7 @@ ipywidgets = pytest.importorskip(
 )
 
 
-def test_get_region():
+def test_get_region(session):
     """Test that get_region returns currnt computational region as dictionary."""
     region = get_region()
     assert isinstance(region, dict)
@@ -20,9 +20,8 @@ def test_get_region():
     assert "west" in region
 
 
-def test_get_location_proj_string():
+def test_get_location_proj_string(simple_dataset):
     """Test that get_location_proj_string returns projection of environment in PROJ.4 format"""
     projection = get_location_proj_string()
     assert isinstance(projection, str)
-    assert projection != ""
     assert "+proj=" in projection


### PR DESCRIPTION
I noticed that there is no test for `utils.py` file in `grass/jupyter/test` directory.
so, In this PR, I add tests for `get_region` and `get_location_proj_string` function of `utils.py` file.
I  verify these test by locally  running `pytest`

<img width="1488" height="348" alt="image" src="https://github.com/user-attachments/assets/8c425392-510b-4d7f-af2e-3cb46014c20c" />
