### PR TITLE
docker: Pin wxpython version for keeping version with wheels available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ ARG GDAL_VERSION=3.12.1
 ARG PDAL_VERSION=2.9.2
 # renovate: datasource=github-tags depName=OSGeo/gdal-grass
 ARG GDAL_GRASS_VERSION=2.0.0
+# renovate: datasource=pypi depName=wxPython
+ARG WXPYTHON_VERSION=4.2.4
 
 # Have build parameters as build arguments?
 # ARG LDFLAGS="-s -Wl,--no-undefined -lblas"
@@ -339,7 +341,7 @@ RUN echo "Installing GRASS GUI packages: $GRASS_GUI_PACKAGES" \
     $GRASS_GUI_PACKAGES \
     && python3 -m pip install  -U --break-system-packages --no-cache-dir --upgrade \
     -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 \
-    wxpython \
+    "wxpython==${WXPYTHON_VERSION}" \
     # Clean up
     && pip cache purge \
     && apt-get autoremove -y \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -18,6 +18,8 @@ ARG GDAL_VERSION=3.12.1
 ARG PDAL_VERSION=2.9.2
 # renovate: datasource=github-tags depName=OSGeo/gdal-grass
 ARG GDAL_GRASS_VERSION=2.0.0
+# renovate: datasource=pypi depName=wxPython
+ARG WXPYTHON_VERSION=4.2.4
 
 # Have build parameters as build arguments?
 # ARG LDFLAGS="-s -Wl,--no-undefined -lblas"
@@ -339,7 +341,7 @@ RUN echo "Installing GRASS GUI packages: $GRASS_GUI_PACKAGES" \
     $GRASS_GUI_PACKAGES \
     && python3 -m pip install  -U --break-system-packages --no-cache-dir --upgrade \
     -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04 \
-    wxpython \
+    "wxpython==${WXPYTHON_VERSION}" \
     # Clean up
     && pip cache purge \
     && apt-get autoremove -y \


### PR DESCRIPTION
On wxPython 4.2.5 release, wheels were not immediately available. To prevent from happening again (and fixing failing builds), pin to 4.2.4 and let renovate open a PR for us to upgrade when we are ready.

The failure can be seen here, as a new release was just made 1-2h before that job: https://github.com/OSGeo/grass/actions/runs/21805436306/job/62907914975?pr=7057