### PR TITLE
wxGUI/history: Display saved region name if stored

### DIFF
--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -150,6 +150,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.sizer_region_settings = wx.StaticBoxSizer(
             self.region_settings_box, wx.VERTICAL
         )
+
         self.sizer_region_name = wx.BoxSizer(wx.HORIZONTAL)
         self.sizer_region_settings.Add(
             self.sizer_region_name,
@@ -157,6 +158,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
             flag=wx.ALL | wx.EXPAND,
             border=5,
         )
+
         self.sizer_region_settings_match = wx.BoxSizer(wx.HORIZONTAL)
         self.sizer_region_settings.Add(
             self.sizer_region_settings_match,
@@ -182,9 +184,6 @@ class HistoryInfoPanel(SP.ScrolledPanel):
     def _general_info_filter(self, key, value):
         filter_keys = ["timestamp", "runtime", "status"]
         return key in filter_keys or ((key in {"mask2d", "mask3d"}) and value is True)
-
-    def _region_settings_filter(self, key):
-        return key not in {"projection", "zone", "cells", "cells3"}
 
     def _updateGeneralInfoBox(self, command_info):
         """Update a static box for displaying general info about the command.
@@ -308,12 +307,11 @@ class HistoryInfoPanel(SP.ScrolledPanel):
     def _compare_regions(self, r1, r2):
         """Compare two region dictionaries for equality."""
         for k, v in r1.items():
-            if self._region_settings_filter(k):
-                try:
-                    if abs(float(v) - float(r2[k])) > 1e-8:
-                        return False
-                except (KeyError, ValueError, TypeError):
+            try:
+                if abs(float(v) - float(r2[k])) > 1e-8:
                     return False
+            except (KeyError, ValueError, TypeError):
+                return False
         return True
 
     def _updateRegionSettingsMatch(self):

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -19,7 +19,6 @@ for details.
 """
 
 from datetime import datetime
-import json
 
 import wx
 import wx.lib.scrolledpanel as SP
@@ -233,9 +232,30 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.sizer_region_settings_grid.Clear(True)
 
         self.region_settings = command_info["region"]
+
+        Display_Order = [
+            "n",
+            "s",
+            "e",
+            "w",
+            "nsres",
+            "ewres",
+            "rows",
+            "cols",
+            "t",
+            "b",
+            "tbres",
+            "nsres3",
+            "ewres3",
+            "rows3",
+            "cols3",
+            "depths",
+        ]
+
         idx = 0
-        for key, value in self.region_settings.items():
-            if self._region_settings_filter(key):
+        for key in Display_Order:
+            if key in self.region_settings:
+                value = self.region_settings[key]
                 self.sizer_region_settings_grid.Add(
                     StaticText(
                         parent=self.region_settings_box,
@@ -263,42 +283,37 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.region_settings_box.Show()
 
     def _get_saved_region_name(self, history_region):
-        """Find if history region matches any saved region in the current mapset."""
+        """Find if history region matches any saved region in the entire project."""
         try:
-            res = self.tools.g_list(type="region", mapset=".", format="json")
-            regions = json.loads(res.stdout)
-            region_names = [r["name"] for r in regions]
-        except Exception:
+            res = self.tools.g_list(type="region", mapset="*", format="json")
+            region_names = [r["name"] for r in res]
+        except (KeyError, TypeError):
             return None
 
         for region_name in region_names:
             region_name = region_name.strip()
-            if not region_name:
-                continue
-            try:
-                saved_region = self.tools.g_region(
-                    region=region_name, flags="u3", format="shell"
-                ).keyval
+            if region_name:
+                try:
+                    saved_region = self.tools.g_region(
+                        region=region_name, flags="u3", format="shell"
+                    ).keyval
 
-                if self._compare_regions(history_region, saved_region):
-                    return region_name
-            except Exception:
-                continue
+                    if self._compare_regions(history_region, saved_region):
+                        return region_name
+                except AttributeError:
+                    continue
 
         return None
 
     def _compare_regions(self, r1, r2):
         """Compare two region dictionaries for equality."""
-        skip_keys = {"projection", "zone", "cells", "cells3"}
-
         for k, v in r1.items():
-            if k in skip_keys:
-                continue
-            try:
-                if abs(float(v) - float(r2[k])) > 1e-8:
+            if self._region_settings_filter(k):
+                try:
+                    if abs(float(v) - float(r2[k])) > 1e-8:
+                        return False
+                except (KeyError, ValueError, TypeError):
                     return False
-            except (KeyError, ValueError, TypeError):
-                return False
         return True
 
     def _updateRegionSettingsMatch(self):
@@ -312,17 +327,17 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         region_matches = self._compare_regions(history_region, current_region)
         saved_name = self._get_saved_region_name(history_region)
 
-        region_label = saved_name or _("Not set")
-
-        self.sizer_region_name.Add(
-            StaticText(
-                parent=self.region_settings_box,
-                id=wx.ID_ANY,
-                label=_("Region name: {}").format(region_label),
-            ),
-            proportion=0,
-            flag=wx.ALIGN_CENTER_VERTICAL,
-        )
+        if saved_name:
+            self.sizer_region_name.Add(
+                StaticText(
+                    parent=self.region_settings_box,
+                    id=wx.ID_ANY,
+                    label=_("Region name: {}").format(saved_name),
+                ),
+                proportion=0,
+                flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+                border=10,
+            )
 
         # Icon and button according to the condition
         if region_matches:
@@ -396,11 +411,24 @@ class HistoryInfoPanel(SP.ScrolledPanel):
 
     def _get_history_region(self):
         """Get computational region settings of executed command."""
+        valid_keys = {
+            "n",
+            "s",
+            "e",
+            "w",
+            "nsres",
+            "ewres",
+            "t",
+            "b",
+            "tbres",
+            "nsres3",
+            "ewres3",
+        }
+
         return {
             key: value
             for key, value in self.region_settings.items()
-            if self._region_settings_filter(key)
-            and key not in {"rows3", "cols3", "depths"}
+            if key in valid_keys
         }
 
     def OnUpdateRegion(self, event):

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -266,7 +266,7 @@ def get_initial_command_info(env_run):
     mask3d_name = f"RASTER3D_MASK@{env['MAPSET']}"
 
     # Computational region settings
-    region_settings = gs.region(env=env_run)
+    region_settings = gs.region(region3d=True, env=env_run)
 
     # Finalize the command info dictionary
     return {


### PR DESCRIPTION
This PR adds the feature referred in #5283 

Here are the outputs:
- When it matches in `MAPSET/windows`
<img width="1287" height="336" alt="Screenshot 2026-02-16 184215" src="https://github.com/user-attachments/assets/95eefec2-f9cb-401a-9e8a-750d726d6f0a" />

- When it doesn't match in `MAPSET/windows`
<img width="1309" height="377" alt="Screenshot 2026-02-16 182910" src="https://github.com/user-attachments/assets/d4fc16fb-3aac-4ce6-a819-cfeb9c7d8c6e" />

Added two new methods to support region name display:
- `_get_saved_region_name()`: Searches MAPSET/windows for matching saved regions
- `_compare_regions()`: Compares regions with epsilon tolerance for floating-point precision

These methods are separate from the existing region match logic to avoid modifying 
working functionality and keep changes minimal and isolated.
Let me know if this needs any changes.