### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/po/grasslibs_hi.po
+++ b/locale/po/grasslibs_hi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-31 15:57+0000\n"
-"PO-Revision-Date: 2026-02-05 20:05+0000\n"
+"PO-Revision-Date: 2026-02-06 14:23+0000\n"
 "Last-Translator: Abhimanyu  <abhimanyupg04@gmail.com>\n"
 "Language-Team: Hindi <https://weblate.osgeo.org/projects/grass-gis/grasslibs/hi/>\n"
 "Language: hi\n"
@@ -2055,7 +2055,7 @@ msgstr ""
 
 #: ../lib/gis/parser_standard_options.c:744
 msgid "Coordinates"
-msgstr "कोआर्डिनेट"
+msgstr "निर्देशांक (Coordinates)"
 
 #: ../lib/gis/parser_standard_options.c:753
 msgid "Name of color table"

--- a/locale/po/grassmods_fr.po
+++ b/locale/po/grassmods_fr.po
@@ -14,7 +14,7 @@ msgstr ""
 "Project-Id-Version: grassmods_fr\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-31 15:57+0000\n"
-"PO-Revision-Date: 2026-01-04 20:50+0000\n"
+"PO-Revision-Date: 2026-02-07 01:25+0000\n"
 "Last-Translator: Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>\n"
 "Language-Team: French <https://weblate.osgeo.org/projects/grass-gis/grassmods/fr/>\n"
 "Language: fr\n"
@@ -273,7 +273,7 @@ msgstr "Lister toutes les colonnes d'une table."
 #: ../db/db.columns/main.c:257 ../general/g.mapsets/main.c:166
 #, fuzzy
 msgid "Separator is part of the format."
-msgstr "Entrer une règle dans un des formats suivants :"
+msgstr "Le séparateur fait partie du format."
 
 #: ../db/db.connect/main.c:50 ../db/db.drivers/main.c:69
 #: ../db/db.login/main.c:40
@@ -1054,12 +1054,15 @@ msgid "Unable to move '%s' to '%s'."
 msgstr ""
 
 #: ../db/drivers/mysql/create_table.c:107
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Unable to create table:\n"
 "%s\n"
 "%s"
-msgstr "Impossible de créer la table : %s"
+msgstr ""
+"Impossible de créer la table :\n"
+"%s\n"
+"%s"
 
 #: ../db/drivers/mysql/cursor.c:42 ../db/drivers/postgres/cursor.c:40
 msgid "Unable allocate cursor."
@@ -1161,7 +1164,7 @@ msgstr ""
 
 #: ../db/drivers/mysql/parse.c:61
 msgid "Wrong port number in MySQL database definition: "
-msgstr "Erreur de définition du numéro de port de la base de données MySQL:"
+msgstr "Erreur de définition du numéro de port de la base de données MySQL : "
 
 #: ../db/drivers/mysql/parse.c:72 ../db/drivers/postgres/parse.c:60
 msgid "'user' in database definition is not supported, use db.login"
@@ -4065,7 +4068,7 @@ msgstr ""
 
 #: ../display/d.rast.arrow/main.c:142
 msgid "Draw arrow every Nth grid cell"
-msgstr "Tracer une flèche sur chaque chaque énième cellule de la grille"
+msgstr "Tracer une flèche sur chaque énième cellule de la grille"
 
 #: ../display/d.rast.arrow/main.c:150
 msgid "Raster map containing values used for arrow length"
@@ -5114,7 +5117,7 @@ msgstr "Taille maximum de la région (hauteur et largeur moyenne) quand la couch
 
 #: ../display/d.vect/main.c:312
 msgid "Random colors according to category number (or layer number if 'layer=-1' is given)"
-msgstr "Couleurs aléatoires en fonction du code de catégorie (ou du code de la couche si 'layer=-1' "
+msgstr "Couleurs aléatoires en fonction du code de catégorie (ou du code de la couche si 'layer=-1' est indiqué)"
 
 #: ../display/d.vect/main.c:319
 msgid "Use values from 'cats' option as feature id"
@@ -5709,7 +5712,7 @@ msgstr ""
 
 #: ../general/g.findfile/element.c:7
 msgid "List of available elements:"
-msgstr "Liste des éléments disponibles : "
+msgstr "Liste des éléments disponibles :"
 
 #: ../general/g.findfile/main.c:64
 msgid "Searches for GRASS data base files and sets variables for the shell."
@@ -7917,13 +7920,8 @@ msgid "Input range"
 msgstr "Cartes d'entrée"
 
 #: ../imagery/i.atcorr/main.cpp:507
-#, fuzzy
 msgid "Name of input elevation raster map (in m)"
-msgstr ""
-"#-#-#-#-#  grassmods_fr.po (grassmods_fr)  #-#-#-#-#\n"
-"Nom de la couche raster cible\n"
-"#-#-#-#-#  grassmods_fr.po (grassmods_fr)  #-#-#-#-#\n"
-"Nom de la couche raster de sortie"
+msgstr "Nom de la carte raster d’altitude en entrée (en m)"
 
 #: ../imagery/i.atcorr/main.cpp:513
 #, fuzzy
@@ -8520,7 +8518,7 @@ msgstr "moyennes"
 #: ../imagery/i.cluster/print1.c:17
 #, c-format
 msgid " stddev "
-msgstr "écart-type"
+msgstr " écart-type "
 
 #: ../imagery/i.cluster/print2.c:17
 #, c-format
@@ -8535,7 +8533,7 @@ msgstr ""
 #: ../imagery/i.cluster/print2.c:23
 #, c-format
 msgid "  means "
-msgstr "moyennes"
+msgstr "  moyennes "
 
 #: ../imagery/i.cluster/print2.c:28
 #, c-format
@@ -9053,7 +9051,7 @@ msgstr ""
 
 #: ../imagery/i.fft/main.c:147
 msgid "Starting FFT..."
-msgstr "Lancement de la FFT ... "
+msgstr "Lancement de la FFT..."
 
 #: ../imagery/i.fft/main.c:168 ../imagery/i.ifft/main.c:192
 msgid "Rotating data..."
@@ -10475,9 +10473,9 @@ msgid "Please select a target for group [%s] first"
 msgstr ""
 
 #: ../imagery/i.ortho.photo/i.ortho.elev/main.c:141
-#, fuzzy, c-format
+#, c-format
 msgid "Target project (location) [%s] not found\n"
-msgstr "Carte raster <%s> non trouvée"
+msgstr "Projet (secteur) cible [%s] introuvable\n"
 
 #: ../imagery/i.ortho.photo/i.ortho.elev/main.c:151
 #, c-format
@@ -11557,7 +11555,7 @@ msgstr ""
 #: ../imagery/i.segment/main.c:70
 #, c-format
 msgid "Number of segments created: %d"
-msgstr "Nombre de segments créés :  %d"
+msgstr "Nombre de segments créés : %d"
 
 #: ../imagery/i.segment/mean_shift.c:92
 #, c-format
@@ -13629,7 +13627,7 @@ msgstr "fusion"
 
 #: ../locale/scriptstrings/i.pansharpen_to_translate.c:4
 msgid "sharpen"
-msgstr "améliorer "
+msgstr "améliorer"
 
 #: ../locale/scriptstrings/i.pansharpen_to_translate.c:5
 msgid "Brovey"
@@ -14219,6 +14217,7 @@ msgstr ""
 
 #: ../locale/scriptstrings/r.in.wms_to_translate.c:4
 #: ../locale/scriptstrings/v.in.wfs_to_translate.c:4
+#, fuzzy
 msgid "OGC web services"
 msgstr "web service OGC"
 
@@ -14267,7 +14266,7 @@ msgstr "Requête"
 
 #: ../locale/scriptstrings/r.in.wms_to_translate.c:14
 msgid "EPSG code of requested source projection"
-msgstr "Code EPSG de  projection de la source demandée"
+msgstr "Code EPSG de projection de la source demandée"
 
 #: ../locale/scriptstrings/r.in.wms_to_translate.c:16
 msgid "Driver used for communication with the server"
@@ -15524,7 +15523,7 @@ msgstr "Échelle logarithmique"
 #: ../locale/scriptstrings/t.rast.colors_to_translate.c:23
 #: ../raster/r.colors/edit_colors.c:186 ../vector/v.colors/main.c:154
 msgid "Logarithmic-absolute scaling"
-msgstr "Échelle logarithmique  absolue"
+msgstr "Échelle logarithmique absolue"
 
 #: ../locale/scriptstrings/t.rast.colors_to_translate.c:25
 #: ../raster/r.colors/edit_colors.c:191
@@ -17873,7 +17872,7 @@ msgstr "mètres"
 
 #: ../ps/ps.map/do_scalebar.c:192
 msgid "kilometers"
-msgstr "kilomètre"
+msgstr "kilomètres"
 
 #: ../ps/ps.map/do_scalebar.c:194
 msgid "feet"
@@ -19668,7 +19667,7 @@ msgstr ""
 #: ../raster/r.cross/cross.c:64
 #, c-format
 msgid "%s: STEP 1 ... "
-msgstr "%s : ÉTAPE 1 ..."
+msgstr "%s : ÉTAPE 1 ... "
 
 #: ../raster/r.cross/main.c:67
 msgid "Creates a cross product of the category values from multiple raster map layers."
@@ -19705,7 +19704,7 @@ msgstr "%d catégories"
 #: ../raster/r.cross/renumber.c:31
 #, c-format
 msgid "%s: STEP 3 ... "
-msgstr "%s : ÉTAPE 3 ..."
+msgstr "%s : ÉTAPE 3 ... "
 
 #: ../raster/r.describe/describe.c:94
 #, c-format
@@ -22577,9 +22576,9 @@ msgid " points found in input file(s)"
 msgstr "%lu points trouvés dans le fichier d'entrée"
 
 #: ../raster/r.in.pdal/main.cpp:938 ../raster/r.in.pdal/main.cpp:945
-#, fuzzy, c-format
+#, c-format
 msgid "Raster map <%s> created. "
-msgstr "Carte raster <%s> créée."
+msgstr "Carte raster <%s> créée. "
 
 #: ../raster/r.in.pdal/projection.c:124 ../vector/v.in.pdal/projection.c:124
 msgid "Overriding projection check"
@@ -22834,7 +22833,7 @@ msgstr "Afficher l'historique du raster à la place des informations générales
 
 #: ../raster/r.info/main.c:127
 msgid "The output format for flags -g, -r, -s, and -e currently defaults to 'shell', but this will change to 'plain' in a future release. To avoid unexpected behaviour, specify the format explicitly."
-msgstr "Le format de sortie des des options -g, -r, -s et -e est actuellement par défaut « shell », mais il sera remplacé par « plain » (texte brut) dans une prochaine version. Pour éviter tout comportement inattendu, spécifiez explicitement le format."
+msgstr "Le format de sortie des options -g, -r, -s et -e est actuellement par défaut « shell », mais il sera remplacé par « plain » (texte brut) dans une prochaine version. Pour éviter tout comportement inattendu, spécifiez explicitement le format."
 
 #: ../raster/r.info/main.c:403 ../raster/r.info/main.c:1024
 #: ../raster3d/r3.info/main.c:193 ../raster3d/r3.info/main.c:200
@@ -24756,7 +24755,7 @@ msgstr "Information de plage pour <%s> non disponible (lancez r.support)"
 #: ../raster/r.out.vrml/main.c:129
 #, c-format
 msgid "Opening %s for writing... "
-msgstr "Ouverture de %s en écriture ..."
+msgstr "Ouverture de %s en écriture... "
 
 #: ../raster/r.out.vrml/put_grid.c:34
 msgid "Writing vertices..."
@@ -25213,7 +25212,7 @@ msgstr "Utilisation de la résolution : %g [%s]"
 
 #: ../raster/r.profile/main.c:232
 msgid "Output columns:"
-msgstr "Colonnes en sortie : "
+msgstr "Colonnes en sortie :"
 
 #: ../raster/r.profile/main.c:235
 #, c-format
@@ -25405,7 +25404,7 @@ msgstr "Carte en entrée <%s@%s> dans le Secteur <%s> :"
 
 #: ../raster/r.proj/main.c:645
 msgid "Input:"
