### PR TITLE
tests: temporarily disable test of g.extension for Windows

### DIFF
--- a/scripts/g.extension/tests/g_extension_test.py
+++ b/scripts/g.extension/tests/g_extension_test.py
@@ -1,8 +1,10 @@
 """Test g.extension"""
 
 import pytest
+import sys
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Temporarily disable tests.")
 # This should cover both C and Python tools.
 @pytest.mark.parametrize("name", ["r.stream.distance", "r.lake.series"])
 def test_install(tools, name):


### PR DESCRIPTION
Temporarily disable test of `g.extension` for Windows, which with the absence of 8.6 Addons for Windows is known to fail.

This is an urgent temporary "fix" to enable normal merging of PRs.