### PR TITLE
CI(macOS): Change removed macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -37,7 +37,7 @@ jobs:
           - "arm64"
         include:
           - name: "x86_64"
-            os: macos-13
+            os: macos-15-intel
             deployment_target: 10.13
           - name: "arm64"
             os: macos-14


### PR DESCRIPTION
This might not be enough to work properly, and it won't run on PRs, but the runner is now completely removed, and the jobs aren't running at all now.

Using macos-13 is now an invalid value that is blocking https://github.com/OSGeo/grass/pull/6781 and https://github.com/OSGeo/grass/pull/6847 for a while now.

See https://github.com/actions/runner-images/issues/13046

<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/07bf2a3b-a553-4cb9-99f2-0bd5b1d2d5c4" />
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/bdfd6142-7356-4269-b4b8-1c4723c5928b" />