-msgstr "Entrée : "
+msgstr "Entrée :"
 
 #: ../raster/r.proj/main.c:646 ../raster/r.proj/main.c:657
 #, c-format
@@ -26847,7 +26846,7 @@ msgstr "Retour à la région originale..."
 
 #: ../raster/r.resamp.rst/main.c:484 ../raster/r.resample/main.c:112
 msgid "Percent complete: "
-msgstr "Pourcentage complet :"
+msgstr "Pourcentage complet : "
 
 #: ../raster/r.resamp.rst/main.c:492
 #, c-format
@@ -28788,7 +28787,7 @@ msgstr "Au moins une carte raster en sortie doit être spécifiée"
 #: ../raster/r.stream.extract/main.c:312
 #, c-format
 msgid "%.2f%% of data are kept in memory"
-msgstr "%.2f% % de données sont gardées en mémoire"
+msgstr "%.2f %% de données sont gardées en mémoire"
 
 #: ../raster/r.stream.extract/main.c:316
 #: ../raster/r.watershed/seg/init_vars.c:252
@@ -29292,7 +29291,7 @@ msgstr "S_decode ==> Merci de fixer la minute : %d"
 #: ../raster/r.sunhours/solpos00.c:980 ../raster/r.sunmask/solpos00.c:939
 #, c-format
 msgid "S_decode ==> Please fix the second: %d"
-msgstr "S_decode ==> Merci de fixer la seconde = %d "
+msgstr "S_decode ==> Merci de fixer la seconde = %d"
 
 #: ../raster/r.sunhours/solpos00.c:982 ../raster/r.sunmask/solpos00.c:941
 #, c-format
@@ -29307,12 +29306,12 @@ msgstr "S_decode ==> Merci de fixer l'intervalle : %d"
 #: ../raster/r.sunhours/solpos00.c:988 ../raster/r.sunmask/solpos00.c:947
 #, c-format
 msgid "S_decode ==> Please fix the latitude: %f"
-msgstr "S_decode ==> Merci de fixer  la latitude : %f"
+msgstr "S_decode ==> Merci de fixer la latitude : %f"
 
 #: ../raster/r.sunhours/solpos00.c:991 ../raster/r.sunmask/solpos00.c:950
 #, c-format
 msgid "S_decode ==> Please fix the longitude: %f"
-msgstr "S_decode ==> Merci de fixer la longitude : %f "
+msgstr "S_decode ==> Merci de fixer la longitude : %f"
 
 #: ../raster/r.sunhours/solpos00.c:994 ../raster/r.sunmask/solpos00.c:953
 #, c-format
@@ -29654,7 +29653,7 @@ msgstr "[%s] est la reclassification d'une autre couche. Sortie."
 #: ../raster/r.support/main.c:328
 #, c-format
 msgid "Writing new null file for [%s]... "
-msgstr "Écriture du nouveau fichier null de [%s]..."
+msgstr "Écriture du nouveau fichier null de [%s]... "
 
 #: ../raster/r.support/main.c:348
 #, c-format
@@ -29701,7 +29700,7 @@ msgstr "Sortie en 'unité de carte au carré'"
 
 #: ../raster/r.surf.area/main.c:151
 msgid "Null value area ignored in calculation:"
-msgstr "Surfaces de valeur nulle ignorées dans les calculs : "
+msgstr "Surfaces de valeur nulle ignorées dans les calculs :"
 
 #: ../raster/r.surf.area/main.c:153
 msgid "Plan area used in calculation:"
@@ -30305,6 +30304,7 @@ msgid ""
 msgstr ""
 
 #: ../raster/r.to.vect/areas_io.c:297
+#, fuzzy
 msgid "Writing areas..."
 msgstr "Écriture des lignes..."
 
@@ -30818,13 +30818,8 @@ msgid "LOS"
 msgstr ""
 
 #: ../raster/r.viewshed/main.cpp:108
-#, fuzzy
 msgid "Computes the viewshed of a point on an elevation raster map."
 msgstr ""
-"#-#-#-#-#  grassmods_fr.po (grassmods_fr)  #-#-#-#-#\n"
-"Nom de la couche raster cible\n"
-"#-#-#-#-#  grassmods_fr.po (grassmods_fr)  #-#-#-#-#\n"
-"Nom de la couche raster de sortie"
 
 #: ../raster/r.viewshed/main.cpp:109
 msgid "Default format: NULL (invisible), vertical angle wrt viewpoint (visible)."
@@ -31025,9 +31020,8 @@ msgid "Running the program in-memory mode requires memory beyond the capability 
 msgstr ""
 
 #: ../raster/r.viewshed/viewshed.cpp:188 ../raster/r.viewshed/viewshed.cpp:441
-#, fuzzy
 msgid "Start sweeping."
-msgstr "Lancement de la FFT ... "
+msgstr ""
 
 #: ../raster/r.viewshed/viewshed.cpp:227 ../raster/r.viewshed/viewshed.cpp:471
 #, fuzzy
@@ -31700,7 +31694,7 @@ msgid ""
 "Your choice: "
 msgstr ""
 "\n"
-"Votre choix :"
+"Votre choix : "
 
 #: ../raster/r.watershed/shed/basin_maps.c:72
 #: ../raster/r.watershed/shed/basin_maps.c:77
@@ -31893,7 +31887,7 @@ msgstr "5)kilomètres carrés, 6)cellules de couche raster, 7)unités de débit"
 #: ../raster/r.watershed/shed/com_line.c:149
 #, c-format
 msgid "Choose 1-7 or 0 to exit this program: "
-msgstr "Choisir une unité entre 1 et 7 ou 0 pour sortir de ce programme :"
+msgstr "Choisir une unité entre 1 et 7 ou 0 pour sortir de ce programme : "
 
 #: ../raster/r.watershed/shed/com_line.c:159
 msgid ""
@@ -31906,7 +31900,7 @@ msgstr ""
 #: ../raster/r.watershed/shed/com_line.c:161
 #, c-format
 msgid "be for it to be an exterior drainage basin: "
-msgstr "pour être un bassin de drainage exogène :"
+msgstr "pour être un bassin de drainage exogène : "
 
 #: ../raster/r.watershed/shed/com_line.c:227
 #, c-format
@@ -32186,7 +32180,7 @@ msgstr "Coordonnées pour la requête"
 
 #: ../raster/r.what/main.c:128
 msgid "Name of vector points map for query"
-msgstr "Nom de la carte vecteur points à interroger "
+msgstr "Nom de la carte vecteur points à interroger"
 
 #: ../raster/r.what/main.c:152
 msgid "Size of point cache"
@@ -32210,7 +32204,7 @@ msgstr "Activer le retour d'information du cache"
 
 #: ../raster/r.what/main.c:215
 msgid "Flag 'v' required option 'points'"
-msgstr "L'option 'v' nécessite l'option 'points' "
+msgstr "L'option 'v' nécessite l'option 'points'"
 
 #: ../raster/r.what/main.c:229
 #, c-format
@@ -32416,7 +32410,7 @@ msgstr "Calcule le gradient d'une carte raster 3D et sort les composantes du gra
 
 #: ../raster3d/r3.gradient/main.c:57
 msgid "Name for output 3D raster map(s)"
-msgstr "Nom  des cartes rasters 3D en sortie"
+msgstr "Nom des cartes rasters 3D en sortie"
 
 #: ../raster3d/r3.gradient/main.c:64
 msgid "Size of blocks"
@@ -32916,7 +32910,7 @@ msgstr "Créer explicitement un fichier 3D de valeurs NULL."
 
 #: ../raster3d/r3.out.ascii/main.c:78
 msgid "3D raster map to be converted to ASCII"
-msgstr "Carte raster 3D  à convertir en ASCII"
+msgstr "Carte raster 3D à convertir en ASCII"
 
 #: ../raster3d/r3.out.ascii/main.c:82
 msgid "Name for ASCII output file"
@@ -33161,7 +33155,7 @@ msgstr "write_vtk_unstructured_grid_cells: Écriture des cellules"
 #: ../raster3d/r3.out.vtk/writeVTKData.c:349
 #, c-format
 msgid "write_vtk_data: Writing Celldata %s with rows %i cols %i depths %i to vtk-ascii file"
-msgstr "write_vtk_data : Écriture des données de cellule %s avec %i  lignes %i colonnes %i profondeur vers un fichier vtk-ascii"
+msgstr "write_vtk_data : Écriture des données de cellule %s avec %i lignes %i colonnes %i profondeur vers un fichier vtk-ascii"
 
 #: ../raster3d/r3.out.vtk/writeVTKData.c:453
 msgid "Wrong 3D raster map values! Values should in between 0 and 255!"
@@ -47990,7 +47984,7 @@ msgstr "Île[%d]: %d\n"
 #: ../vector/v.what/what.c:1101
 #, c-format
 msgid "Island: %d In area: %d\n"
-msgstr "Île: %d  Dans entité surfacique: %d\n"
+msgstr "Île : %d Dans entité surfacique : %d\n"
 
 #: ../vector/v.what/what.c:1144
 #, c-format

--- a/locale/po/grassmods_hi.po
+++ b/locale/po/grassmods_hi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-31 15:57+0000\n"
-"PO-Revision-Date: 2026-02-05 20:05+0000\n"
+"PO-Revision-Date: 2026-02-06 14:23+0000\n"
 "Last-Translator: Abhimanyu  <abhimanyupg04@gmail.com>\n"
 "Language-Team: Hindi <https://weblate.osgeo.org/projects/grass-gis/grassmods/hi/>\n"
 "Language: hi\n"
@@ -6068,7 +6068,7 @@ msgstr ""
 #: ../general/g.mapset/main.c:96 ../general/g.proj/main.c:218
 #: ../locale/scriptstrings/r.mask_to_translate.c:20
 msgid "Create"
-msgstr ""
+msgstr "बनाएं"
 
 #: ../general/g.mapset/main.c:101
 msgid "List available mapsets and exit"
@@ -15527,7 +15527,7 @@ msgstr ""
 #: ../locale/scriptstrings/t.rast.export_to_translate.c:12
 #: ../raster/r.out.gdal/main.c:198
 msgid "Data type"
-msgstr ""
+msgstr "डेटा टाइप"
 
 #: ../locale/scriptstrings/t.rast.export_to_translate.c:13
 msgid "Supported only for GTiff"
@@ -17351,7 +17351,7 @@ msgstr ""
 #: ../misc/m.nviz.image/args.c:824 ../misc/m.nviz.image/args.c:836
 #: ../misc/m.nviz.image/args.c:847
 msgid "Cutting planes"
-msgstr ""
+msgstr "कटिंग प्लेन्स (Cutting planes)"
 
 #: ../misc/m.nviz.image/args.c:814
 msgid "Cutting plane x,y,z coordinates"
@@ -28312,7 +28312,7 @@ msgstr ""
 
 #: ../raster/r.stats/main.c:191 ../raster/r.stats/main.c:198
 msgid "Coordinates"
-msgstr "कोआर्डिनेट"
+msgstr "निर्देशांक (Coordinates)"
 
 #: ../raster/r.stats/main.c:195
 msgid "Print x and y (column and row)"

--- a/locale/po/grasswxpy_fr.po
+++ b/locale/po/grasswxpy_fr.po
@@ -5,13 +5,13 @@
 # Eve (alias 'phyto') <dendrosociology[a]yahoo.co.uk>, 2006.
 # Vincent Bain <bain toraval.fr>, 2007, 2012.
 # Sylvain Maillard <sylvain.maillard gmail.com>, 2011-2015, 2017.
-# Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>, 2025.
+# Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>, 2025, 2026.
 msgid ""
 msgstr ""
 "Project-Id-Version: grasswxpy_fr\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-31 15:57+0000\n"
-"PO-Revision-Date: 2025-12-26 20:58+0000\n"
+"PO-Revision-Date: 2026-02-07 01:25+0000\n"
 "Last-Translator: Edouard Choiniere <echoix@users.noreply.weblate.osgeo.org>\n"
 "Language-Team: French <https://weblate.osgeo.org/projects/grass-gis/grasswxpy/fr/>\n"
 "Language: fr\n"
