### PR TITLE
cmake: add relevant files to IDE, consolidate Tools FOLDERS

### DIFF
--- a/cmake/modules/build_addon.cmake
+++ b/cmake/modules/build_addon.cmake
@@ -186,6 +186,7 @@ function(_build_addon)
         WORLD_EXECUTE)
 
     add_custom_target(${G_NAME} ALL)
+    target_sources(${G_NAME} PRIVATE ${G_SRC_DIR}/${G_NAME}.py)
 
     if(WIN32)
       install(PROGRAMS ${OUTDIR}/${GRASSAddon_ScriptDIR}/${G_NAME}.bat
@@ -285,6 +286,7 @@ function(_build_addon)
       COMMENT "Creating ${OUT_HTML_FILE}")
 
     add_custom_target(${G_NAME}-docs ALL DEPENDS ${G_NAME} ${_out_html_file})
+    target_sources(${G_NAME}-docs PRIVATE ${html_doc} ${md_doc} ${img_files})
 
     install(FILES ${_out_html_file} DESTINATION ${GRASSAddon_DocDIR})
   endif()

--- a/cmake/modules/build_gui_in_subdir.cmake
+++ b/cmake/modules/build_gui_in_subdir.cmake
@@ -99,7 +99,7 @@ function(build_gui_in_subdir dir_name)
       "${G_TARGET_NAME};${modules_list}"
       CACHE INTERNAL "list of modules")
 
