### PR TITLE
r.coin: Add JSON output support

### DIFF
--- a/raster/r.coin/Makefile
+++ b/raster/r.coin/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.coin
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.coin/coin.h
+++ b/raster/r.coin/coin.h
@@ -61,6 +61,7 @@ int collapse(long *, int);
 /* print_coin.c */
 int print_coin(int, int, int);
 
+void print_json(char);
 /* print_hdr.c */
 int print_coin_hdr(int);
 

--- a/raster/r.coin/local_proto.h
+++ b/raster/r.coin/local_proto.h
@@ -40,6 +40,7 @@ int collapse(long *, int);
 /* print_coin.c */
 int print_coin(int, int, int);
 
+void print_json(char);
 /* print_hdr.c */
 int print_coin_hdr(int);
 

--- a/raster/r.coin/main.c
+++ b/raster/r.coin/main.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
         struct Option *map1, *map2, *units;
     } parm;
     struct {
-        struct Flag *w;
+        struct Flag *w, *j;
     } flag;
 
     fill =
@@ -90,6 +90,10 @@ int main(int argc, char *argv[])
     flag.w->key = 'w';
     flag.w->description = _("Wide report, 132 columns (default: 80)");
 
+    flag.j = G_define_flag();
+    flag.j->key = 'j';
+    flag.j->description = _("Generate JSON output");
+
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
@@ -121,8 +125,13 @@ int main(int argc, char *argv[])
         G_fatal_error(_("Raster map <%s> not found"), map2name);
 
     make_coin();
-    print_coin(*parm.units->answer, flag.w->answer ? 132 : 80, 0);
 
+    if (flag.j->answer) {
+        print_json(*parm.units->answer);
+    }
+    else {
+        print_coin(*parm.units->answer, flag.w->answer ? 132 : 80, 0);
+    }
     remove(dumpname);
     remove(statname);
 

--- a/raster/r.coin/print_json.c
+++ b/raster/r.coin/print_json.c
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ * MODULE:       r.coin
+ *
+ * AUTHOR(S):    Sumit Chintanwar
+ *
+ * PURPOSE:      Json Output for r.coin
+ *
+ * COPYRIGHT:    (C) 2026 by the GRASS Development Team
+ *
+ *               This program is free software under the GNU General Public
+ *               License (>=v2). Read the file COPYING that comes with GRASS
+ *               for details.
+ *
+ ***************************************************************************/
+
+#include "coin.h"
+#include <grass/gjson.h>
+
+#define F_CTOK(C)    ((double)(C)) / 1000000.0
+#define F_CTOM(C)    F_CTOK(C) * 0.386102158542446
+#define F_CTOA(C)    F_CTOK(C) * 247.105381467165
+#define F_CTOH(C)    F_CTOK(C) * 100.0000
+#define F_CTOP(C, R) ((int)R) ? (double)C / (double)R * 100.0 : 0.0
+
+static const char *get_unit_name(char unit)
+{
+    switch (unit) {
+    case 'c':
+        return "cells";
+    case 'p':
+        return "percent";
+    case 'x':
+        return "percent_of_column";
+    case 'y':
+        return "percent_of_row";
+    case 'a':
+        return "acres";
+    case 'h':
+        return "hectares";
+    case 'k':
+        return "square_kilometers";
+    case 'm':
+        return "square_miles";
+    default:
+        return "unknown";
+    }
+}
+
+void print_json(char unit)
+{
+    int r, c;
+    long cat1, cat2;
+    int idx;
+    char *json_string;
+    long total_count;
+    double total_area;
+    double val;
+    char unit_str[2];
+
+    G_JSON_Value *root_value = G_json_value_init_object();
+    G_JSON_Object *root = G_json_object(root_value);
+
+    G_json_object_set_string(root, "module", "r.coin");
+    G_json_object_set_string(root, "map1", map1name);
+    G_json_object_set_string(root, "map2", map2name);
+
+    G_JSON_Value *unit_info_value = G_json_value_init_object();
+    G_JSON_Object *unit_info = G_json_object(unit_info_value);
+
+    unit_str[0] = unit;
+    unit_str[1] = '\0';
+    G_json_object_set_string(unit_info, "code", unit_str);
+    G_json_object_set_string(unit_info, "name", get_unit_name(unit));
+    G_json_object_set_value(root, "unit", unit_info_value);
+
+    G_JSON_Value *coincidence_array_value = G_json_value_init_array();
+    G_JSON_Array *coincidence_array = G_json_array(coincidence_array_value);
+
+    for (r = 0; r < ncat2; r++) {
+        for (c = 0; c < ncat1; c++) {
+            idx = r * ncat1 + c;
+
+            if (table[idx].count > 0) {
+                cat1 = catlist1[c];
+                cat2 = catlist2[r];
+                Cndex = c;
+                Rndex = r;
+
+                switch (unit) {
+                case 'c':
+                    val = (double)table[idx].count;
+                    break;
+                case 'p':
+                    val = F_CTOP(table[idx].area, window_area);
+                    break;
+                case 'x':
+                    col_total(c, 1, &total_count, &total_area);
+                    val = F_CTOP(table[idx].area, total_area);
+                    break;
+                case 'y':
+                    row_total(r, 1, &total_count, &total_area);
+                    val = F_CTOP(table[idx].area, total_area);
+                    break;
+                case 'a':
+                    val = F_CTOA(table[idx].area);
+                    break;
+                case 'h':
+                    val = F_CTOH(table[idx].area);
+                    break;
+                case 'k':
+                    val = F_CTOK(table[idx].area);
+                    break;
+                case 'm':
+                    val = F_CTOM(table[idx].area);
+                    break;
+                default:
+                    val = (double)table[idx].count;
+                    break;
+                }
+
+                G_JSON_Value *entry_value = G_json_value_init_object();
+                G_JSON_Object *entry = G_json_object(entry_value);
+
+                G_json_object_set_number(entry, "cat1", (double)cat1);
+                G_json_object_set_number(entry, "cat2", (double)cat2);
+                G_json_object_set_number(entry, "count",
+                                         (double)table[idx].count);
+                G_json_object_set_number(entry, "area", table[idx].area);
+                G_json_object_set_number(entry, "value", val);
+
+                G_json_array_append_value(coincidence_array, entry_value);
+            }
+        }
+    }
+
+    G_json_object_set_value(root, "coincidence", coincidence_array_value);
+
+    json_string = G_json_serialize_to_string_pretty(root_value);
+    fprintf(stdout, "%s\n", json_string);
+
+    G_json_free_serialized_string(json_string);
+    G_json_value_free(root_value);
+}