@@ -488,8 +488,9 @@ msgid ""
 "Please install it first and make sure\n"
 "it's in the PATH variable."
 msgstr ""
-"Le programme 'ffmpeg' n'a pas été trouvé.Merci de l'installer et de vérifier\n"
-"qu'il ets dans le PATH."
+"Le programme 'ffmpeg' n'a pas été trouvé.\n"
+"Veuillez d'abord l'installer et vous assurer qu'il\n"
+"est dans la variable PATH."
 
 #: ../gui/wxpython/animation/dialogs.py:1276
 msgid "AVI file:"
@@ -1259,7 +1260,7 @@ msgstr "mètres"
 
 #: ../gui/wxpython/core/units.py:36 ../gui/wxpython/psmap/utils.py:110
 msgid "kilometers"
-msgstr "kilomètre"
+msgstr "kilomètres"
 
 #: ../gui/wxpython/core/units.py:37 ../gui/wxpython/psmap/utils.py:112
 msgid "miles"

--- a/locale/po/grasswxpy_hi.po
+++ b/locale/po/grasswxpy_hi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-31 15:57+0000\n"
-"PO-Revision-Date: 2026-02-05 21:57+0000\n"
+"PO-Revision-Date: 2026-02-06 14:23+0000\n"
 "Last-Translator: Abhimanyu  <abhimanyupg04@gmail.com>\n"
 "Language-Team: Hindi <https://weblate.osgeo.org/projects/grass-gis/grasswxpy/hi/>\n"
 "Language: hi\n"
@@ -351,7 +351,7 @@ msgstr ""
 
 #: ../gui/wxpython/animation/dialogs.py:952 ../gui/wxpython/nviz/tools.py:828
 msgid "Decorations"
-msgstr ""
+msgstr "डेकोरेशन्स"
 
 #: ../gui/wxpython/animation/dialogs.py:957
 #: ../gui/wxpython/lmgr/layertree.py:771 ../gui/wxpython/tplot/frame.py:395
@@ -497,12 +497,12 @@ msgstr "अतिरिक्त विकल्प:"
 
 #: ../gui/wxpython/animation/dialogs.py:1290
 msgid "Consider adding '-sameq' or '-qscale 1' if not satisfied with video quality. Options depend on ffmpeg version."
-msgstr "वीडियो की गुणवत्ता से संतुष्ट न होने पर '-sameq' या '-qscale 1' जोड़ने पर विचार करें। विकल्प ffmpeg संस्करण पर निर्भर करते हैं।"
+msgstr "यदि वीडियो की गुणवत्ता से संतुष्ट नहीं हैं, तो '-sameq' या '-qscale 1' जोड़ने पर विचार करें। विकल्प ffmpeg संस्करण पर निर्भर करते हैं।"
 
 #: ../gui/wxpython/animation/dialogs.py:1322
 #, python-format
 msgid "Current frame rate: %.2f fps"
-msgstr ""
+msgstr "वर्तमान फ्रेम दर: %.2f fps"
 
 #: ../gui/wxpython/animation/dialogs.py:1449
 #, python-format
@@ -511,7 +511,7 @@ msgstr ""
 
 #: ../gui/wxpython/animation/dialogs.py:1453
 msgid "Decoration image file is missing."
-msgstr ""
+msgstr "डेकोरेशन इमेज फ़ाइल गायब है।"
 
 #: ../gui/wxpython/animation/dialogs.py:1461
 #, python-format
@@ -1041,7 +1041,7 @@ msgstr ""
 
 #: ../gui/wxpython/core/settings.py:505
 msgid "Data point"
-msgstr ""
+msgstr "डेटा पॉइंट"
 
 #: ../gui/wxpython/core/settings.py:582
 msgid "animation"
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: ../gui/wxpython/core/toolboxes.py:457
 msgid "Custom toolboxes"
-msgstr ""
+msgstr "कस्टम टूलबॉक्स"
 
 #: ../gui/wxpython/core/toolboxes.py:485
 #, python-format
@@ -1328,7 +1328,7 @@ msgstr " पंक्ति %d:"
 
 #: ../gui/wxpython/datacatalog/catalog.py:55
 msgid "Data catalog"
-msgstr ""
+msgstr "डेटा कैटलॉग"
 
 #: ../gui/wxpython/datacatalog/catalog.py:217
 msgid "Choose GRASS project:"
@@ -1360,11 +1360,11 @@ msgstr ""
 
 #: ../gui/wxpython/datacatalog/catalog.py:353
 msgid "Create raster map from x,y,z data  [r.in.xyz]"
-msgstr ""
+msgstr "x,y,z डेटा से रास्टर मैप बनाएं [r.in.xyz]"
 
 #: ../gui/wxpython/datacatalog/catalog.py:359
 msgid "Create vector map from x,y,z data  [v.in.ascii]"
-msgstr ""
+msgstr "x,y,z डेटा से वेक्टर मैप बनाएं [v.in.ascii]"
 
 #: ../gui/wxpython/datacatalog/catalog.py:365
 msgid "Link external data"
@@ -1412,7 +1412,7 @@ msgstr ""
 
 #: ../gui/wxpython/datacatalog/frame.py:31
 msgid "Data Catalog"
-msgstr ""
+msgstr "डेटा कैटलॉग"
 
 #: ../gui/wxpython/datacatalog/frame.py:42
 msgid "Close GRASS Data Catalog"
@@ -1420,12 +1420,12 @@ msgstr "GRASS डेटा कैटलॉग बंद करें"
 
 #: ../gui/wxpython/datacatalog/g.gui.datacatalog.py:50
 msgid "Data Catalog - GRASS"
-msgstr ""
+msgstr "डेटा कैटलॉग - GRASS"
 
 #: ../gui/wxpython/datacatalog/infomanager.py:36
 #: ../gui/wxpython/datacatalog/toolbars.py:34
 msgid "Create new project"
-msgstr ""
+msgstr "नया प्रोजेक्ट बनाएं"
 
 #: ../gui/wxpython/datacatalog/infomanager.py:37
 msgid "Learn more"
@@ -1508,7 +1508,7 @@ msgstr ""
 
 #: ../gui/wxpython/datacatalog/toolbars.py:26
 msgid "Create new mapset in current project"
-msgstr ""
+msgstr "वर्तमान प्रोजेक्ट में नया मैपसेट बनाएं"
 
 #: ../gui/wxpython/datacatalog/toolbars.py:30
 msgid "Add an existing project"
@@ -1676,7 +1676,7 @@ msgstr ""
 #: ../gui/wxpython/datacatalog/tree.py:1343
 #, python-brace-format
 msgid "Copying <{name}>..."
-msgstr "{name} की प्रतिलिपि बनाई जा रही है…"
+msgstr "<{name}> को कॉपी किया जा रहा है..।"
 
 #: ../gui/wxpython/datacatalog/tree.py:1345
 #, python-brace-format
@@ -1685,7 +1685,7 @@ msgstr ""
 
 #: ../gui/wxpython/datacatalog/tree.py:1359
 msgid "Copying completed"
-msgstr "कॉपी पूरी हो गई"
+msgstr "कॉपी करना पूर्ण हुआ"
 
 #: ../gui/wxpython/datacatalog/tree.py:1365
 msgid "Moving completed"
@@ -1712,7 +1712,7 @@ msgstr ""
 
 #: ../gui/wxpython/datacatalog/tree.py:1551
 msgid "Delete map"
-msgstr ""
+msgstr "मैप हटाएं"
 
 #: ../gui/wxpython/datacatalog/tree.py:1552
 #, python-brace-format
@@ -1737,7 +1737,7 @@ msgstr "&कांपी करें"
 
 #: ../gui/wxpython/datacatalog/tree.py:2095
 msgid "Copy &name"
-msgstr "कॉपी करें और नाम दें"
+msgstr "&name कॉपी करें"
 
 #: ../gui/wxpython/datacatalog/tree.py:2099
 #: ../gui/wxpython/datacatalog/tree.py:2142
@@ -2011,11 +2011,11 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/base.py:1464
 msgid "Delete selected record(s)"
-msgstr ""
+msgstr "चयनित रिकॉर्ड(ओं) को हटाएं"
 
 #: ../gui/wxpython/dbmgr/base.py:1465
 msgid "Delete all records"
-msgstr ""
+msgstr "सभी रिकॉर्ड हटाएं"
 
 #: ../gui/wxpython/dbmgr/base.py:1471 ../gui/wxpython/gui_core/dialogs.py:838
 #: ../gui/wxpython/gui_core/dialogs.py:896
@@ -2044,7 +2044,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/base.py:1480
 msgid "Delete selected features"
-msgstr ""
+msgstr "चयनित विशेषताओं को हटाएं"
 
 #: ../gui/wxpython/dbmgr/base.py:1488 ../gui/wxpython/dbmgr/base.py:2671
 #: ../gui/wxpython/gmodeler/dialogs.py:925
@@ -2098,7 +2098,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/base.py:1762 ../gui/wxpython/dbmgr/base.py:1812
 msgid "Delete records"
-msgstr ""
+msgstr "रिकॉर्ड्स हटाएं"
 
 #: ../gui/wxpython/dbmgr/base.py:1808
 #, python-format
@@ -2132,7 +2132,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/base.py:2353 ../gui/wxpython/dbmgr/sqlbuilder.py:105
 msgid "Database connection"
-msgstr ""
+msgstr "डेटाबेस कनेक्शन"
 
 #: ../gui/wxpython/dbmgr/base.py:2370
 #, python-format
@@ -2216,17 +2216,17 @@ msgstr "कॉलम का नाम"
 
 #: ../gui/wxpython/dbmgr/base.py:2993
 msgid "Data length"
-msgstr ""
+msgstr "डेटा की लंबाई"
 
 #: ../gui/wxpython/dbmgr/base.py:2993 ../gui/wxpython/gmodeler/panels.py:1351
 #: ../gui/wxpython/gmodeler/panels.py:1407
 msgid "Data type"
-msgstr ""
+msgstr "डेटा टाइप"
 
 #: ../gui/wxpython/dbmgr/base.py:3051 ../gui/wxpython/dbmgr/base.py:3203
 #: ../gui/wxpython/dbmgr/base.py:3471 ../gui/wxpython/gui_core/gselect.py:1483
 msgid "Database"
-msgstr ""
+msgstr "डेटाबेस"
 
 #: ../gui/wxpython/dbmgr/base.py:3051 ../gui/wxpython/dbmgr/base.py:3192
 #: ../gui/wxpython/dbmgr/base.py:3460
@@ -2332,7 +2332,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/base.py:3958
 msgid "Copy statistics the clipboard (Ctrl+C)"
-msgstr "सांख्यिकी को क्लिपबोर्ड पर कॉपी करें (Ctrl+C)"
+msgstr "आंकड़े क्लिपबोर्ड पर कॉपी करें (Ctrl+C)"
 
 #: ../gui/wxpython/dbmgr/base.py:4019
 msgid "Statistics is not support for DBF tables."
@@ -2366,7 +2366,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/dialogs.py:85
 msgid "Create table?"
-msgstr ""
+msgstr "टेबल बनाएं?"
 
 #: ../gui/wxpython/dbmgr/dialogs.py:107
 msgid "Close dialog on submit"
@@ -2382,7 +2382,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/dialogs.py:128
 msgid "Define attributes"
-msgstr ""
+msgstr "एट्रिब्यूट्स परिभाषित करें"
 
 #: ../gui/wxpython/dbmgr/dialogs.py:130
 msgid "Display attributes"
@@ -2446,7 +2446,7 @@ msgstr ""
 #: ../gui/wxpython/dbmgr/manager.py:112
 #, python-format
 msgid "Database connection for vector map <%s> is not defined in DB file. You can define new connection in 'Manage layers' tab."
-msgstr ""
+msgstr "वेक्टर मैप <%s> के लिए डेटाबेस कनेक्शन DB फ़ाइल में परिभाषित नहीं है। आप 'लेयर्स प्रबंधित करें' (Manage layers) टैब में नया कनेक्शन परिभाषित कर सकते हैं।"
 
 #: ../gui/wxpython/dbmgr/manager.py:121
 msgid "Please wait, loading attribute data..."