-  set_target_properties(${G_TARGET_NAME} PROPERTIES FOLDER "Tools/GUI (Scripts)")
+  set_target_properties(${G_TARGET_NAME} PROPERTIES FOLDER "Tools/GUI")
 
   if(WIN32)
     install(PROGRAMS ${OUTDIR}/${GRASS_INSTALL_SCRIPTDIR}/${G_TARGET_NAME}.bat

--- a/cmake/modules/build_module.cmake
+++ b/cmake/modules/build_module.cmake
@@ -32,7 +32,7 @@ function(build_module)
   endforeach()
 
   if(NOT G_SRC_REGEX)
-    set(G_SRC_REGEX "*.c")
+    set(G_SRC_REGEX "*.[ch]")
   endif()
 
   if(NOT G_SRC_DIR)
@@ -171,7 +171,7 @@ function(build_module)
   get_property(MODULE_LIST GLOBAL PROPERTY MODULE_LIST)
   set_property(GLOBAL PROPERTY MODULE_LIST "${MODULE_LIST};${G_NAME}")
 
-  add_dependencies(${G_NAME} copy_header)
+  add_dependencies(${G_NAME} INCLUDE_HEADERS)
 
   foreach(G_OPTIONAL_DEPEND ${G_OPTIONAL_DEPENDS})
     if(TARGET ${G_OPTIONAL_DEPEND})
@@ -290,4 +290,11 @@ function(build_module)
     install(TARGETS ${G_NAME} DESTINATION ${install_dest})
   endif()
 
+  set(_headers ${G_HEADERS})
+  list(TRANSFORM _headers PREPEND "${G_SRC_DIR}/")
+  file(GLOB _docs_files
+       LIST_DIRECTORIES FALSE
+       ${G_SRC_DIR}/*.html ${G_SRC_DIR}/*.md
+       ${G_SRC_DIR}/*.png ${G_SRC_DIR}/*.jpg)
+  target_sources(${G_NAME} PRIVATE ${_headers} ${_docs_files})
 endfunction()

--- a/cmake/modules/build_script_in_subdir.cmake
+++ b/cmake/modules/build_script_in_subdir.cmake
@@ -107,27 +107,27 @@ function(build_script_in_subdir dir_name)
       CACHE INTERNAL "list of modules")
 
  if("${G_NAME}" MATCHES "^v[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Vector (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Vector")
  elseif("${G_NAME}" MATCHES "^r[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Raster (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Raster")
  elseif("${G_NAME}" MATCHES "^d[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Display (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Display")
  elseif("${G_NAME}" MATCHES "^db[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Database (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Database")
  elseif("${G_NAME}" MATCHES "^g[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/General (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/General")
  elseif("${G_NAME}" MATCHES "^i[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Imagery (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Imagery")
  elseif("${G_NAME}" MATCHES "^m[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Miscellaneous (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Miscellaneous")
  elseif("${G_NAME}" MATCHES "^ps[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/PostScript (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/PostScript")
  elseif("${G_NAME}" MATCHES "^r3[\.]")
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Raster 3D (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Raster 3D")
  elseif("${G_NAME}" MATCHES "^t[\.]")
-    set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Temporal (Scripts)")
+    set_target_properties(${G_NAME} PROPERTIES FOLDER "Tools/Temporal")
  else()
-   set_target_properties(${G_NAME} PROPERTIES FOLDER "Binaries (Scripts)")
+   set_target_properties(${G_NAME} PROPERTIES FOLDER "Binaries")
  endif()
 
   if(WIN32)
@@ -137,5 +137,13 @@ function(build_script_in_subdir dir_name)
 
   install(PROGRAMS ${OUTDIR}/${G_DEST_DIR}/${G_NAME}${script_ext}
           DESTINATION ${G_DEST_DIR})
+
+  file(GLOB _files
+       LIST_DIRECTORIES FALSE
+       ${G_SRC_DIR}/*.py
+       ${G_SRC_DIR}/*.html ${G_SRC_DIR}/*.md
+       ${G_SRC_DIR}/*.png ${G_SRC_DIR}/*.jpg)
+  target_sources(${G_NAME} PRIVATE ${_files})
+
 
 endfunction()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,106 @@
-file(GLOB_RECURSE SRCHS "*.h")
+set(SRCHS
+  arraystats.h
+  bitmap.h
+  btree.h
+  calc.h
+  cdhc.h
+  cluster.h
+  colors.h
+  datetime.h
+  dbmi.h
+  display.h
+  fontcap.h
+  form.h
+  gis.h
+  glocale.h
+  gmath.h
+  gprojects.h
+  imagery.h
+  la.h
+  linkm.h
+  manage.h
+  neta.h
+  nviz.h
+  ogsf.h
+  ortholib.h
+  raster.h
+  raster3d.h
+  rbtree.h
+  rowio.h
+  segment.h
+  spawn.h
+  sqlp.h
+  stats.h
+  symbol.h
+  temporal.h
+  vector.h
+  vedit.h
+  defs/arraystats.h
+  defs/bitmap.h
+  defs/btree.h
+  defs/calc.h
+  defs/cdhc.h
+  defs/cluster.h
+  defs/colors.h
+  defs/datetime.h
+  defs/dbmi.h
+  defs/devlib.h
+  defs/dig_atts.h
+  defs/display.h
+  defs/form.h
+  defs/gis.h
+  defs/glocale.h
+  defs/gmath.h
+  defs/gprojects.h
+  defs/imagery.h
+  defs/la.h
+  defs/linkm.h
+  defs/manage.h
+  defs/neta.h
+  defs/nviz.h
+  defs/ogsf.h
+  defs/ortholib.h
+  defs/Paintlib.h
+  defs/raster.h
+  defs/raster3d.h
+  defs/rbtree.h
+  defs/rowio.h
+  defs/segment.h
+  defs/spawn.h
+  defs/sqlp.h
+  defs/stats.h
+  defs/symbol.h
+  defs/vector.h
+  defs/vedit.h
+  iostream/ami_config.h
+  iostream/ami_sort_impl.h
+  iostream/ami_sort.h
+  iostream/ami_stream.h
+  iostream/ami.h
+  iostream/embuffer.h
+  iostream/empq_adaptive_impl.h
+  iostream/empq_adaptive.h
+  iostream/empq_impl.h
+  iostream/empq.h
+  iostream/imbuffer.h
+  iostream/mem_stream.h
+  iostream/minmaxheap.h
+  iostream/mm_utils.h
+  iostream/mm.h
+  iostream/pqheap.h
+  iostream/queue.h
+  iostream/quicksort.h
+  iostream/replacementHeap.h
+  iostream/replacementHeapBlock.h
+  iostream/rtimer.h
+  vect/dig_defines.h
+  vect/dig_externs.h
+  vect/dig_macros.h
+  vect/dig_structs.h
+  vect/digit.h)
+
+list(TRANSFORM SRCHS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/grass/")
+
 set(include_depends)
 foreach(srch ${SRCHS})
   get_filename_component(srch_DIR ${srch} DIRECTORY)
@@ -13,8 +115,9 @@ foreach(srch ${SRCHS})
   list(APPEND include_depends ${output_dir}/${srch_NAME})
 endforeach()
 
-add_custom_target(copy_header DEPENDS ${include_depends} LIB_PYTHON)
-set_target_properties(copy_header PROPERTIES FOLDER Misc)
+add_custom_target(INCLUDE_HEADERS DEPENDS ${include_depends} LIB_PYTHON)
+target_sources(INCLUDE_HEADERS PRIVATE ${SRCHS} config.h.cmake.in grass/version.h.in)
+set_target_properties(INCLUDE_HEADERS PROPERTIES FOLDER "GRASS Libraries")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/grass/version.h.in
                "${OUTDIR}/${GRASS_INSTALL_INCLUDEDIR}/grass/version.h")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -193,7 +193,10 @@ build_program_in_subdir(
 build_library_in_subdir(
   gpde
   HEADERS
-  "N_*.h"
+  N_gwflow.h
+  N_heatflow.h
+  N_pde.h
+  N_solute_transport.h
   DEPENDS
   grass_gis
   grass_raster

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -152,4 +152,4 @@ add_custom_target(
   DEPENDS v.to.lines)
 add_dependencies(r.in.wms r.in.wms_files)
 
-set_target_properties(r.in.wms_files PROPERTIES FOLDER "Tools/Raster (Scripts)")
+set_target_properties(r.in.wms_files PROPERTIES FOLDER "Tools/Raster")


### PR DESCRIPTION
Following discussions in #7069, I decided to explore what it would take to add non-compilation files (e.g. not C, nor C++) to the IDE. Turned out it wasn't much of a mystery.

This adds Python files, documentation files to IDE:

<img width="297" height="535" alt="image" src="https://github.com/user-attachments/assets/10eab60f-76d0-410b-a7d7-36fab21f7dea" />

And now it makes more sense to have all tools, regardless of code language, in the same IDE folder:

<img width="297" height="602" alt="image" src="https://github.com/user-attachments/assets/abba1c98-c1a5-43e4-bae1-914036c6ac2c" />