--- a/raster/r.coin/print_json.c
+++ b/raster/r.coin/print_json.c
@@ -16,6 +16,8 @@
 
 #include "coin.h"
 #include <grass/gjson.h>
+#include <grass/gis.h>
+#include <time.h>
 
 #define F_CTOK(C)    ((double)(C)) / 1000000.0
 #define F_CTOM(C)    F_CTOK(C) * 0.386102158542446
@@ -47,98 +49,177 @@ static const char *get_unit_name(char unit)
     }
 }
 
+static double cell_value(int r, int c, char unit)
+{
+    int idx = r * ncat1 + c;
+    long total_count;
+    double total_area;
+
+    switch (unit) {
+    case 'c':
+        return (double)table[idx].count;
+    case 'p':
+        return F_CTOP(table[idx].area, window_area);
+    case 'x':
+        col_total(c, 1, &total_count, &total_area);
+        return F_CTOP(table[idx].area, total_area);
+    case 'y':
+        row_total(r, 1, &total_count, &total_area);
+        return F_CTOP(table[idx].area, total_area);
+    case 'a':
+        return F_CTOA(table[idx].area);
+    case 'h':
+        return F_CTOH(table[idx].area);
+    case 'k':
+        return F_CTOK(table[idx].area);
+    case 'm':
+        return F_CTOM(table[idx].area);
+    default:
+        return (double)table[idx].count;
+    }
+}
+
 void print_json(char unit)
 {
     int r, c;
-    long cat1, cat2;
-    int idx;
     char *json_string;
-    long total_count;
-    double total_area;
-    double val;
-    char unit_str[2];
+    char timestamp[64];
+    time_t now;
+    struct tm *tm_info;
+    struct Cell_head window;
+
+    time(&now);
+    tm_info = gmtime(&now);
+    strftime(timestamp, sizeof(timestamp), "%Y-%m-%dT%H:%M:%SZ", tm_info);
+
+    G_get_window(&window);
 
     G_JSON_Value *root_value = G_json_value_init_object();
     G_JSON_Object *root = G_json_object(root_value);
 
-    G_json_object_set_string(root, "module", "r.coin");
-    G_json_object_set_string(root, "map1", map1name);
-    G_json_object_set_string(root, "map2", map2name);
+    G_json_object_set_string(root, "project", G_location());
+    G_json_object_set_string(root, "created", timestamp);
 
-    G_JSON_Value *unit_info_value = G_json_value_init_object();
-    G_JSON_Object *unit_info = G_json_object(unit_info_value);
+    G_JSON_Value *region_value = G_json_value_init_object();
+    G_JSON_Object *region = G_json_object(region_value);
+    G_json_object_set_number(region, "north", window.north);
+    G_json_object_set_number(region, "south", window.south);
+    G_json_object_set_number(region, "east", window.east);
+    G_json_object_set_number(region, "west", window.west);
+    G_json_object_set_number(region, "ewres", window.ew_res);
+    G_json_object_set_number(region, "nsres", window.ns_res);
+    G_json_object_set_value(root, "region", region_value);
 
-    unit_str[0] = unit;
-    unit_str[1] = '\0';
-    G_json_object_set_string(unit_info, "code", unit_str);
-    G_json_object_set_string(unit_info, "name", get_unit_name(unit));
-    G_json_object_set_value(root, "unit", unit_info_value);
+    if (G_find_raster("MASK", G_mapset()) != NULL)
+        G_json_object_set_string(root, "mask", "MASK");
+    else
+        G_json_object_set_null(root, "mask");
 
-    G_JSON_Value *coincidence_array_value = G_json_value_init_array();
-    G_JSON_Array *coincidence_array = G_json_array(coincidence_array_value);
+    G_JSON_Value *maps_value = G_json_value_init_array();
+    G_JSON_Array *maps_array = G_json_array(maps_value);
+
+    {
+        G_JSON_Value *m = G_json_value_init_object();
+        G_JSON_Object *o = G_json_object(m);
+        G_json_object_set_string(o, "name", map1name);
+        G_json_object_set_string(o, "title", title1 ? title1 : "");
+        G_json_object_set_string(o, "type", "raster");
+        G_json_array_append_value(maps_array, m);
+    }
+    {
+        G_JSON_Value *m = G_json_value_init_object();
+        G_JSON_Object *o = G_json_object(m);
+        G_json_object_set_string(o, "name", map2name);
+        G_json_object_set_string(o, "title", title2 ? title2 : "");
+        G_json_object_set_string(o, "type", "raster");
+        G_json_array_append_value(maps_array, m);
+    }
+    G_json_object_set_value(root, "maps", maps_value);
+
+    G_json_object_set_string(root, "unit", get_unit_name(unit));
+
+    G_JSON_Value *row_cats_value = G_json_value_init_array();
+    G_JSON_Array *row_cats = G_json_array(row_cats_value);
+    for (r = 0; r < ncat2; r++)
+        G_json_array_append_number(row_cats, (double)catlist2[r]);
+    G_json_object_set_value(root, "row_cats", row_cats_value);
+
+    G_JSON_Value *col_cats_value = G_json_value_init_array();
+    G_JSON_Array *col_cats_arr = G_json_array(col_cats_value);
+    for (c = 0; c < ncat1; c++)
+        G_json_array_append_number(col_cats_arr, (double)catlist1[c]);
+    G_json_object_set_value(root, "col_cats", col_cats_value);
+
+    G_JSON_Value *matrix_value = G_json_value_init_array();
+    G_JSON_Array *matrix = G_json_array(matrix_value);
+
+    double *row_total_arr = G_calloc(ncat2, sizeof(double));
+    double *row_total_nz_arr = G_calloc(ncat2, sizeof(double));
+    double *col_total_arr = G_calloc(ncat1, sizeof(double));
+    double *col_total_nz_arr = G_calloc(ncat1, sizeof(double));
+    double grand_total = 0.0;
+    double grand_total_nz = 0.0;
 
     for (r = 0; r < ncat2; r++) {
+        G_JSON_Value *row_value = G_json_value_init_array();
+        G_JSON_Array *row_arr = G_json_array(row_value);
+
         for (c = 0; c < ncat1; c++) {
-            idx = r * ncat1 + c;
+            double val = cell_value(r, c, unit);
 
-            if (table[idx].count > 0) {
-                cat1 = catlist1[c];
-                cat2 = catlist2[r];
-                Cndex = c;
-                Rndex = r;
+            G_json_array_append_number(row_arr, val);
 
-                switch (unit) {
-                case 'c':
-                    val = (double)table[idx].count;
-                    break;
-                case 'p':
-                    val = F_CTOP(table[idx].area, window_area);
-                    break;
-                case 'x':
-                    col_total(c, 1, &total_count, &total_area);
-                    val = F_CTOP(table[idx].area, total_area);
-                    break;
-                case 'y':
-                    row_total(r, 1, &total_count, &total_area);
-                    val = F_CTOP(table[idx].area, total_area);
-                    break;
-                case 'a':
-                    val = F_CTOA(table[idx].area);
-                    break;
-                case 'h':
-                    val = F_CTOH(table[idx].area);
-                    break;
-                case 'k':
-                    val = F_CTOK(table[idx].area);
-                    break;
-                case 'm':
-                    val = F_CTOM(table[idx].area);
-                    break;
-                default:
-                    val = (double)table[idx].count;
-                    break;
-                }
+            row_total_arr[r] += val;
+            col_total_arr[c] += val;
+            grand_total += val;
 
-                G_JSON_Value *entry_value = G_json_value_init_object();
-                G_JSON_Object *entry = G_json_object(entry_value);
-
-                G_json_object_set_number(entry, "cat1", (double)cat1);
-                G_json_object_set_number(entry, "cat2", (double)cat2);
-                G_json_object_set_number(entry, "count",
-                                         (double)table[idx].count);
-                G_json_object_set_number(entry, "area", table[idx].area);
-                G_json_object_set_number(entry, "value", val);
-
-                G_json_array_append_value(coincidence_array, entry_value);
+            if (catlist1[c] != 0 && catlist2[r] != 0) {
+                row_total_nz_arr[r] += val;
+                col_total_nz_arr[c] += val;
+                grand_total_nz += val;
             }
         }
+        G_json_array_append_value(matrix, row_value);
     }
+    G_json_object_set_value(root, "matrix", matrix_value);
 
-    G_json_object_set_value(root, "coincidence", coincidence_array_value);
+    G_JSON_Value *rt_value = G_json_value_init_array();
+    G_JSON_Array *rt = G_json_array(rt_value);
+    G_JSON_Value *rt_nz_value = G_json_value_init_array();
+    G_JSON_Array *rt_nz = G_json_array(rt_nz_value);
+
+    for (r = 0; r < ncat2; r++) {
+        G_json_array_append_number(rt, row_total_arr[r]);
+        G_json_array_append_number(rt_nz, row_total_nz_arr[r]);
+    }
+    G_json_object_set_value(root, "row_totals", rt_value);
+    G_json_object_set_value(root, "row_totals_without_zero", rt_nz_value);
+
+    G_JSON_Value *ct_value = G_json_value_init_array();
+    G_JSON_Array *ct = G_json_array(ct_value);
+    G_JSON_Value *ct_nz_value = G_json_value_init_array();
+    G_JSON_Array *ct_nz = G_json_array(ct_nz_value);
+
+    for (c = 0; c < ncat1; c++) {
+        G_json_array_append_number(ct, col_total_arr[c]);
+        G_json_array_append_number(ct_nz, col_total_nz_arr[c]);
+    }
+    G_json_object_set_value(root, "col_totals", ct_value);
+    G_json_object_set_value(root, "col_totals_without_zero", ct_nz_value);
+
+    G_JSON_Value *totals_value = G_json_value_init_object();
+    G_JSON_Object *totals = G_json_object(totals_value);
+    G_json_object_set_number(totals, "value", grand_total);
+    G_json_object_set_number(totals, "value_without_zero", grand_total_nz);
+    G_json_object_set_value(root, "totals", totals_value);
 
     json_string = G_json_serialize_to_string_pretty(root_value);
     fprintf(stdout, "%s\n", json_string);
 
     G_json_free_serialized_string(json_string);
     G_json_value_free(root_value);
+    G_free(row_total_arr);
+    G_free(row_total_nz_arr);
+    G_free(col_total_arr);
+    G_free(col_total_nz_arr);
 }

--- a/raster/r.coin/tests/test_json.py
+++ b/raster/r.coin/tests/test_json.py
@@ -1,0 +1,195 @@
+"""
+Name:      r_coin_json_test
+Purpose:   Tests for r.coin JSON output functionality
+
+Author:    Sumit Chintanwar
+Copyright: (C) 2026 by Sumit Chintanwar and the GRASS Development Team
+Licence:   This program is free software under the GNU General Public
+           License (>=v2). Read the file COPYING that comes with GRASS
+           for details.
+"""
+
+import json
+import grass.script as gs
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class TestRCoinJSON(TestCase):
+    """Test r.coin JSON output"""
+
+    map1 = "geology"
+    map2 = "soils"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.use_temp_region()
+        cls.runModule("g.region", raster=cls.map1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+
+    def run_json(self, unit: str) -> dict:
+        output = gs.read_command(
+            "r.coin", flags="j", first=self.map1, second=self.map2, units=unit
+        )
+        return json.loads(output)
+
+    def test_structure(self):
+        data = self.run_json("c")
+
+        assert data["module"] == "r.coin"
+        assert data["map1"] == self.map1
+        assert data["map2"] == self.map2
+
+        assert "coincidence" in data
+        assert isinstance(data["coincidence"], list)
+        assert len(data["coincidence"]) > 0
+
+        entry = data["coincidence"][0]
+        for field in ["cat1", "cat2", "count", "area", "value"]:
+            assert field in entry
+
+    def test_entry_fields(self):
+        data = self.run_json("c")
+        entry = data["coincidence"][0]
+
+        required = ["cat1", "cat2", "count", "area", "value"]
+        for field in required:
+            assert field in entry
+
+        assert isinstance(entry["cat1"], (int, float))
+        assert isinstance(entry["cat2"], (int, float))
+        assert isinstance(entry["count"], (int, float))
+        assert isinstance(entry["area"], (int, float))
+        assert isinstance(entry["value"], (int, float))
+
+        assert entry["count"] > 0
+        assert entry["area"] > 0
+
+    def test_unit_names(self):
+        units = {
+            "c": "cells",
+            "p": "percent",
+            "x": "percent_of_column",
+            "y": "percent_of_row",
+            "a": "acres",
+            "h": "hectares",
+            "k": "square_kilometers",
+            "m": "square_miles",
+        }
+
+        for code, name in units.items():
+            data = self.run_json(code)
+            assert data["unit"]["code"] == code
+            assert data["unit"]["name"] == name
+
+    def test_cells_equal_count(self):
+        data = self.run_json("c")
+
+        for entry in data["coincidence"][:50]:
+            assert entry["value"] == entry["count"]
+
+    def test_area_conversions(self):
+        data_c = self.run_json("c")
+        areas = {
+            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_c["coincidence"]
+        }
+
+        conversions = [
+            ("a", 247.105381467165, 1.0),
+            ("h", 100.0, 1.0),
+            ("k", 1.0, 0.001),
+            ("m", 0.386102158542446, 0.001),
+        ]
+
+        for unit, factor, tol in conversions:
+            data = self.run_json(unit)
+
+            for entry in data["coincidence"][:20]:
+                key = (int(entry["cat1"]), int(entry["cat2"]))
+                if key not in areas:
+                    continue
+
+                expected = (areas[key] / 1000000.0) * factor
+                assert abs(entry["value"] - expected) <= tol
+
+    def test_cross_unit_consistency(self):
+        data_k = self.run_json("k")
+        data_h = self.run_json("h")
+        data_a = self.run_json("a")
+
+        km = {
+            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_k["coincidence"]
+        }
+        ha = {
+            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_h["coincidence"]
+        }
+        ac = {
+            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_a["coincidence"]
+        }
+
+        keys = list(set(km.keys()) & set(ha.keys()) & set(ac.keys()))[:20]
+
+        for key in keys:
+            assert abs(ha[key] - km[key] * 100.0) <= 1.0
+            assert abs(ac[key] - km[key] * 247.105381467165) <= 1.0
+
+    def test_same_entry_count(self):
+        units = ["c", "p", "x", "y", "a", "h", "k", "m"]
+        counts = [len(self.run_json(u)["coincidence"]) for u in units]
+        assert len(set(counts)) == 1
+
+    def test_same_categories(self):
+        data_c = self.run_json("c")
+        data_a = self.run_json("a")
+
+        cats_c = {(int(e["cat1"]), int(e["cat2"])) for e in data_c["coincidence"]}
+        cats_a = {(int(e["cat1"]), int(e["cat2"])) for e in data_a["coincidence"]}
+
+        assert cats_c == cats_a
+
+    def test_same_area_values(self):
+        data_c = self.run_json("c")
+        data_a = self.run_json("a")
+
+        areas_c = {
+            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_c["coincidence"]
+        }
+        areas_a = {
+            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_a["coincidence"]
+        }
+
+        for key in list(areas_c.keys())[:20]:
+            assert areas_c[key] == areas_a[key]
+
+    def test_known_cells(self):
+        data = self.run_json("c")
+        values = {
+            (int(e["cat1"]), int(e["cat2"])): int(e["count"])
+            for e in data["coincidence"]
+        }
+
+        key = (270, 46348)
+        assert key in values
+        assert values[key] == 9387
+
+    def test_known_acres(self):
+        data = self.run_json("a")
+        values = {
+            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data["coincidence"]
+        }
+
+        key = (270, 46348)
+        assert key in values
+        assert abs(values[key] - 2087.62) <= 1.0
+
+    def test_percent_total(self):
+        data = self.run_json("p")
+        total = sum(e["value"] for e in data["coincidence"])
+        assert abs(total - 100.0) <= 0.01
+
+
+if __name__ == "__main__":
+    test()

--- a/raster/r.coin/tests/test_json.py
+++ b/raster/r.coin/tests/test_json.py
@@ -21,174 +21,204 @@ class TestRCoinJSON(TestCase):
     map1 = "geology"
     map2 = "soils"
 
+    grand_total_miles = 78.185687104845513
+
+    known_col_totals = {
+        217: 28.014105435637472,
+        262: 7.671232126784743,
+        270: 26.616840334088188,
+        405: 9.795797864380406,
+        583: 0.834328154394372,
+        720: 0.186255681280876,
+        766: 0.273128666952926,
+        862: 2.383099742955688,
+        910: 1.736069745670255,
+        921: 0.483708784221976,
+        945: 0.000347491942688,
+        946: 0.157066358095067,
+        948: 0.033706718440756,
+    }
+
+    known_row_totals = {
+        18683: 0.503168333012516,
+        19401: 0.023976944045486,
+        19447: 0.426720105621111,
+        19548: 0.001042475828065,
+        20149: 0.036834145924949,
+    }
+
+    known_matrix_miles = {
+        (217, 18683): 0.503168333012516,
+        (262, 19401): 0.023976944045486,
+        (217, 19447): 0.326989918069598,
+        (262, 19447): 0.099730187551514,
+        (217, 20149): 0.014247169650216,
+    }
+
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.map1)
 
+        cls._data = {}
+        for unit in ("c", "p", "a", "h", "k", "m"):
+            output = gs.read_command(
+                "r.coin",
+                flags="j",
+                first=cls.map1,
+                second=cls.map2,
+                units=unit,
+            )
+            cls._data[unit] = json.loads(output)
+
     @classmethod
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def run_json(self, unit: str) -> dict:
-        output = gs.read_command(
-            "r.coin", flags="j", first=self.map1, second=self.map2, units=unit
-        )
-        return json.loads(output)
+    def data(self, unit: str) -> dict:
+        """Return cached JSON output for the given unit."""
+        return self._data[unit]
 
-    def test_structure(self):
-        data = self.run_json("c")
+    def get_cell(self, data, cat1, cat2):
+        """Return matrix value for a given (cat1, cat2) pair."""
+        c = data["col_cats"].index(cat1)
+        r = data["row_cats"].index(cat2)
+        return data["matrix"][r][c]
 
-        assert data["module"] == "r.coin"
-        assert data["map1"] == self.map1
-        assert data["map2"] == self.map2
-
-        assert "coincidence" in data
-        assert isinstance(data["coincidence"], list)
-        assert len(data["coincidence"]) > 0
-
-        entry = data["coincidence"][0]
-        for field in ["cat1", "cat2", "count", "area", "value"]:
-            assert field in entry
-
-    def test_entry_fields(self):
-        data = self.run_json("c")
-        entry = data["coincidence"][0]
-
-        required = ["cat1", "cat2", "count", "area", "value"]
-        for field in required:
-            assert field in entry
-
-        assert isinstance(entry["cat1"], (int, float))
-        assert isinstance(entry["cat2"], (int, float))
-        assert isinstance(entry["count"], (int, float))
-        assert isinstance(entry["area"], (int, float))
-        assert isinstance(entry["value"], (int, float))
-
-        assert entry["count"] > 0
-        assert entry["area"] > 0
+    def test_top_level_keys(self):
+        data = self.data("c")
+        required = {
+            "project",
+            "created",
+            "region",
+            "mask",
+            "maps",
+            "unit",
+            "row_cats",
+            "col_cats",
+            "matrix",
+            "row_totals",
+            "row_totals_without_zero",
+            "col_totals",
+            "col_totals_without_zero",
+            "totals",
+        }
+        for key in required:
+            assert key in data, f"missing top-level key: {key}"
 
     def test_unit_names(self):
-        units = {
+        expected = {
             "c": "cells",
             "p": "percent",
-            "x": "percent_of_column",
-            "y": "percent_of_row",
             "a": "acres",
             "h": "hectares",
             "k": "square_kilometers",
             "m": "square_miles",
         }
+        for code, name in expected.items():
+            assert self.data(code)["unit"] == name, f"unit mismatch for code={code}"
 
-        for code, name in units.items():
-            data = self.run_json(code)
-            assert data["unit"]["code"] == code
-            assert data["unit"]["name"] == name
-
-    def test_cells_equal_count(self):
-        data = self.run_json("c")
-
-        for entry in data["coincidence"][:50]:
-            assert entry["value"] == entry["count"]
-
-    def test_area_conversions(self):
-        data_c = self.run_json("c")
-        areas = {
-            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_c["coincidence"]
-        }
-
-        conversions = [
-            ("a", 247.105381467165, 1.0),
-            ("h", 100.0, 1.0),
-            ("k", 1.0, 0.001),
-            ("m", 0.386102158542446, 0.001),
+    def test_col_cats(self):
+        assert self.data("m")["col_cats"] == [
+            217,
+            262,
+            270,
+            405,
+            583,
+            720,
+            766,
+            862,
+            910,
+            921,
+            945,
+            946,
+            948,
         ]
 
-        for unit, factor, tol in conversions:
-            data = self.run_json(unit)
+    def test_matrix_shape(self):
+        data = self.data("c")
+        assert len(data["matrix"]) == 3345
+        assert len(data["matrix"][0]) == 13
 
-            for entry in data["coincidence"][:20]:
-                key = (int(entry["cat1"]), int(entry["cat2"]))
-                if key not in areas:
-                    continue
+    def test_row_totals_match_matrix_sums(self):
+        data = self.data("k")
+        for r, row in enumerate(data["matrix"]):
+            assert abs(sum(row) - data["row_totals"][r]) < 1e-6, (
+                f"row_total mismatch at row {r}"
+            )
 
-                expected = (areas[key] / 1000000.0) * factor
-                assert abs(entry["value"] - expected) <= tol
+    def test_col_totals_match_matrix_sums(self):
+        data = self.data("k")
+        nrows = len(data["row_cats"])
+        for c in range(len(data["col_cats"])):
+            col_sum = sum(data["matrix"][r][c] for r in range(nrows))
+            assert abs(col_sum - data["col_totals"][c]) < 1e-6, (
+                f"col_total mismatch at col {c}"
+            )
 
-    def test_cross_unit_consistency(self):
-        data_k = self.run_json("k")
-        data_h = self.run_json("h")
-        data_a = self.run_json("a")
+    def test_grand_total_miles(self):
+        assert abs(self.data("m")["totals"]["value"] - self.grand_total_miles) < 0.001
 
-        km = {
-            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_k["coincidence"]
-        }
-        ha = {
-            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_h["coincidence"]
-        }
-        ac = {
-            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data_a["coincidence"]
-        }
+    def test_grand_total_percent_is_100(self):
+        assert abs(self.data("p")["totals"]["value"] - 100.0) < 0.01
 
-        keys = list(set(km.keys()) & set(ha.keys()) & set(ac.keys()))[:20]
+    def test_known_col_totals(self):
+        data = self.data("m")
+        for cat1, expected in self.known_col_totals.items():
+            c = data["col_cats"].index(cat1)
+            assert abs(data["col_totals"][c] - expected) < 0.001, (
+                f"col_total mismatch for cat1={cat1}"
+            )
 
-        for key in keys:
-            assert abs(ha[key] - km[key] * 100.0) <= 1.0
-            assert abs(ac[key] - km[key] * 247.105381467165) <= 1.0
+    def test_known_row_totals(self):
+        data = self.data("m")
+        for cat2, expected in self.known_row_totals.items():
+            r = data["row_cats"].index(cat2)
+            assert abs(data["row_totals"][r] - expected) < 0.001, (
+                f"row_total mismatch for cat2={cat2}"
+            )
 
-    def test_same_entry_count(self):
-        units = ["c", "p", "x", "y", "a", "h", "k", "m"]
-        counts = [len(self.run_json(u)["coincidence"]) for u in units]
-        assert len(set(counts)) == 1
+    def test_known_matrix_miles(self):
+        data = self.data("m")
+        for (cat1, cat2), expected in self.known_matrix_miles.items():
+            assert abs(self.get_cell(data, cat1, cat2) - expected) < 0.001, (
+                f"matrix mismatch for cat1={cat1}, cat2={cat2}"
+            )
 
-    def test_same_categories(self):
-        data_c = self.run_json("c")
-        data_a = self.run_json("a")
+    def test_cross_unit_km_to_hectares(self):
+        data_k = self.data("k")
+        data_h = self.data("h")
+        for r in range(len(data_k["row_cats"])):
+            for c in range(len(data_k["col_cats"])):
+                assert (
+                    abs(data_h["matrix"][r][c] - data_k["matrix"][r][c] * 100.0) < 0.001
+                ), f"km->ha mismatch at row={r}, col={c}"
 
-        cats_c = {(int(e["cat1"]), int(e["cat2"])) for e in data_c["coincidence"]}
-        cats_a = {(int(e["cat1"]), int(e["cat2"])) for e in data_a["coincidence"]}
+    def test_cross_unit_km_to_acres(self):
+        data_k = self.data("k")
+        data_a = self.data("a")
+        for r in range(len(data_k["row_cats"])):
+            for c in range(len(data_k["col_cats"])):
+                assert (
+                    abs(
+                        data_a["matrix"][r][c]
+                        - data_k["matrix"][r][c] * 247.105381467165
+                    )
+                    < 0.001
+                ), f"km->acres mismatch at row={r}, col={c}"
 
-        assert cats_c == cats_a
-
-    def test_same_area_values(self):
-        data_c = self.run_json("c")
-        data_a = self.run_json("a")
-
-        areas_c = {
-            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_c["coincidence"]
-        }
-        areas_a = {
-            (int(e["cat1"]), int(e["cat2"])): e["area"] for e in data_a["coincidence"]
-        }
-
-        for key in list(areas_c.keys())[:20]:
-            assert areas_c[key] == areas_a[key]
-
-    def test_known_cells(self):
-        data = self.run_json("c")
-        values = {
-            (int(e["cat1"]), int(e["cat2"])): int(e["count"])
-            for e in data["coincidence"]
-        }
-
-        key = (270, 46348)
-        assert key in values
-        assert values[key] == 9387
-
-    def test_known_acres(self):
-        data = self.run_json("a")
-        values = {
-            (int(e["cat1"]), int(e["cat2"])): e["value"] for e in data["coincidence"]
-        }
-
-        key = (270, 46348)
-        assert key in values
-        assert abs(values[key] - 2087.62) <= 1.0
-
-    def test_percent_total(self):
-        data = self.run_json("p")
-        total = sum(e["value"] for e in data["coincidence"])
-        assert abs(total - 100.0) <= 0.01
+    def test_cross_unit_km_to_miles(self):
+        data_k = self.data("k")
+        data_m = self.data("m")
+        for r in range(len(data_k["row_cats"])):
+            for c in range(len(data_k["col_cats"])):
+                assert (
+                    abs(
+                        data_m["matrix"][r][c]
+                        - data_k["matrix"][r][c] * 0.386102158542446
+                    )
+                    < 0.001
+                ), f"km->miles mismatch at row={r}, col={c}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds JSON output support for r.coin module.

Below is an example of JSON Output for r.coin:

```
{
  "project": "nc_spm_full_v2beta1",
  "created": "2026-03-17T16:38:11Z",
  "region": {
    "north": 228500,
    "south": 215000,
    "east": 645000,
    "west": 630000,
    "ewres": 30,
    "nsres": 30
  },
  "mask": null,
  "maps": [
    {"name": "geology", "title": "Geology", "type": "raster"},
    {"name": "soils",   "title": "Soils",   "type": "raster"}
  ],
  "unit": "square_miles",
  "row_cats": [18683, 19401, 19447],
  "col_cats": [217, 262, 270],
  "matrix": [
    [0.503168, 0.000000, 0.000000],
    [0.000000, 0.023977, 0.000000],
    [0.326990, 0.099730, 0.000000]
  ],
  "row_totals": [0.503168, 0.023977, 0.426720],
  "row_totals_without_zero": [0.503168, 0.023977, 0.426720],
  "col_totals": [0.830158, 0.123707, 0.000000],
  "col_totals_without_zero": [0.830158, 0.123707, 0.000000],
  "totals": {
    "value": 0.953865,
    "value_without_zero": 0.953865
  }
}
```


Results: All tests pass with no issues on the `nc_spm_full_v2beta1` dataset