@@ -2538,7 +2538,7 @@ msgstr "दिखाने के लिए कॉलम (खंड चुने
 #: ../gui/wxpython/dbmgr/sqlbuilder.py:478
 #: ../gui/wxpython/dbmgr/sqlbuilder.py:632
 msgid "Constraint for query (WHERE clause)"
-msgstr "क्वेरी के लिए बाधा (WHERE क्लॉज)"
+msgstr "क्वेरी के लिए प्रतिबंध (WHERE क्लॉज)"
 
 #: ../gui/wxpython/dbmgr/sqlbuilder.py:502
 msgid "Verify"
@@ -2590,7 +2590,7 @@ msgstr ""
 
 #: ../gui/wxpython/dbmgr/sqlbuilder.py:793
 msgid "Dbf driver does not support usage of SQL functions."
-msgstr ""
+msgstr "Dbf ड्राइवर SQL फ़ंक्शन्स के उपयोग का समर्थन नहीं करता है।"
 
 #: ../gui/wxpython/gcp/manager.py:147
 #: ../gui/wxpython/image2target/ii2t_manager.py:188
@@ -2660,12 +2660,12 @@ msgstr ""
 #: ../gui/wxpython/gcp/manager.py:565
 #: ../gui/wxpython/image2target/ii2t_manager.py:586
 msgid "Create group if none exists"
-msgstr ""
+msgstr "यदि कोई ग्रुप मौजूद नहीं है तो ग्रुप बनाएं"
 
 #: ../gui/wxpython/gcp/manager.py:573 ../gui/wxpython/iclass/dialogs.py:92
 #: ../gui/wxpython/image2target/ii2t_manager.py:594
 msgid "Create/edit group..."
-msgstr ""
+msgstr "ग्रुप बनाएं/संपादित करें..।"
 
 #: ../gui/wxpython/gcp/manager.py:576
 #: ../gui/wxpython/image2target/ii2t_manager.py:597
@@ -2874,6 +2874,8 @@ msgid ""
 "Could not calculate RMS Error.\n"
 "Possible error with m.transform."
 msgstr ""
+"RMS त्रुटि की गणना नहीं की जा सकी।\n"
+"m.transform के साथ संभावित त्रुटि।"
 
 #: ../gui/wxpython/gcp/manager.py:2135
 #: ../gui/wxpython/photo2image/ip2i_manager.py:1393
@@ -2881,6 +2883,8 @@ msgid ""
 "Could not calculate new extends.\n"
 "Possible error with m.transform."
 msgstr ""
+"नया विस्तार (extends) की गणना नहीं की जा सकी।\n"
+"m.transform के साथ संभावित त्रुटि।"
 
 #: ../gui/wxpython/gcp/manager.py:2264
 #: ../gui/wxpython/image2target/ii2t_manager.py:2205
@@ -2952,7 +2956,7 @@ msgstr ""
 #: ../gui/wxpython/gcp/manager.py:2595
 #: ../gui/wxpython/image2target/ii2t_manager.py:2544
 msgid "Create vector map group"
-msgstr ""
+msgstr "वेक्टर मैप ग्रुप बनाएं"
 
 #: ../gui/wxpython/gcp/manager.py:2663
 #: ../gui/wxpython/image2target/ii2t_manager.py:2622
@@ -3326,7 +3330,7 @@ msgstr "सूची में नया GCP जोड़ें"
 #: ../gui/wxpython/image2target/ii2t_toolbars.py:41
 #: ../gui/wxpython/photo2image/ip2i_toolbars.py:41
 msgid "Delete selected GCP"
-msgstr ""
+msgstr "चयनित GCP हटाएं"
 
 #: ../gui/wxpython/gcp/toolbars.py:42
 #: ../gui/wxpython/image2target/ii2t_toolbars.py:42
@@ -3434,7 +3438,7 @@ msgstr "टिप्पणी:"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:60
 msgid "Data properties"
-msgstr ""
+msgstr "डेटा गुण (Data properties)"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:103
 #: ../gui/wxpython/iclass/dialogs.py:269
@@ -3504,7 +3508,7 @@ msgstr ""
 #: ../gui/wxpython/gmodeler/dialogs.py:435
 #, python-format
 msgid "Data: %s"
-msgstr ""
+msgstr "डेटा: %s"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:444
 msgid "Command:"
@@ -3534,7 +3538,7 @@ msgstr ""
 
 #: ../gui/wxpython/gmodeler/dialogs.py:531
 msgid "Condition"
-msgstr "स्थिति"
+msgstr "शर्त"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:539
 #: ../gui/wxpython/gmodeler/dialogs.py:668
@@ -3557,11 +3561,11 @@ msgstr ""
 
 #: ../gui/wxpython/gmodeler/dialogs.py:582
 msgid "Define map series as condition for the loop"
-msgstr ""
+msgstr "लूप के लिए शर्त के रूप में मैप सीरीज़ परिभाषित करें"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:624
 msgid "Define series of maps"
-msgstr ""
+msgstr "मैप्स की सीरीज़ परिभाषित करें"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:647
 msgid "If-else properties"
@@ -3592,12 +3596,12 @@ msgstr ""
 #: ../gui/wxpython/gmodeler/dialogs.py:1075
 #: ../gui/wxpython/vdigit/dialogs.py:300
 msgid "Delete selected"
-msgstr ""
+msgstr "चयनित हटाएं"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:919
 #: ../gui/wxpython/vdigit/dialogs.py:304
 msgid "Delete all"
-msgstr ""
+msgstr "सभी हटाएं"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:983
 #: ../gui/wxpython/gui_core/gselect.py:2298
@@ -3617,7 +3621,7 @@ msgstr ""
 
 #: ../gui/wxpython/gmodeler/dialogs.py:1204
 msgid "Delete intermediate data when finish"
-msgstr ""
+msgstr "समाप्त होने पर इंटरमीडिएट डेटा हटाएं"
 
 #: ../gui/wxpython/gmodeler/dialogs.py:1212
 #: ../gui/wxpython/gmodeler/panels.py:1598
@@ -3715,7 +3719,7 @@ msgstr "<परिभाषित नहीं है>"
 
 #: ../gui/wxpython/gmodeler/model_items.py:865
 msgid "Condition: "
-msgstr "स्थिति: "
+msgstr "शर्त: "
 
 #: ../gui/wxpython/gmodeler/model_items.py:866
 msgid "Condition: not defined"
@@ -3786,12 +3790,12 @@ msgstr ""
 #: ../gui/wxpython/gmodeler/panels.py:797
 #: ../gui/wxpython/gmodeler/panels.py:938
 msgid "Current model is not empty. Do you want to store current settings to model file?"
-msgstr ""
+msgstr "वर्तमान मॉडल खाली नहीं है। क्या आप वर्तमान सेटिंग्स को मॉडल फ़ाइल में सहेजना चाहते हैं?"
 
 #: ../gui/wxpython/gmodeler/panels.py:801
 #: ../gui/wxpython/gmodeler/panels.py:942
 msgid "Create new model?"
-msgstr ""
+msgstr "नया मॉडल बनाएं?"
 
 #: ../gui/wxpython/gmodeler/panels.py:830
 msgid "Choose model file"
@@ -3857,7 +3861,7 @@ msgstr ""
 
 #: ../gui/wxpython/gmodeler/panels.py:1255
 msgid "Delete intermediate data?"
-msgstr ""
+msgstr "इंटरमीडिएट डेटा हटाएं?"
 
 #: ../gui/wxpython/gmodeler/panels.py:1267
 msgid "Model is empty. Nothing to validate."
@@ -3902,7 +3906,7 @@ msgstr ""
 #: ../gui/wxpython/gmodeler/panels.py:1351
 #: ../gui/wxpython/gmodeler/panels.py:1413
 msgid "Default value"
-msgstr ""
+msgstr "डिफ़ॉल्ट मान"
 
 #: ../gui/wxpython/gmodeler/panels.py:1351
 #: ../gui/wxpython/gmodeler/panels.py:1419
@@ -4133,7 +4137,7 @@ msgstr ""
 #: ../gui/wxpython/lmgr/frame.py:629 ../gui/wxpython/main_window/frame.py:648
 #: ../gui/wxpython/nviz/tools.py:113
 msgid "Data"
-msgstr ""
+msgstr "डेटा"
 
 #: ../gui/wxpython/gmodeler/preferences.py:296
 msgid "Raster:"
@@ -4203,7 +4207,7 @@ msgstr "लेखक (Authors):"
 
 #: ../gui/wxpython/gmodeler/toolbars.py:47
 msgid "Create new model"
-msgstr ""
+msgstr "नया मॉडल बनाएं"
 
 #: ../gui/wxpython/gmodeler/toolbars.py:51
 msgid "Load model from file"
@@ -4304,11 +4308,11 @@ msgstr ""
 #: ../gui/wxpython/gui_core/dialogs.py:294
 #: ../gui/wxpython/gui_core/dialogs.py:448
 msgid "Create new vector map"
-msgstr ""
+msgstr "नया वेक्टर मैप बनाएं"
 
 #: ../gui/wxpython/gui_core/dialogs.py:320
 msgid "Create attribute table"
-msgstr ""
+msgstr "एट्रिब्यूट टेबल बनाएं"
 
 #: ../gui/wxpython/gui_core/dialogs.py:340
 #: ../gui/wxpython/gui_core/preferences.py:1242
@@ -4359,7 +4363,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/dialogs.py:690
 msgid "Create or edit imagery groups"
-msgstr ""
+msgstr "इमेजरी ग्रुप्स (imagery groups) बनाएं या संपादित करें"
 
 #: ../gui/wxpython/gui_core/dialogs.py:725
 msgid "Apply changes to selected group and close dialog"
@@ -4455,7 +4459,7 @@ msgstr ""
 #: ../gui/wxpython/gui_core/dialogs.py:1325
 #, python-format
 msgid "Creating of new group <%s> failed."
-msgstr ""
+msgstr "नया ग्रुप <%s> बनाना विफल रहा।"
 
 #: ../gui/wxpython/gui_core/dialogs.py:1327
 #, python-format
@@ -4602,12 +4606,12 @@ msgstr ""
 #: ../gui/wxpython/gui_core/forms.py:614
 #: ../gui/wxpython/modules/mcalc_builder.py:177
 msgid "Copy"
-msgstr "कॉपी"
+msgstr "कॉपी करें"
 
 #: ../gui/wxpython/gui_core/forms.py:616
 #: ../gui/wxpython/modules/mcalc_builder.py:178
 msgid "Copy the current command string to the clipboard"
-msgstr "वर्तमान कमांड स्ट्रिंग को क्लिपबोर्ड में कॉपी करें"
+msgstr "वर्तमान कमांड स्ट्रिंग को क्लिपबोर्ड पर कॉपी करें"
 
 #: ../gui/wxpython/gui_core/forms.py:625
 msgid "Show manual page of the command (Ctrl+H)"
@@ -4808,7 +4812,7 @@ msgstr "लेखक"
 
 #: ../gui/wxpython/gui_core/ghelp.py:86
 msgid "Contributors"
-msgstr "योगदानकर्ताओं"
+msgstr "योगदानकर्ता"
 
 #: ../gui/wxpython/gui_core/ghelp.py:87
 msgid "Extra contributors"
@@ -4871,7 +4875,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/ghelp.py:439 ../gui/wxpython/gui_core/ghelp.py:444
 msgid "Country"
-msgstr ""
+msgstr "देश"
 
 #: ../gui/wxpython/gui_core/ghelp.py:439 ../gui/wxpython/gui_core/ghelp.py:443
 #: ../gui/wxpython/gui_core/ghelp.py:517
@@ -5098,7 +5102,7 @@ msgstr ""
 #: ../gui/wxpython/gui_core/gselect.py:1875
 #: ../gui/wxpython/gui_core/gselect.py:1920
 msgid "Creation options:"
-msgstr ""
+msgstr "निर्माण विकल्प:"
 
 #: ../gui/wxpython/gui_core/gselect.py:1790
 #: ../gui/wxpython/gui_core/gselect.py:1836
