### PR TITLE
CI(docker): Add missing `artifact-metadata: write` permission

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,7 @@ jobs:
               GUI=with
 
     permissions:
+      artifact-metadata: write # For actions/attest-build-provenance
       attestations: write
       contents: read
       id-token: write


### PR DESCRIPTION
Since v3 of [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance), a new permission is needed to push the attestation to the registry.

The warnings show up in existing CI Docker builds like in the following screenshots:
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/b5bfd992-badd-42cc-a148-5fc542cdc2cd" />
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/4a02ecc9-7ae7-46e3-8518-e1014db8f0d6" />
