### PR TITLE
Add --region option and tests

### DIFF
--- a/python/grass/app/cli.py
+++ b/python/grass/app/cli.py
@@ -68,13 +68,18 @@ def subcommand_run_tool(args, tool_args: list, print_help: bool) -> int:
                     # other special flags, so later use of --json in tools will fail
                     # with the other flags active.
                     return tools.call_cmd(command).returncode
-                
+
                 if args.region:
                     try:
                         gs.run_command("g.region", raster=args.region, env=session.env)
-                        print(f"Temporary computational region set: raster={args.region}")
+                        print(
+                            f"Temporary computational region set: raster={args.region}"
+                        )
                     except ScriptError as e:
-                        print(f"Error setting region '{args.region}': {e}", file=sys.stderr)
+                        print(
+                            f"Error setting region '{args.region}': {e}",
+                            file=sys.stderr,
+                        )
                         return 1
                 return tools.run_cmd(command).returncode
             except subprocess.CalledProcessError as error:
@@ -264,9 +269,9 @@ def main(args=None, program=None):
         "--project", type=str, help="project to use for computations"
     )
     run_subparser.add_argument(
-    "--region",
-    type=str,
-    help="Set temporary computational region before running the tool (e.g., raster=name)",
+        "--region",
+        type=str,
+        help="Set temporary computational region before running the tool (e.g., raster=name)",
     )
     run_subparser.set_defaults(func=subcommand_run_tool)
 

--- a/python/grass/app/tests/grass_app_cli_test.py
+++ b/python/grass/app/tests/grass_app_cli_test.py
@@ -8,7 +8,6 @@ from grass.app.cli import main
 
 from unittest.mock import patch, MagicMock
 from grass.app.cli import subcommand_run_tool
-from grass.app.cli import Tools
 
 
 def test_cli_help_runs():
@@ -55,12 +54,15 @@ def test_subcommand_run_tool_regular_run():
     """Check that a tool runs without error"""
     assert main(["run", "g.region", "-p"]) == 0
 
+
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix only")
 @patch("grass.app.cli.Tools.run_cmd")
 @patch("grass.app.cli.gs.run_command")
 @patch("grass.app.cli.gs.create_project")
 @patch("grass.app.cli.gs.setup.init")
-def test_run_tool_with_region(mock_init, mock_create_project, mock_run_command, mock_tools_run_cmd):
+def test_run_tool_with_region(
+    mock_init, mock_create_project, mock_run_command, mock_tools_run_cmd
+):
     """Verify that providing --region calls g.region before running the tool."""
     # Mock GRASS session
     mock_session = MagicMock()
@@ -79,7 +81,9 @@ def test_run_tool_with_region(mock_init, mock_create_project, mock_run_command, 
     subcommand_run_tool(Args, tool_args=[], print_help=False)
 
     # g.region should be called with the correct raster and environment
-    mock_run_command.assert_any_call("g.region", raster="elevation", env=mock_session.env)
+    mock_run_command.assert_any_call(
+        "g.region", raster="elevation", env=mock_session.env
+    )
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix only")
@@ -87,7 +91,9 @@ def test_run_tool_with_region(mock_init, mock_create_project, mock_run_command, 
 @patch("grass.app.cli.gs.run_command")
 @patch("grass.app.cli.gs.create_project")
 @patch("grass.app.cli.gs.setup.init")
-def test_run_tool_without_region(mock_init, mock_create_project, mock_run_command, mock_tools_run_cmd):
+def test_run_tool_without_region(
+    mock_init, mock_create_project, mock_run_command, mock_tools_run_cmd
+):
     """Verify that omitting --region does NOT call g.region."""
     # Mock GRASS session
     mock_session = MagicMock()
@@ -108,6 +114,7 @@ def test_run_tool_without_region(mock_init, mock_create_project, mock_run_comman
     # g.region should never be called
     for call in mock_run_command.call_args_list:
         assert call[0][0] != "g.region"
+
 
 def test_subcommand_run_tool_failure_run():
     """Check that a tool produces non-zero return code"""


### PR DESCRIPTION
Hi maintainers,

This PR is a work-in-progress draft to improve the CLI experience for running GRASS tools. It includes the following changes:

Added --region support to the run subcommand:
Allows users to temporarily set a computational region (e.g., raster map) before running a tool.

Initial tests for subcommand_run_tool using mocks:
test_run_tool_with_region checks that g.region is called when --region is provided.
test_run_tool_without_region ensures g.region is not called when the option is omitted.
All tests mock GRASS binaries to avoid requiring a full GRASS session.



**Notes / Guidance Requested.**

The mocks allow the tests to run without setting up a full GRASS environment, but I’m not sure if this aligns with project standards.
Should I replace these with integration-style tests once a GRASS session is available?
Any recommendations on how to structure or extend these tests for coverage of other CLI features would be greatly appreciated.

This PR is explicitly draft/WIP; the goal is to get feedback on the approach before finalizing tests or merging.




Verified both test_run_tool_with_region and test_run_tool_without_region run successfully with mocks.
Existing CLI tests (--help, man, regular tool runs) continue to pass.


**Next steps (after feedback)**

Potentially add full integration tests using a live GRASS session.
Refactor mocks if needed.
Expand tests for other flags or tools in the CLI.