@@ -5316,7 +5320,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/preferences.py:459
 msgid "Data Catalog settings"
-msgstr ""
+msgstr "डेटा कैटलॉग सेटिंग्स"
 
 #: ../gui/wxpython/gui_core/preferences.py:464
 msgid "At startup load maps from current mapset only (in the Data tab)"
@@ -5401,11 +5405,11 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/preferences.py:888
 msgid "Default font for GRASS displays:"
-msgstr ""
+msgstr "GRASS डिस्प्ले के लिए डिफ़ॉल्ट फ़ॉन्ट:"
 
 #: ../gui/wxpython/gui_core/preferences.py:906
 msgid "Default display settings"
-msgstr ""
+msgstr "डिफ़ॉल्ट डिस्प्ले सेटिंग्स"
 
 #: ../gui/wxpython/gui_core/preferences.py:917
 msgid "Display driver:"
@@ -5485,7 +5489,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/preferences.py:1358
 msgid "Default raster settings"
-msgstr ""
+msgstr "डिफ़ॉल्ट रास्टर सेटिंग्स"
 
 #: ../gui/wxpython/gui_core/preferences.py:1371
 msgid "Make null cells opaque"
@@ -5493,11 +5497,11 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/preferences.py:1384
 msgid "Default color table"
-msgstr ""
+msgstr "डिफ़ॉल्ट रंग टेबल"
 
 #: ../gui/wxpython/gui_core/preferences.py:1422
 msgid "Default vector settings"
-msgstr ""
+msgstr "डिफ़ॉल्ट वेक्टर सेटिंग्स"
 
 #: ../gui/wxpython/gui_core/preferences.py:1429
 msgid "Display:"
@@ -5534,7 +5538,7 @@ msgstr "मानचित्र प्रदर्शन में चयनि
 
 #: ../gui/wxpython/gui_core/preferences.py:1676
 msgid "Data browser"
-msgstr ""
+msgstr "डेटा ब्राउज़र"
 
 #: ../gui/wxpython/gui_core/preferences.py:1683
 msgid "Left mouse double click:"
@@ -5550,7 +5554,7 @@ msgstr "तालिका से डेटा रिकॉर्ड हटा�
 
 #: ../gui/wxpython/gui_core/preferences.py:1749
 msgid "Create table"
-msgstr ""
+msgstr "टेबल बनाएं"
 
 #: ../gui/wxpython/gui_core/preferences.py:1783
 msgid "Projection"
@@ -5660,7 +5664,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/pyedit.py:308
 msgid "Couldn't read file <{}>."
-msgstr "नई सीमाओं की गणना नहीं कर सका। m.transform में संभव त्रुटि।"
+msgstr "फ़ाइल <{}> नहीं पढ़ी जा सकी।"
 
 #: ../gui/wxpython/gui_core/pyedit.py:327
 msgid "Permission denied <{}>. Please change file permission for writing.{}"
@@ -5668,7 +5672,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/pyedit.py:338
 msgid "Couldn't write file <{}>.{}"
-msgstr ""
+msgstr "फ़ाइल <{}> नहीं लिखी जा सकी।{}"
 
 #: ../gui/wxpython/gui_core/pyedit.py:362
 #: ../gui/wxpython/gui_core/pyedit.py:372
@@ -5726,7 +5730,7 @@ msgstr "ओवरराइट सक्रिय करें"
 
 #: ../gui/wxpython/gui_core/pyedit.py:664
 msgid "Deactivate overwrite"
-msgstr ""
+msgstr "ओवरराइट निष्क्रिय करें"
 
 #: ../gui/wxpython/gui_core/pyedit.py:883
 msgid "Simple Python Editor"
@@ -5763,7 +5767,7 @@ msgstr "'%s' कॉलम से कॉपी करें"
 
 #: ../gui/wxpython/gui_core/query.py:133
 msgid "Copy selected lines"
-msgstr "चयनित पंक्तियों को कॉपी करें"
+msgstr "चयनित लाइनें कॉपी करें"
 
 #: ../gui/wxpython/gui_core/query.py:138 ../gui/wxpython/gui_core/query.py:142
 #, python-format
@@ -5796,11 +5800,11 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/simplelmgr.py:157
 msgid "Copy map names to clipboard (top to bottom)"
-msgstr "मानचित्र नामों को क्लिपबोर्ड पर कॉपी करें (ऊपर से नीचे)"
+msgstr "मैप के नाम क्लिपबोर्ड पर कॉपी करें (ऊपर से नीचे)"
 
 #: ../gui/wxpython/gui_core/simplelmgr.py:158
 msgid "Copy map names to clipboard (bottom to top)"
-msgstr "मानचित्र नामों को क्लिपबोर्ड पर कॉपी करें (नीचे से ऊपर)"
+msgstr "मैप के नाम क्लिपबोर्ड पर कॉपी करें (नीचे से ऊपर)"
 
 #: ../gui/wxpython/gui_core/simplelmgr.py:307
 #: ../gui/wxpython/lmgr/layertree.py:1282
@@ -5954,7 +5958,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/toolbars.py:82
 msgid "Create histogram with d.histogram"
-msgstr ""
+msgstr "d.histogram के साथ हिस्टोग्राम बनाएं"
 
 #: ../gui/wxpython/gui_core/toolbars.py:84
 #: ../gui/wxpython/iscatt/toolbars.py:184 ../gui/wxpython/nviz/tools.py:2385
@@ -5985,7 +5989,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/vselect.py:134
 msgid "Create a new map"
-msgstr ""
+msgstr "एक नया मैप बनाएं"
 
 #: ../gui/wxpython/gui_core/vselect.py:267
 #, python-format
@@ -6066,7 +6070,7 @@ msgstr ""
 
 #: ../gui/wxpython/gui_core/widgets.py:1414
 msgid "Delete currently selected settings"
-msgstr ""
+msgstr "वर्तमान में चयनित सेटिंग्स हटाएं"
 
 #: ../gui/wxpython/gui_core/widgets.py:1433
 msgid "Load:"
@@ -6743,7 +6747,7 @@ msgstr "&नया"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:203
 msgid "Create a new Mapset in selected Location"
-msgstr ""
+msgstr "चयनित लोकेशन में एक नया मैपसेट (Mapset) बनाएं"
 
 #. GTC New location
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:208
@@ -6752,7 +6756,7 @@ msgstr ""
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:212
 msgid "Create a new location using location wizard. After location is created successfully, GRASS session is started."
-msgstr ""
+msgstr "लोकेशन विजार्ड का उपयोग करके एक नई लोकेशन बनाएं। लोकेशन सफलतापूर्वक बनने के बाद, GRASS सेशन शुरू हो जाता है।"
 
 #. GTC Rename location
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:221
@@ -6767,12 +6771,12 @@ msgstr ""
 #. GTC Delete location
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:228
 msgid "De&lete"
-msgstr ""
+msgstr "GTC लोकेशन हटाएं"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:230
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:842
 msgid "Delete selected location"
-msgstr ""
+msgstr "चयनित स्थान हटाएं"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:237
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:701
@@ -6783,7 +6787,7 @@ msgstr ""
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:244
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:812
 msgid "Delete selected mapset"
-msgstr ""
+msgstr "चयनित मानचित्र-सेट (mapset) हटाएं"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:299
 #, python-format
@@ -6837,7 +6841,7 @@ msgstr ""
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:1034
 #: ../gui/wxpython/startup/guiutils.py:134
 msgid "Create new mapset"
-msgstr ""
+msgstr "नया मैपसेट बनाएं"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:670
 #: ../gui/wxpython/startup/guiutils.py:653
@@ -6850,7 +6854,7 @@ msgstr ""
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:676
 #, python-format
 msgid "Data file <%(name)s> imported successfully. The location's default region was set from this imported map."
-msgstr ""
+msgstr "डेटा फ़ाइल <%(name)s> सफलतापूर्वक इंपोर्ट की गई। इस इंपोर्ट किए गए मैप से लोकेशन का डिफ़ॉल्ट क्षेत्र (region) सेट किया गया था।"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:692
 msgid ""
@@ -6867,6 +6871,9 @@ msgid ""
 "\n"
 "Enter new name:"
 msgstr ""
+"वर्तमान नाम: %s\n"
+"\n"
+"नया नाम दर्ज करें:"
 
 #: ../gui/wxpython/image2target/ii2t_gis_set.py:716
 #, python-format
@@ -7036,12 +7043,16 @@ msgid ""
 "Could not calculate RMS Error.\n"
 "Possible error with i.ortho.transform."
 msgstr ""
+"RMS त्रुटि की गणना नहीं की जा सकी।\n"
+"i.ortho.transform के साथ संभावित त्रुटि।"
 
 #: ../gui/wxpython/image2target/ii2t_manager.py:2075
 msgid ""
 "Could not calculate new extends.\n"
 "Possible error with i.ortho.transform."
 msgstr ""
+"नया विस्तार (extends) की गणना नहीं की जा सकी।\n"
+"i.ortho.transform के साथ संभावित त्रुटि।"
 
 #: ../gui/wxpython/image2target/ii2t_manager.py:2322
 #: ../gui/wxpython/image2target/ii2t_manager.py:2343
@@ -7296,7 +7307,7 @@ msgstr ""
 
 #: ../gui/wxpython/iscatt/iscatt_core.py:142
 msgid "Computing of scatter plots failed."
-msgstr "स्कैटर प्लॉट की गणना विफल रही।"
+msgstr "स्कैटर प्लॉट्स की गणना विफल रही।"
 
 #: ../gui/wxpython/iscatt/iscatt_core.py:277
 msgid "Patching category raster conditions file failed."
@@ -7369,7 +7380,7 @@ msgstr "बहुभुज सीमा स्कैटर प्लॉट म�
 
 #: ../gui/wxpython/iscatt/toolbars.py:227
 msgid "Create selection polygon"
-msgstr ""
+msgstr "चयन पॉलीगॉन (selection polygon) बनाएं"
 
 #: ../gui/wxpython/iscatt/toolbars.py:228
 msgid "Add new vertex between last and first points of the boundary"
@@ -7440,7 +7451,7 @@ msgstr "मैप डिस्प्ले {} बंद करें"
 
 #: ../gui/wxpython/lmgr/frame.py:639 ../gui/wxpython/main_window/frame.py:693
 msgid "Console"
-msgstr "सांत्वना देना"
+msgstr "कंसोल"
 
 #: ../gui/wxpython/lmgr/frame.py:794 ../gui/wxpython/main_window/frame.py:922
 msgid "Map Swipe Tool"
@@ -7642,7 +7653,7 @@ msgstr ""
 
 #: ../gui/wxpython/lmgr/frame.py:2342 ../gui/wxpython/main_window/frame.py:2451
 msgid "Constrain map to region geometry?"
-msgstr "मानचित्र को क्षेत्र ज्यामिति तक सीमित करें?"
+msgstr "मैप को क्षेत्र की ज्यामिति (geometry) तक सीमित रखें?"
 
 #: ../gui/wxpython/lmgr/layertree.py:54
 msgid "Import data from WMS server"
@@ -7754,7 +7765,7 @@ msgstr ""
 
 #: ../gui/wxpython/lmgr/layertree.py:653 ../gui/wxpython/lmgr/layertree.py:784
 msgid "Create pack"
-msgstr ""
+msgstr "पैक बनाएं"
 
 #: ../gui/wxpython/lmgr/layertree.py:667 ../gui/wxpython/lmgr/layertree.py:800
 msgid "Make a copy in the current mapset"
@@ -7903,7 +7914,7 @@ msgstr ""
 
 #: ../gui/wxpython/lmgr/pyshell.py:74
 msgid "Delete all text from the shell"
-msgstr ""
+msgstr "शेल (shell) से सारा टेक्स्ट हटाएं"
 
 #: ../gui/wxpython/lmgr/pyshell.py:78
 msgid "Simple &editor"
@@ -7947,7 +7958,7 @@ msgstr ""
 
 #: ../gui/wxpython/lmgr/toolbars.py:46
 msgid "Create new workspace (Ctrl+N)"
