### PR TITLE
ci: reenable g.extension test in Windows CI runner (fixes #7080)

### DIFF
--- a/scripts/g.extension/tests/g_extension_test.py
+++ b/scripts/g.extension/tests/g_extension_test.py
@@ -1,10 +1,8 @@
-"""Test g.extension"""
+"""Test g.extension (re-enabled for Windows per https://github.com/OSGeo/grass/issues/7080)."""
 
 import pytest
-import sys
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Temporarily disable tests.")
 # This should cover both C and Python tools.
 @pytest.mark.parametrize("name", ["r.stream.distance", "r.lake.series"])
 def test_install(tools, name):


### PR DESCRIPTION
## ci: reenable g.extension test in Windows CI runner 

Fixes #7080


### Summary

Re-enables the g.extension test on Windows CI by reverting the temporary skip added in commit 87f364a (PR #7075). Windows addons for GRASS 8.6 are now available from the server, so the test can run again.

### What changed

**Single file:** `scripts/g.extension/tests/g_extension_test.py`

- Removed `import sys`
- Removed `@pytest.mark.skipif(sys.platform.startswith("win"), reason="Temporarily disable tests.")` so the test runs on all platforms including Windows
- Updated module docstring to reference this issue

### Diff

```diff
diff --git a/scripts/g.extension/tests/g_extension_test.py b/scripts/g.extension/tests/g_extension_test.py
index 07558b1916..c2588d0b02 100644
--- a/scripts/g.extension/tests/g_extension_test.py
+++ b/scripts/g.extension/tests/g_extension_test.py
@@ -1,10 +1,8 @@
-"""Test g.extension"""
+"""Test g.extension (re-enabled for Windows per https://github.com/OSGeo/grass/issues/7080)."""
 
 import pytest
-import sys
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Temporarily disable tests.")
 # This should cover both C and Python tools.
 @pytest.mark.parametrize("name", ["r.stream.distance", "r.lake.series"])
 def test_install(tools, name):
```

### Verification

- **Content check:** Confirmed the file has no `skipif`, no `import sys`, and no `sys.platform` — i.e. the revert of 87f364a is correct.
- **Verification script output:**
  ```
  === Verification: g.extension test (issue #7080) ===
  File: scripts/g.extension/tests/g_extension_test.py
  Has skipif (Windows skip): False
  Has import sys: False
  Has issue reference (7080): True
  test_install parametrized: True
  Result: Revert of 87f364a applied correctly.
  ```

## Testing

- **CI:** Windows (OSGeo4W) and Linux pytest workflows will run `g_extension_test.py`; the test will now execute on Windows instead of being skipped.
- **Manual:** With a GRASS build from this repo:  
  `pytest scripts/g.extension/tests/g_extension_test.py -v`