-msgstr ""
+msgstr "नया वर्कस्पेस बनाएं (Ctrl+N)"
 
 #: ../gui/wxpython/lmgr/toolbars.py:49
 msgid "Open existing workspace file (Ctrl+O)"
@@ -8036,7 +8047,7 @@ msgstr "वेब सेवा मानचित्र जोड़ें"
 
 #: ../gui/wxpython/lmgr/toolbars.py:169
 msgid "Delete map layer"
-msgstr ""
+msgstr "मैप लेयर हटाएं"
 
 #: ../gui/wxpython/lmgr/toolbars.py:203
 msgid "Start new map display"
@@ -8097,11 +8108,11 @@ msgstr ""
 
 #: ../gui/wxpython/lmgr/workspace.py:73
 msgid "Current workspace is not empty. Do you want to store current settings to workspace file?"
-msgstr ""
+msgstr "वर्तमान वर्कस्पेस खाली नहीं है। क्या आप वर्तमान सेटिंग्स को वर्कस्पेस फ़ाइल में सहेजना चाहते हैं?"
 
 #: ../gui/wxpython/lmgr/workspace.py:77
 msgid "Create new workspace?"
-msgstr ""
+msgstr "नया वर्कस्पेस बनाएं?"
 
 #: ../gui/wxpython/lmgr/workspace.py:106
 msgid "Choose workspace file"
@@ -8135,6 +8146,8 @@ msgid ""
 "Current location is <%(loc)s>.\n"
 "Current mapset is <%(mapset)s>."
 msgstr ""
+"वर्तमान लोकेशन <%(loc)s> है।\n"
+"वर्तमान मैपसेट <%(mapset)s> है।"
 
 #: ../gui/wxpython/lmgr/workspace.py:180
 #, python-format
@@ -8288,7 +8301,7 @@ msgstr ""
 #: ../gui/wxpython/location_wizard/wizard.py:183
 #: ../gui/wxpython/location_wizard/wizard.py:2437
 msgid "Define new GRASS project"
-msgstr ""
+msgstr "नया GRASS प्रोजेक्ट परिभाषित करें"
 
 #: ../gui/wxpython/location_wizard/wizard.py:197
 msgid "Change"
@@ -8345,7 +8358,7 @@ msgstr ""
 
 #: ../gui/wxpython/location_wizard/wizard.py:389
 msgid "Create a generic cartesian coordinate system (XY)"
-msgstr ""
+msgstr "एक सामान्य कार्टेशियन निर्देशांक प्रणाली (XY) बनाएं"
 
 #: ../gui/wxpython/location_wizard/wizard.py:392
 #: ../gui/wxpython/location_wizard/wizard.py:1521
@@ -8360,7 +8373,7 @@ msgstr ""
 #: ../gui/wxpython/location_wizard/wizard.py:398
 #: ../gui/wxpython/location_wizard/wizard.py:513
 msgid "Define custom CRS"
-msgstr ""
+msgstr "कस्टम CRS परिभाषित करें"
 
 #: ../gui/wxpython/location_wizard/wizard.py:409
 msgid "Additional methods:"
@@ -8399,7 +8412,7 @@ msgstr ""
 
 #: ../gui/wxpython/location_wizard/wizard.py:857
 msgid "Datum with associated ellipsoid"
-msgstr ""
+msgstr "संबद्ध दीर्घवृत्ताभ (ellipsoid) के साथ डेटम"
 
 #: ../gui/wxpython/location_wizard/wizard.py:861
 msgid "Ellipsoid only"
@@ -8426,7 +8439,7 @@ msgstr ""
 
 #: ../gui/wxpython/location_wizard/wizard.py:1081
 msgid "Datum code:"
-msgstr ""
+msgstr "डेटम कोड (Datum code):"
 
 #: ../gui/wxpython/location_wizard/wizard.py:1242
 msgid "Specify ellipsoid"
@@ -8502,7 +8515,7 @@ msgstr ""
 #: ../gui/wxpython/location_wizard/wizard.py:2130
 #: ../gui/wxpython/location_wizard/wizard.py:2134
 msgid "Datum transform is required."
-msgstr ""
+msgstr "डेटम ट्रांसफ़ॉर्म आवश्यक है।"
 
 #: ../gui/wxpython/location_wizard/wizard.py:2178
 #: ../gui/wxpython/rlisetup/wizard.py:1947
@@ -8728,7 +8741,7 @@ msgstr "केंद्र बिंदु से डिस्प्ले आ�
 
 #: ../gui/wxpython/mapdisp/properties.py:157
 msgid "Constrain display resolution to computational region settings. Default value for new map displays can be set up in 'User GUI settings' dialog."
-msgstr "डिस्प्ले रिज़ॉल्यूशन को कम्प्यूटेशनल क्षेत्र सेटिंग्स तक सीमित रखें। नए मानचित्र डिस्प्ले के लिए डिफ़ॉल्ट मान 'उपयोगकर्ता जीयूआई सेटिंग्स' संवाद में सेट किया जा सकता है।"
+msgstr "डिस्प्ले रिज़ॉल्यूशन को कम्प्यूटेशनल क्षेत्र सेटिंग्स तक सीमित रखें। नए मैप डिस्प्ले के लिए डिफ़ॉल्ट मान 'यूजर GUI सेटिंग्स' डायलॉग में सेट किया जा सकता है।"
 
 #: ../gui/wxpython/mapdisp/properties.py:195
 msgid "Show computational extent"
@@ -8790,7 +8803,7 @@ msgstr ""
 
 #: ../gui/wxpython/mapdisp/statusbar.py:730
 msgid "Coordinates"
-msgstr "कोआर्डिनेट"
+msgstr "निर्देशांक (Coordinates)"
 
 #: ../gui/wxpython/mapdisp/statusbar.py:814
 msgid "Display extent"
@@ -8886,11 +8899,11 @@ msgstr ""
 
 #: ../gui/wxpython/mapdisp/toolbars.py:51
 msgid "Create bivariate scatterplot of raster maps"
-msgstr ""
+msgstr "रास्टर मैप्स का बाइवेरिएट (bivariate) स्कैटरप्लॉट बनाएं"
 
 #: ../gui/wxpython/mapdisp/toolbars.py:55
 msgid "Create histogram of raster map"
-msgstr ""
+msgstr "रास्टर मैप का हिस्टोग्राम बनाएं"
 
 #: ../gui/wxpython/mapdisp/toolbars.py:57
 msgid "Vector network analysis tool"
@@ -9105,7 +9118,7 @@ msgstr ""
 
 #: ../gui/wxpython/mapwin/buffered.py:281
 msgid "Copy coordinates to clipboard"
-msgstr "निर्देशांक को क्लिपबोर्ड पर कॉपी करें"
+msgstr "निर्देशांक क्लिपबोर्ड पर कॉपी करें"
 
 #: ../gui/wxpython/mapwin/buffered.py:315
 msgid "Resize and move legend"
@@ -9290,7 +9303,7 @@ msgstr ""
 
 #: ../gui/wxpython/modules/colorrules.py:870
 msgid "Create new color table for raster map"
-msgstr ""
+msgstr "रास्टर मैप के लिए नई रंग टेबल बनाएं"
 
 #: ../gui/wxpython/modules/colorrules.py:964
 msgid "Enter raster category values or percents"
@@ -9314,7 +9327,7 @@ msgstr ""
 
 #: ../gui/wxpython/modules/colorrules.py:1076
 msgid "Create new color rules for vector map"
-msgstr ""
+msgstr "वेक्टर मैप के लिए नए रंग नियम बनाएं"
 
 #: ../gui/wxpython/modules/colorrules.py:1088
 #: ../gui/wxpython/modules/colorrules.py:1670
@@ -9378,7 +9391,7 @@ msgstr ""
 #: ../gui/wxpython/modules/colorrules.py:1239
 #, python-format
 msgid "Database connection for vector map <%s> is not defined in DB file.  Do you want to create and connect new attribute table?"
-msgstr ""
+msgstr "वेक्टर मैप <%s> के लिए डेटाबेस कनेक्शन DB फ़ाइल में परिभाषित नहीं है। क्या आप एक नई एट्रिब्यूट टेबल बनाना और कनेक्ट करना चाहते हैं?"
 
 #: ../gui/wxpython/modules/colorrules.py:1244
 msgid "No database connection defined"
@@ -9636,11 +9649,11 @@ msgstr ""
 
 #: ../gui/wxpython/modules/import_export.py:754
 msgid "Define output format for vector data"
-msgstr ""
+msgstr "वेक्टर डेटा के लिए आउटपुट फ़ॉर्मेट परिभाषित करें"
 
 #: ../gui/wxpython/modules/import_export.py:756
 msgid "Define output format for raster data"
-msgstr ""
+msgstr "रास्टर डेटा के लिए आउटपुट फ़ॉर्मेट परिभाषित करें"
 
 #: ../gui/wxpython/modules/import_export.py:764
 msgid "Set external format and close dialog"
@@ -10172,7 +10185,7 @@ msgstr "एनिमेशन"
 
 #: ../gui/wxpython/nviz/tools.py:314
 msgid "Control View"
-msgstr "नियंत्रण दृश्य"
+msgstr "कंट्रोल व्यू"
 
 #: ../gui/wxpython/nviz/tools.py:336
 msgid "Adjusts the distance and angular perspective of the image viewpoint"
@@ -10272,7 +10285,7 @@ msgstr ""
 
 #: ../gui/wxpython/nviz/tools.py:753 ../gui/wxpython/nviz/tools.py:1435
 msgid "Constant surface"
-msgstr "स्थिर सतह"
+msgstr "स्थिर सतह (Constant surface)"
 
 #: ../gui/wxpython/nviz/tools.py:817
 msgid "Fringe"
@@ -10280,7 +10293,7 @@ msgstr ""
 
 #: ../gui/wxpython/nviz/tools.py:862 ../gui/wxpython/nviz/tools.py:1187
 msgid "Cutting planes"
-msgstr ""
+msgstr "कटिंग प्लेन्स (Cutting planes)"
 
 #: ../gui/wxpython/nviz/tools.py:939 ../gui/wxpython/nviz/tools.py:1206
 #: ../gui/wxpython/nviz/tools.py:1998
@@ -10416,7 +10429,7 @@ msgstr ""
 #: ../gui/wxpython/nviz/tools.py:1451 ../gui/wxpython/nviz/tools.py:2484
 #: ../gui/wxpython/nviz/tools.py:2546 ../gui/wxpython/psmap/dialogs.py:1859
 msgid "Delete"
-msgstr ""
+msgstr "हटाएं"
 
 #: ../gui/wxpython/nviz/tools.py:1463
 msgid "Fine resolution:"
@@ -11089,7 +11102,7 @@ msgstr ""
 
 #: ../gui/wxpython/psmap/dialogs.py:1819
 msgid "Data Type"
-msgstr ""
+msgstr "डेटा टाइप"
 
 #: ../gui/wxpython/psmap/dialogs.py:1846
 msgid "Manage vector maps"
@@ -11128,7 +11141,7 @@ msgstr "%s संपत्तियां"
 
 #: ../gui/wxpython/psmap/dialogs.py:2264
 msgid "Data selection"
-msgstr ""
+msgstr "डेटा चयन"
 
 #: ../gui/wxpython/psmap/dialogs.py:2277
 msgid "centroids"
@@ -11144,7 +11157,7 @@ msgstr ""
 
 #: ../gui/wxpython/psmap/dialogs.py:2312
 msgid "Database connection is not defined in DB file."
-msgstr ""
+msgstr "डेटाबेस कनेक्शन DB फ़ाइल में परिभाषित नहीं है।"
 
 #: ../gui/wxpython/psmap/dialogs.py:2314
 msgid "Select layer:"
@@ -11527,7 +11540,7 @@ msgstr ""
 
 #: ../gui/wxpython/psmap/dialogs.py:5881 ../gui/wxpython/psmap/dialogs.py:6392
 msgid "Counterclockwise rotation in degrees"
-msgstr ""
+msgstr "डिग्री में वामावर्त (Counterclockwise) घुमाव"
 
 #: ../gui/wxpython/psmap/dialogs.py:5982
 msgid ""
@@ -11886,7 +11899,7 @@ msgstr "मैप फ्रेम लगाने के लिए क्लि�
 
 #: ../gui/wxpython/psmap/toolbars.py:94
 msgid "Delete selected object"
-msgstr ""
+msgstr "चयनित ऑब्जेक्ट हटाएं"
 
 #: ../gui/wxpython/psmap/toolbars.py:96
 msgid "Show preview"
@@ -12006,7 +12019,7 @@ msgstr ""
 
 #: ../gui/wxpython/rdigit/dialogs.py:34
 msgid "Create new raster map"
-msgstr ""
+msgstr "नया रास्टर मैप बनाएं"
 
 #: ../gui/wxpython/rdigit/dialogs.py:54
 msgid "Name for new raster map:"
@@ -12115,11 +12128,11 @@ msgstr ""
 
 #: ../gui/wxpython/rlisetup/frame.py:159
 msgid "Create"
-msgstr ""
+msgstr "बनाएं"
 
 #: ../gui/wxpython/rlisetup/frame.py:160
 msgid "Create a new configuration file"
-msgstr ""
+msgstr "एक नई कॉन्फ़िगरेशन फ़ाइल बनाएं"
 
 #: ../gui/wxpython/rlisetup/frame.py:162
 msgid "Rename a configuration file"
@@ -12221,7 +12234,7 @@ msgstr ""
 
 #: ../gui/wxpython/rlisetup/wizard.py:72
 msgid "Create new configuration file for r.li modules"
-msgstr ""
+msgstr "r.li मॉड्यूल के लिए नई कॉन्फ़िगरेशन फ़ाइल बनाएं"
 
 #: ../gui/wxpython/rlisetup/wizard.py:137
 #, python-format
@@ -12230,7 +12243,7 @@ msgstr ""
 
 #: ../gui/wxpython/rlisetup/wizard.py:139
 msgid "Create new r.li configuration file?"
-msgstr ""
+msgstr "नई r.li कॉन्फ़िगरेशन फ़ाइल बनाएं?"
 
 #: ../gui/wxpython/rlisetup/wizard.py:155
 msgid "r.li.setup wizard canceled. Configuration file not created."
@@ -12258,7 +12271,7 @@ msgstr ""
 
 #: ../gui/wxpython/rlisetup/wizard.py:593
 msgid "Define sampling region (region for analysis)"
-msgstr ""
+msgstr "सैंपलिंग क्षेत्र (विश्लेषण के लिए क्षेत्र) परिभाषित करें"
 
 #: ../gui/wxpython/rlisetup/wizard.py:595
 #: ../gui/wxpython/rlisetup/wizard.py:982
@@ -12632,6 +12645,9 @@ msgid ""
 "\n"
 "Enter new name:"
 msgstr ""
+"वर्तमान नाम: {}\n"
+"\n"
+"नया नाम दर्ज करें:"
 
 #: ../gui/wxpython/startup/guiutils.py:256
 msgid ""
@@ -12696,7 +12712,7 @@ msgstr ""
 
 #: ../gui/wxpython/startup/guiutils.py:396
 msgid "Delete selected mapsets"
-msgstr ""
+msgstr "चयनित मानचित्रों को हटाएं"
 
 #: ../gui/wxpython/startup/guiutils.py:409
 msgid "Error when deleting mapsets"
@@ -12743,7 +12759,7 @@ msgstr ""
 
 #: ../gui/wxpython/startup/guiutils.py:481
 msgid "Delete selected projects"
-msgstr ""
+msgstr "चयनित परियोजनाएँ हटाएँ"
 
 #: ../gui/wxpython/startup/guiutils.py:494
 msgid "Error when deleting projects"
@@ -12790,7 +12806,7 @@ msgstr ""
 
 #: ../gui/wxpython/startup/guiutils.py:546
 msgid "Delete selected GRASS database"
-msgstr ""
+msgstr "चयनित GRASS डेटाबेस हटाएं"
 
 #: ../gui/wxpython/startup/guiutils.py:558
 msgid "Error when deleting GRASS database"
@@ -12836,7 +12852,7 @@ msgstr ""
 #: ../gui/wxpython/startup/guiutils.py:659
 #, python-format
 msgid "Data file <%(name)s> imported successfully. The project's default region was set from this imported map."
-msgstr ""
+msgstr "डेटा फ़ाइल <%(name)s> सफलतापूर्वक इंपोर्ट की गई। इस इंपोर्ट किए गए मैप से प्रोजेक्ट का डिफ़ॉल्ट क्षेत्र (region) सेट किया गया था।"
 
 #: ../gui/wxpython/startup/guiutils.py:690
 #, python-format
@@ -12845,6 +12861,9 @@ msgid ""
 "Current project is <%(loc)s>.\n"
 "Current mapset is <%(mapset)s>."
 msgstr ""
+"वर्तमान GRASS डेटाबेस <%(dbase)s> है।\n"
+"वर्तमान प्रोजेक्ट <%(loc)s> है।\n"
+"वर्तमान मैपसेट <%(mapset)s> है।"
 
 #: ../gui/wxpython/startup/guiutils.py:708
 #, python-format
@@ -12852,11 +12871,13 @@ msgid ""
 "Current project is <%(loc)s>.\n"
 "Current mapset is <%(mapset)s>."
 msgstr ""
+"वर्तमान प्रोजेक्ट <%(loc)s> है।\n"
+"वर्तमान मैपसेट <%(mapset)s> है।"
 
 #: ../gui/wxpython/startup/guiutils.py:719
 #, python-format
 msgid "Current mapset is <%s>."
-msgstr ""
+msgstr "वर्तमान मैपसेट <%s> है।"
 
 #: ../gui/wxpython/startup/locdownload.py:152
 msgid "Download in progress, wait until it is finished 0%"
@@ -12925,7 +12946,7 @@ msgstr ""
 
 #: ../gui/wxpython/startup/locdownload.py:440
 msgid "Dataset Download"
-msgstr ""
+msgstr "डेटासेट डाउनलोड"
 
 #: ../gui/wxpython/startup/locdownload.py:448
 msgid "Download selected dataset"
@@ -12963,22 +12984,22 @@ msgstr ""
 #: ../gui/wxpython/tplot/frame.py:569
 #, python-format
 msgid "Dataset <%s> not found in temporal database"
-msgstr ""
+msgstr "टेम्पोरल डेटाबेस में डेटासेट <%s> नहीं मिला"
 
 #: ../gui/wxpython/timeline/frame.py:201 ../gui/wxpython/tplot/frame.py:455
 #: ../gui/wxpython/tplot/frame.py:593
 msgid "Datasets have different temporal type (absolute x relative), which is not allowed."
-msgstr ""
+msgstr "डेटासेट का टेम्पोरल टाइप भिन्न (पूर्ण बनाम सापेक्ष) है, जिसकी अनुमति नहीं है।"
 
 #: ../gui/wxpython/timeline/frame.py:222 ../gui/wxpython/tplot/frame.py:477
 #: ../gui/wxpython/tplot/frame.py:606
 msgid "Datasets have different time unit which is not allowed."
-msgstr ""
+msgstr "डेटासेट में अलग-अलग समय इकाइयाँ (time units) हैं, जिसकी अनुमति नहीं है।"
 
 #: ../gui/wxpython/timeline/frame.py:244
 #, python-brace-format
 msgid "Dataset <{name}> is empty"
-msgstr ""
+msgstr "डेटासेट <{name}> खाली है"
 
 #: ../gui/wxpython/timeline/frame.py:301
 #, python-format
@@ -13084,7 +13105,7 @@ msgstr ""
 
 #: ../gui/wxpython/tplot/frame.py:225
 msgid "Coordinates can be obtained for example by right-clicking on Map Display."
-msgstr "उदाहरण के लिए मानचित्र प्रदर्शन पर राइट-क्लिक करके निर्देशांक प्राप्त किए जा सकते हैं।"
+msgstr "उदाहरण के लिए मैप डिस्प्ले पर राइट-क्लिक करके निर्देशांक प्राप्त किए जा सकते हैं।"
 
 #: ../gui/wxpython/tplot/frame.py:232 ../gui/wxpython/tplot/frame.py:298
 msgid "Show simple linear regression line"
@@ -13221,7 +13242,7 @@ msgstr ""
 
 #: ../gui/wxpython/tplot/frame.py:1329
 msgid "Datasets have different number of values"
-msgstr ""
+msgstr "डेटासेट में मानों की संख्या भिन्न है"
 
 #: ../gui/wxpython/tplot/frame.py:1362
 #, python-brace-format
@@ -13501,11 +13522,11 @@ msgstr ""
 
 #: ../gui/wxpython/vdigit/preferences.py:583
 msgid "Delete existing feature(s)"
-msgstr ""
+msgstr "मौजूदा फीचर (features) हटाएं"
 
 #: ../gui/wxpython/vdigit/preferences.py:589
 msgid "Delete record from table"
-msgstr ""
+msgstr "टेबल से रिकॉर्ड हटाएं"
 
 #: ../gui/wxpython/vdigit/preferences.py:606
 msgid "Geometry attributes"
@@ -13649,11 +13670,11 @@ msgstr ""
 
 #: ../gui/wxpython/vdigit/toolbars.py:186
 msgid "Delete selected point(s), line(s), boundary(ies) or centroid(s) (Ctrl+D)"
-msgstr ""
+msgstr "चयनित बिंदु(ओं), रेखा(ओं), सीमा(ओं) या केन्द्रक(ओं) को मिटाएँ (Ctrl+D)"
 
 #: ../gui/wxpython/vdigit/toolbars.py:193
 msgid "Delete selected area(s) (Ctrl+F)"
-msgstr ""
+msgstr "चयनित क्षेत्र (क्षेत्रों) को हटाएं (Ctrl+F)"
 
 #: ../gui/wxpython/vdigit/toolbars.py:198
 msgid "Display/update attributes (Ctrl+K)"
@@ -13734,19 +13755,19 @@ msgstr "प्रतिच्छेदन पर चयनित रेखाए
 
 #: ../gui/wxpython/vdigit/toolbars.py:718
 msgid "Connect selected lines/boundaries"
-msgstr "चयनित लाइनों/सीमाओं को कनेक्ट करें"
+msgstr "चयनित लाइनों/सीमाओं को जोड़ें"
 
 #: ../gui/wxpython/vdigit/toolbars.py:723
 msgid "Copy categories"
-msgstr "श्रेणियाँ कॉपी करें"
+msgstr "श्रेणियां (categories) कॉपी करें"
 
 #: ../gui/wxpython/vdigit/toolbars.py:725
 msgid "Copy features from (background) vector map"
-msgstr "(पृष्ठभूमि) वेक्टर मानचित्र से सुविधाएँ कॉपी करें"
+msgstr "(पृष्ठभूमि) वेक्टर मैप से सुविधाएँ (features) कॉपी करें"
 
 #: ../gui/wxpython/vdigit/toolbars.py:730
 msgid "Copy attributes"
-msgstr "विशेषताएँ कॉपी करें"
+msgstr "एट्रिब्यूट्स कॉपी करें"
 
 #: ../gui/wxpython/vdigit/toolbars.py:732
 msgid "Feature type conversion"
@@ -13862,7 +13883,7 @@ msgstr ""
 #: ../gui/wxpython/vdigit/wxdigit.py:218
 #, python-format
 msgid "Database link %d not available. Operation canceled."
-msgstr ""
+msgstr "डेटाबेस लिंक %d उपलब्ध नहीं है। ऑपरेशन रद्द कर दिया गया।"
 
 #: ../gui/wxpython/vdigit/wxdigit.py:226
 #, python-format
@@ -13961,7 +13982,7 @@ msgstr ""
 
 #: ../gui/wxpython/vnet/dialogs.py:725
 msgid "Creating turntable..."
-msgstr ""
+msgstr "टर्नटेबल बनाया जा रहा है..।"
 
 #: ../gui/wxpython/vnet/dialogs.py:896
 msgid "Input vector map does not exist."
@@ -14043,7 +14064,7 @@ msgstr ""
 
 #: ../gui/wxpython/vnet/dialogs.py:1813
 msgid "Define Global Turn Costs"
-msgstr ""
+msgstr "ग्लोबल टर्न कॉस्ट्स परिभाषित करें"
 
 #: ../gui/wxpython/vnet/toolbars.py:50
 msgid "Insert points from Map Display"
@@ -14067,7 +14088,7 @@ msgstr "नया बिंदु जोड़ें"
 
 #: ../gui/wxpython/vnet/toolbars.py:60
 msgid "Delete selected point"
-msgstr ""
+msgstr "चयनित बिंदुओं को हटाएं"
 
 #: ../gui/wxpython/vnet/toolbars.py:123
 msgid "Execute analysis"
@@ -14131,7 +14152,7 @@ msgstr ""
 
 #: ../gui/wxpython/vnet/vnet_core.py:308
 msgid "Creation of turntable failed."
-msgstr ""
+msgstr "टर्नटेबल का निर्माण विफल रहा।"
 
 #: ../gui/wxpython/vnet/vnet_core.py:327
 msgid "Vector map with analysis result does not exist."
@@ -14336,7 +14357,7 @@ msgstr ""
 #: ../gui/wxpython/vnet/vnet_data.py:789
 #, python-format
 msgid "Cost isolines %s"
-msgstr "लागत समरेखाएं %s"
+msgstr "कॉस्ट आइसोलाइन्स %s"
 
 #: ../gui/wxpython/vnet/vnet_data.py:867
 msgid "Overwrite map layer"
@@ -14393,7 +14414,7 @@ msgstr ""
 #: ../gui/wxpython/web_services/dialogs.py:380
 #, python-format
 msgid "Connecting to <%s>..."
-msgstr "<%s> से कनेक्ट हो रहा है..।"
+msgstr "<%s> से कनेक्ट किया जा रहा है..।"
 
 #: ../gui/wxpython/web_services/dialogs.py:448
 msgid "Available web services"
@@ -14402,7 +14423,7 @@ msgstr "उपलब्ध वेब सेवाएँ (Available web services)
 #: ../gui/wxpython/web_services/dialogs.py:463
 #, python-format
 msgid "Connected to <%s>"
-msgstr "<%s> से जुड़ा हुआ"
+msgstr "<%s> से कनेक्ट किया गया"
 
 #: ../gui/wxpython/web_services/dialogs.py:470
 #, python-format
@@ -14533,11 +14554,11 @@ msgstr ""
 
 #: ../gui/wxpython/web_services/widgets.py:283
 msgid "Cubic interpolation"
-msgstr ""
+msgstr "क्यूबिक इंटरपोलेशन"
 
 #: ../gui/wxpython/web_services/widgets.py:284
 msgid "Cubic spline interpolation"
-msgstr ""
+msgstr "क्यूबिक स्पलाइन इंटरपोलेशन"
 
 #: ../gui/wxpython/web_services/widgets.py:291
 msgid "Maximum columns to request from server at time:"
@@ -14666,7 +14687,7 @@ msgstr "कॉपी (&C)"
 
 #: ../gui/wxpython/wxplot/dialogs.py:357
 msgid "Copy regression statistics the clipboard (Ctrl+C)"
-msgstr "प्रतिगमन सांख्यिकी को क्लिपबोर्ड पर कॉपी करें (Ctrl+C)"
+msgstr "रिग्रेशन आंकड़े क्लिपबोर्ड पर कॉपी करें (Ctrl+C)"
 
 #: ../gui/wxpython/wxplot/dialogs.py:385
 msgid "Regression statistics copied to clipboard"
@@ -14783,11 +14804,11 @@ msgstr "स्वचालित अक्ष स्केलिंग (Automati
 
 #: ../gui/wxpython/wxplot/dialogs.py:1216
 msgid "Custom min"
-msgstr ""
+msgstr "कस्टम न्यूनतम (Custom min)"
 
 #: ../gui/wxpython/wxplot/dialogs.py:1224
 msgid "Custom max"
-msgstr ""
+msgstr "कस्टम अधिकतम (Custom max)"
 
 #: ../gui/wxpython/wxplot/dialogs.py:1232
 msgid "Log scale"

--- a/locale/tbx/grassglossary_ar.tbx
+++ b/locale/tbx/grassglossary_ar.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_bn.tbx
+++ b/locale/tbx/grassglossary_bn.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_cs.tbx
+++ b/locale/tbx/grassglossary_cs.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_de.tbx
+++ b/locale/tbx/grassglossary_de.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
                 <langSet xml:lang="de"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_el.tbx
+++ b/locale/tbx/grassglossary_el.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="el"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_es.tbx
+++ b/locale/tbx/grassglossary_es.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>línea</term></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
                 <langSet xml:lang="es"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_fi.tbx
+++ b/locale/tbx/grassglossary_fi.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_fr.tbx
+++ b/locale/tbx/grassglossary_fr.tbx
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Entité</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Écart-type</term></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>topologie</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>légende</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>kilomètres</term></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>couche</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>mètres</term></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>projet</term></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>SCR</term></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>sommet</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Coordonnées</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Projection</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>polygone</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>ligne</term></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>ligne</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>système de coordonnées de référence</term></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>SCR</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="fr"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>quantile</term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>JSON</term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>netCDF</term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_hi.tbx
+++ b/locale/tbx/grassglossary_hi.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
                 <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_hu.tbx
+++ b/locale/tbx/grassglossary_hu.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_id.tbx
+++ b/locale/tbx/grassglossary_id.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
                 <langSet xml:lang="id"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_it.tbx
+++ b/locale/tbx/grassglossary_it.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="it"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ja.tbx
+++ b/locale/tbx/grassglossary_ja.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ko.tbx
+++ b/locale/tbx/grassglossary_ko.tbx
@@ -12,7 +12,7 @@
         <body>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
@@ -20,7 +20,149 @@
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_lv.tbx
+++ b/locale/tbx/grassglossary_lv.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ml.tbx
+++ b/locale/tbx/grassglossary_ml.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_pl.tbx
+++ b/locale/tbx/grassglossary_pl.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_pt.tbx
+++ b/locale/tbx/grassglossary_pt.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_pt_BR.tbx
+++ b/locale/tbx/grassglossary_pt_BR.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>linha</term></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ro.tbx
+++ b/locale/tbx/grassglossary_ro.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ru.tbx
+++ b/locale/tbx/grassglossary_ru.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_si.tbx
+++ b/locale/tbx/grassglossary_si.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="si"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_sl.tbx
+++ b/locale/tbx/grassglossary_sl.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_sv.tbx
+++ b/locale/tbx/grassglossary_sv.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_ta.tbx
+++ b/locale/tbx/grassglossary_ta.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
                 <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_th.tbx
+++ b/locale/tbx/grassglossary_th.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
                 <langSet xml:lang="th"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_tr.tbx
+++ b/locale/tbx/grassglossary_tr.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_uk.tbx
+++ b/locale/tbx/grassglossary_uk.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_vi.tbx
+++ b/locale/tbx/grassglossary_vi.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
                 <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/tbx/grassglossary_zh_Hans.tbx
+++ b/locale/tbx/grassglossary_zh_Hans.tbx
@@ -16,11 +16,153 @@
             </termEntry>
             <termEntry id="The name of this project. Do not use GRASS GIS for 8.5 and later">
                 <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
-                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
             </termEntry>
             <termEntry>
                 <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Feature</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Standard deviation</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>https://en.wikipedia.org/wiki/Standard_deviation</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>topology</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>legend</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>layer</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>meters</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>Localized units</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>kilometers</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <note from="translator">Localized units</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>project</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <note from="translator">A project, previously called a location in GRASS.</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>node</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry id="coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system">
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>coordinate reference system, we use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_systeM</descrip>
+            </termEntry>
+            <termEntry id="Need to distinguish between meanings of map, and the verb.">
+                <langSet xml:lang="en"><tig><term>map</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>label</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>vertex</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Coordinates</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Projection</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>polygon</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term>polygon</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>Feature type1</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term>line</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>point</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term>point</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>face</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term>face</term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>Line of a file</descrip>
+            </termEntry>
+            <termEntry id="Feature type">
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry id="1">
+                <langSet xml:lang="en"><tig><term>coordinate reference system</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+                <descrip>We use CRS instead of SRS https://en.wikipedia.org/wiki/Spatial_reference_system</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>CRS</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term/></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>line</term></tig></langSet>
                 <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+                <descrip>Feature type</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>quantile</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+                <note from="translator">Statistical measure</note>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>raster</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JavaScript Object Notation</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>JSON</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+                <descrip>JavaScript Object Notation, should be in uppercase</descrip>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>netCDF</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+                <note from="translator">File format</note>
+                <descrip>File format, Network Common Data Form, with lowercase n when not at the beginning of a sentence (in English)</descrip>
             </termEntry>
         </body>
     </text>

--- a/locale/templates/ar.tbx
+++ b/locale/templates/ar.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ar"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/bn.tbx
+++ b/locale/templates/bn.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="bn"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/cs.tbx
+++ b/locale/templates/cs.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="cs"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/de.tbx
+++ b/locale/templates/de.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="de"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/el.tbx
+++ b/locale/templates/el.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="el"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/es.tbx
+++ b/locale/templates/es.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="es"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/fi.tbx
+++ b/locale/templates/fi.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="fi"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/fr.tbx
+++ b/locale/templates/fr.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="fr"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/hi.tbx
+++ b/locale/templates/hi.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="hi"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/hu.tbx
+++ b/locale/templates/hu.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="hu"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/id.tbx
+++ b/locale/templates/id.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="id"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/it.tbx
+++ b/locale/templates/it.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="it"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ja.tbx
+++ b/locale/templates/ja.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ja"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ko.tbx
+++ b/locale/templates/ko.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ko"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/lv.tbx
+++ b/locale/templates/lv.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="lv"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ml.tbx
+++ b/locale/templates/ml.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ml"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/pl.tbx
+++ b/locale/templates/pl.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="pl"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/pt.tbx
+++ b/locale/templates/pt.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="pt"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/pt_BR.tbx
+++ b/locale/templates/pt_BR.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="pt_BR"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ro.tbx
+++ b/locale/templates/ro.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ro"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ru.tbx
+++ b/locale/templates/ru.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ru"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/si.tbx
+++ b/locale/templates/si.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="si"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/sl.tbx
+++ b/locale/templates/sl.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="sl"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/sv.tbx
+++ b/locale/templates/sv.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="sv"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/ta.tbx
+++ b/locale/templates/ta.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="ta"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/th.tbx
+++ b/locale/templates/th.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="th"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/tr.tbx
+++ b/locale/templates/tr.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="tr"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/uk.tbx
+++ b/locale/templates/uk.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="uk"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/vi.tbx
+++ b/locale/templates/vi.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="vi"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>

--- a/locale/templates/zh_Hans.tbx
+++ b/locale/templates/zh_Hans.tbx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE martif PUBLIC "ISO 12200:1999A//DTD MARTIF core (DXFcdV04)//EN" "TBXcdv04.dtd">
+<martif type="TBX" xml:lang="en">
+    <martifHeader>
+        <fileDesc>
+            <sourceDesc>
+                <p>Translate Toolkit</p>
+            </sourceDesc>
+        </fileDesc>
+    </martifHeader>
+    <text>
+        <body>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Raster</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term>Raster</term></tig></langSet>
+            </termEntry>
+            <termEntry>
+                <langSet xml:lang="en"><tig><term>Vector</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+            </termEntry>
+            <termEntry id="The name of this project">
+                <langSet xml:lang="en"><tig><term>GRASS</term></tig></langSet>
+                <langSet xml:lang="zh_Hans"><tig><term></term></tig></langSet>
+            </termEntry>
+        </body>
+    </text>
+</martif>


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GRASS GIS/grasslibs](https://weblate.osgeo.org/projects/grass-gis/grasslibs/).


It also includes following components:

* [GRASS GIS/grassmods](https://weblate.osgeo.org/projects/grass-gis/grassmods/)

* [GRASS GIS/grasswxpy](https://weblate.osgeo.org/projects/grass-gis/grasswxpy/)

* [GRASS GIS/grassglossary](https://weblate.osgeo.org/projects/grass-gis/grassglossary/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/grass-gis/grasslibs/horizontal-auto.svg)