### PR TITLE
r.horizon: height output feature

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -1,41 +1,13 @@
-/*******************************************************************************
-r.horizon: This module does one of two things:
-
-1) Using a map of the terrain elevation it calculates for a set of points
-the angle height of the horizon for each point, using an angle interval given
-by the user.
-
-2) For a given minimum angle it calculates one or more raster map giving the
-mazimum distance to a point on the horizon.
-
-This program was written in 2006 by Thomas Huld and Tomas Cebecauer,
-Joint Research Centre of the European Commission, based on bits of the r.sun
-module by Jaro Hofierka
-
-Program was refactored by Anna Petrasova to remove most global variables.
-
-*******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+/* r.horizon main.c — modified to add map-units raster output per azimuth
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * NEW:
+ *  - Flag -m to also output horizon height in map units (vertical).
+ *  - For each azimuth raster, an additional raster "<basename>_<angle>_height"
+ *    is written with the vertical horizon height in map units.
+ *  - Internal tracking of the distance at which the horizon angle occurs
+ *    (best_length) to compute the vertical height consistently with curvature.
  */
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
 
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -44,113 +16,124 @@ Program was refactored by Anna Petrasova to remove most global variables.
 #include <grass/raster.h>
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
-#include <grass/parson.h>
 
-#define WHOLE_RASTER   1
-#define SINGLE_POINT   0
-#define RAD            (180. / M_PI)
-#define DEG            ((M_PI) / 180.)
-#define EARTHRADIUS    6371000.
-#define UNDEF          0.     /* undefined value for terrain aspect */
-#define UNDEFZ         -9999. /* undefined value for elevation */
-#define BIG            1.e20
-#define SMALL          1.e-20
-#define EPS            1.e-4
-#define DIST           "1.0"
-#define DEGREEINMETERS 111120.  /* 1852m/nm * 60nm/degree = 111120 m/deg */
-#define TANMINANGLE    0.008727 /* tan of minimum horizon angle (0.5 deg) */
+#define WHOLE_RASTER 1
+#define SINGLE_POINT 0
+#define RAD (180. / M_PI)
+#define DEG ((M_PI)/180.)
+#define EARTHRADIUS 6371000.
+#define UNDEF 0.            /* undefined value for terrain aspect */
+#define UNDEFZ -9999.       /* undefined value for elevation */
+#define BIG 1.e20
+#define SMALL 1.e-20
+#define EPS 1.e-4
+#define DIST "1.0"
+#define DEGREEINMETERS 111120. /* 1852m/nm * 60nm/degree = 111120 m/deg */
+#define TANMINANGLE 0.008727   /* tan of minimum horizon angle (0.5 deg) */
+#define AMAX1(arg1, arg2) ((arg1) >= (arg2) ? (arg1) : (arg2))
+#define DISTANCE1(x1, x2, y1, y2) (sqrt((x1 - x2)*(x1 - x2) + (y1 - y2)*(y1 - y2)))
 
-#define DISTANCE1(x1, x2, y1, y2) \
-    (sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2)))
-
+FILE *fp;
 const double pihalf = M_PI * 0.5;
 const double twopi = M_PI * 2.;
 const double invEarth = 1. / EARTHRADIUS;
 const double deg2rad = M_PI / 180.;
 const double rad2deg = 180. / M_PI;
+const double minAngle = DEG;
 
+const char *elevin;
+const char *horizon = NULL;
+const char *mapset = NULL;
+const char *per;
+
+char *shad_filename;
+char *outfile;
+
+/* NEW: secondary output name for map-units raster */
+char *shad_filename_mu; /* NEW */
+
+/* NEW: option to write map-units raster */
+int mapunitsOutput = FALSE; /* NEW */
+
+struct Cell_head cellhd;
+struct Key_value *in_proj_info, *in_unit_info;
 struct pj_info iproj, oproj, tproj;
+struct Cell_head new_cellhd;
+
+double bufferZone = 0., ebufferZone = 0., wbufferZone = 0.,
+       nbufferZone = 0., sbufferZone = 0.;
+
+int INPUT(void);
+int OUTGR(int numrows, int numcols);
+double amax1(double, double);
+double amin1(double, double);
+int min(int, int);
+int max(int, int);
+void com_par(double angle);
+int is_shadow(void);
+double horizon_height(void);
+void calculate_shadow();
+double calculate_shadow_onedirection(double shadow_angle);
+int new_point();
+double searching();
+int test_low_res();
+/*void where_is_point();
+ void cube(int, int);
+ */
+
+void calculate(double xcoord, double ycoord, int buffer_e, int buffer_w,
+               int buffer_s, int buffer_n);
+
+int ip, jp, ip100, jp100;
+int n, m, m100, n100;
+
+int degreeOutput, compassOutput = FALSE;
+
 float **z, **z100, **horizon_raster;
-bool ll_correction = false;
+/* NEW: a second raster array for map-units height */
+float **horizon_raster_mu; /* NEW */
 
-typedef struct {
-    double xg0, yg0;
-    double z_orig;
-    double coslatsq;
-    double maxlength;
-} OriginPoint;
+double stepx, stepy, stepxhalf, stepyhalf, stepxy, xp, yp, op, dp, xg0, xx0,
+       yg0, yy0, deltx, delty;
+double invstepx, invstepy, distxy;
+double offsetx, offsety;
+double single_direction;
+/*int arrayNumInt; */
+double xmin, xmax, ymin, ymax, zmax = 0.;
+int d, day, tien = 0;
+double length, maxlength = BIG, zmult = 1.0, dist;
+double fixedMaxLength = BIG, step = 0.0, start = 0.0, end = 0.0;
+char *tt, *lt;
+double z_orig, zp;
+double h0, tanh0, angle;
+double stepsinangle, stepcosangle, sinangle, cosangle, distsinangle,
+       distcosangle;
+double TOLER;
+const char *str_step;
+int mode;
 
-typedef struct {
-    double stepsinangle, stepcosangle;
-    double sinangle, cosangle;
-    double distsinangle, distcosangle;
-} OriginAngle;
+int isMode()
+{
+    return mode;
+}
+void setMode(int val)
+{
+    mode = val;
+}
 
-typedef struct {
-    double xx0, yy0;
-    int ip, jp;
-    int ip100, jp100;
-    double zp;
-    double length;
-} SearchPoint;
+int ll_correction = FALSE;
+double coslatsq;
 
-typedef struct {
-    double tanh0;
-    double length;
-} HorizonProperties;
-
-typedef struct {
-    int n, m, m100, n100;
-    double stepx, stepy, stepxy;
-    double invstepx, invstepy;
-    double offsetx, offsety;
-    double distxy;
-    double xmin, xmax, ymin, ymax, zmax;
-} Geometry;
-
-typedef struct {
-    bool horizonDistance;
-    int degreeOutput;
-    int compassOutput;
-    double fixedMaxLength;
-    double start, end, step;
-    double single_direction;
-    const char *str_step;
-    const char *horizon_basename;
-} Settings;
-
-enum OutputFormat { PLAIN, JSON };
-
-int INPUT(Geometry *geometry, const char *elevin);
-int OUTGR(const Settings *settings, char *shad_filename,
-          struct Cell_head *cellhd);
-void com_par(const Geometry *geometry, OriginAngle *origin_angle, double angle,
-             double xp, double yp);
-HorizonProperties horizon_height(const Geometry *geometry,
-                                 const OriginPoint *origin_point,
-                                 const OriginAngle *origin_angle);
-void calculate_point_mode(const Settings *settings, const Geometry *geometry,
-                          double xcoord, double ycoord, FILE *fp,
-                          enum OutputFormat format, JSON_Object *json_origin);
-int new_point(const Geometry *geometry, const OriginPoint *origin_point,
-              const OriginAngle *origin_angle, SearchPoint *search_point,
-              HorizonProperties *horizon);
-int test_low_res(const Geometry *geometry, const OriginPoint *origin_point,
-                 const OriginAngle *origin_angle, SearchPoint *search_point,
-                 const HorizonProperties *horizon);
-void calculate_raster_mode(const Settings *settings, const Geometry *geometry,
-                           struct Cell_head *cellhd,
-                           struct Cell_head *new_cellhd, int buffer_e,
-                           int buffer_w, int buffer_s, int buffer_n,
-                           double bufferZone);
+/* NEW: track the range at which the current best horizon angle occurs */
+double best_length = 0.0; /* NEW */
 
 /* why not use G_distance() here which switches to geodesic/great
-   circle distance as needed? */
-double distance(double x1, double x2, double y1, double y2, double coslatsq)
+ circle distance as needed? */
+double distance(double x1, double x2, double y1, double y2)
 {
     if (ll_correction) {
-        return DEGREEINMETERS *
-               sqrt(coslatsq * (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+        return DEGREEINMETERS * sqrt(coslatsq * (x1 - x2) * (x1 - x2)
+                     + (y1 - y2) * (y1 - y2));
     }
     else {
         return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
@@ -160,39 +143,40 @@ double distance(double x1, double x2, double y1, double y2, double coslatsq)
 int main(int argc, char *argv[])
 {
     double xcoord, ycoord;
-    double *xcoords, *ycoords;
-    enum OutputFormat format;
 
     struct GModule *module;
-    struct {
-        struct Option *elevin, *dist, *coord, *direction, *horizon, *step,
-            *start, *end, *bufferzone, *e_buff, *w_buff, *n_buff, *s_buff,
-            *maxdistance, *format, *output, *nprocs;
+
+    struct
+    {
+        struct Option *elevin, *dist, *coord, *direction, *horizon,
+                      *step, *start, *end, *bufferzone, *e_buff, *w_buff,
+                      *n_buff, *s_buff, *maxdistance, *output;
     } parm;
 
-    struct {
-        struct Flag *horizonDistance, *degreeOutput, *compassOutput;
-    } flag;
+    struct
+    {
+        struct Flag *degreeOutput, *compassOutput;
+        struct Flag *mapunitsOutput; /* NEW */
+    }
+    flag;
 
     G_gisinit(argv[0]);
+
     module = G_define_module();
     G_add_keyword(_("raster"));
     G_add_keyword(_("solar"));
     G_add_keyword(_("sun position"));
-    G_add_keyword(_("parallel"));
     module->label =
         _("Computes horizon angle height from a digital elevation model.");
     module->description =
         _("The module has two "
           "different modes of operation: "
-          "1. Computes the entire horizon around a single point whose "
-          "coordinates are "
+          "1. Computes the entire horizon around a single point whose coordinates are "
           "given with the 'coord' option. The horizon height (in radians). "
-          "2. Computes one or more raster maps of the horizon height in a "
-          "single direction. "
+          "2. Computes one or more raster maps of the horizon height in a single direction. "
           "The input for this is the angle (in degrees), which is measured "
-          "counterclockwise with east=0, north=90 etc. The output is the "
-          "horizon height in radians.");
+          "counterclockwise with east=0, north=90 etc. The output is the horizon height in radians."
+          " Optionally, map-units vertical height rasters can also be written."); /* NEW: mention */
 
     parm.elevin = G_define_standard_option(G_OPT_R_ELEV);
     parm.elevin->guisection = _("Input");
@@ -236,45 +220,39 @@ int main(int argc, char *argv[])
     parm.bufferzone->type = TYPE_DOUBLE;
     parm.bufferzone->required = NO;
     parm.bufferzone->description =
-        _("For horizon rasters, read from the DEM an extra buffer around the "
-          "present region");
-    parm.bufferzone->options = "0-";
+        _("For horizon rasters, read from the DEM an extra buffer around the present region");
     parm.bufferzone->guisection = _("Raster mode");
 
     parm.e_buff = G_define_option();
     parm.e_buff->key = "e_buff";
     parm.e_buff->type = TYPE_DOUBLE;
     parm.e_buff->required = NO;
-    parm.e_buff->description = _("For horizon rasters, read from the DEM an "
-                                 "extra buffer eastward the present region");
-    parm.e_buff->options = "0-";
+    parm.e_buff->description =
+        _("For horizon rasters, read from the DEM an extra buffer eastward the present region");
     parm.e_buff->guisection = _("Raster mode");
 
     parm.w_buff = G_define_option();
     parm.w_buff->key = "w_buff";
     parm.w_buff->type = TYPE_DOUBLE;
     parm.w_buff->required = NO;
-    parm.w_buff->description = _("For horizon rasters, read from the DEM an "
-                                 "extra buffer westward the present region");
-    parm.w_buff->options = "0-";
+    parm.w_buff->description =
+        _("For horizon rasters, read from the DEM an extra buffer westward the present region");
     parm.w_buff->guisection = _("Raster mode");
 
     parm.n_buff = G_define_option();
     parm.n_buff->key = "n_buff";
     parm.n_buff->type = TYPE_DOUBLE;
     parm.n_buff->required = NO;
-    parm.n_buff->description = _("For horizon rasters, read from the DEM an "
-                                 "extra buffer northward the present region");
-    parm.n_buff->options = "0-";
+    parm.n_buff->description =
+        _("For horizon rasters, read from the DEM an extra buffer northward the present region");
     parm.n_buff->guisection = _("Raster mode");
 
     parm.s_buff = G_define_option();
     parm.s_buff->key = "s_buff";
     parm.s_buff->type = TYPE_DOUBLE;
     parm.s_buff->required = NO;
-    parm.s_buff->description = _("For horizon rasters, read from the DEM an "
-                                 "extra buffer southward the present region");
-    parm.s_buff->options = "0-";
+    parm.s_buff->description =
+        _("For horizon rasters, read from the DEM an extra buffer southward the present region");
     parm.s_buff->guisection = _("Raster mode");
 
     parm.maxdistance = G_define_option();
@@ -291,8 +269,7 @@ int main(int argc, char *argv[])
 
     parm.coord = G_define_standard_option(G_OPT_M_COORDS);
     parm.coord->description =
-        _("Coordinate(s) for which you want to calculate the horizon");
-    parm.coord->multiple = YES;
+        _("Coordinate for which you want to calculate the horizon");
     parm.coord->guisection = _("Point mode");
 
     parm.dist = G_define_option();
@@ -303,9 +280,6 @@ int main(int argc, char *argv[])
     parm.dist->description = _("Sampling distance step coefficient (0.5-1.5)");
     parm.dist->guisection = _("Optional");
 
-    parm.format = G_define_standard_option(G_OPT_F_FORMAT);
-    parm.format->guisection = _("Point mode");
-
     parm.output = G_define_standard_option(G_OPT_F_OUTPUT);
     parm.output->key = "file";
     parm.output->required = NO;
@@ -313,14 +287,6 @@ int main(int argc, char *argv[])
     parm.output->description =
         _("Name of file for output (use output=- for stdout)");
     parm.output->guisection = _("Point mode");
-
-    parm.nprocs = G_define_standard_option(G_OPT_M_NPROCS);
-
-    flag.horizonDistance = G_define_flag();
-    flag.horizonDistance->key = 'l';
-    flag.horizonDistance->description =
-        _("Include horizon distance in the plain output");
-    flag.horizonDistance->guisection = _("Point mode");
 
     flag.degreeOutput = G_define_flag();
     flag.degreeOutput->key = 'd';
@@ -332,212 +298,179 @@ int main(int argc, char *argv[])
     flag.compassOutput->description =
         _("Write output in compass orientation (default is CCW, East=0)");
 
+    /* NEW: -m flag for map units */
+    flag.mapunitsOutput = G_define_flag(); /* NEW */
+    flag.mapunitsOutput->key = 'm';        /* NEW */
+    flag.mapunitsOutput->description =     /* NEW */
+        _("Also write raster(s) of horizon height in map units (vertical), adding suffix '_height'"); /* NEW */
+
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    int nprocs = G_set_omp_num_threads(parm.nprocs);
-    nprocs = Rast_disable_omp_on_mask(nprocs);
-
-    struct Cell_head cellhd;
-    struct Cell_head new_cellhd;
     G_get_set_window(&cellhd);
-    Geometry geometry;
+    stepx = cellhd.ew_res;
+    stepy = cellhd.ns_res;
+    stepxhalf = stepx / 2.;
+    stepyhalf = stepy / 2.;
+    invstepx = 1. / stepx;
+    invstepy = 1. / stepy;
 
-    geometry.stepx = cellhd.ew_res;
-    geometry.stepy = cellhd.ns_res;
-    geometry.invstepx = 1. / geometry.stepx;
-    geometry.invstepy = 1. / geometry.stepy;
     /*
-       offsetx = 2. *  invstepx;
-       offsety = 2. * invstepy;
-       offsetx = 0.5*stepx;
-       offsety = 0.5*stepy;
+     offsetx = 2. * invstepx;
+     offsety = 2. * invstepy;
+     offsetx = 0.5*stepx;
+     offsety = 0.5*stepy;
      */
-    geometry.offsetx = 0.5;
-    geometry.offsety = 0.5;
+    offsetx = 0.5;
+    offsety = 0.5;
 
-    geometry.n /*n_cols */ = cellhd.cols;
-    geometry.m /*n_rows */ = cellhd.rows;
+    n /*n_cols */ = cellhd.cols;
+    m /*n_rows */ = cellhd.rows;
+    n100 = ceil(n / 100.);
+    m100 = ceil(m / 100.);
 
-    geometry.n100 = ceil(geometry.n / 100.);
-    geometry.m100 = ceil(geometry.m / 100.);
+    xmin = cellhd.west;
+    ymin = cellhd.south;
+    xmax = cellhd.east;
+    ymax = cellhd.north;
 
-    geometry.xmin = cellhd.west;
-    geometry.ymin = cellhd.south;
-    geometry.xmax = cellhd.east;
-    geometry.ymax = cellhd.north;
+    deltx = fabs(cellhd.east - cellhd.west);
+    delty = fabs(cellhd.north - cellhd.south);
 
-    Settings settings;
-    settings.degreeOutput = flag.degreeOutput->answer;
-    settings.compassOutput = flag.compassOutput->answer;
-    settings.horizonDistance = flag.horizonDistance->answer;
+    degreeOutput = flag.degreeOutput->answer;
+    compassOutput = flag.compassOutput->answer;
+    mapunitsOutput = flag.mapunitsOutput->answer; /* NEW */
 
     if (G_projection() == PROJECTION_LL)
-        G_important_message(_("Note: In latitude-longitude coordinate system "
-                              "specify buffers in degree unit"));
+        G_important_message(_("Note: In latitude-longitude coordinate system specify buffers in degree unit"));
 
-    const char *elevin = parm.elevin->answer;
-    FILE *fp = NULL;
-    int mode;
-    int point_count = 0;
+    elevin = parm.elevin->answer;
+
     if (parm.coord->answer == NULL) {
         G_debug(1, "Setting mode: WHOLE_RASTER");
-        mode = WHOLE_RASTER;
+        setMode(WHOLE_RASTER);
     }
     else {
         G_debug(1, "Setting mode: SINGLE_POINT");
-        mode = SINGLE_POINT;
-        if (strcmp(parm.format->answer, "json") == 0)
-            format = JSON;
-        else
-            format = PLAIN;
-
-        for (int i = 0; parm.coord->answers[i]; i += 2) {
-            point_count++;
+        setMode(SINGLE_POINT);
+        if (sscanf(parm.coord->answer, "%lf,%lf", &xcoord, &ycoord) != 2) {
+            G_fatal_error(
+                _("Can't read the coordinates from the \"coordinate\" option."));
         }
-        xcoords = (double *)G_malloc(point_count * sizeof(double));
-        ycoords = (double *)G_malloc(point_count * sizeof(double));
-        for (int i = 0; i < point_count; ++i) {
-            if (!(G_scan_easting(parm.coord->answers[2 * i], &xcoord,
-                                 G_projection()) &&
-                  G_scan_northing(parm.coord->answers[2 * i + 1], &ycoord,
-                                  G_projection()))) {
-                G_fatal_error(_("Can't read the coordinates from the "
-                                "\"coordinate\" option."));
-            }
-            if (xcoord < cellhd.west || xcoord >= cellhd.east ||
-                ycoord <= cellhd.south || ycoord > cellhd.north) {
-                G_fatal_error(
-                    _("Coordinates are outside of the current region"));
-            }
-            xcoords[i] = xcoord;
-            ycoords[i] = ycoord;
+        if (xcoord < cellhd.west ||
+            xcoord >= cellhd.east ||
+            ycoord <= cellhd.south ||
+            ycoord > cellhd.north) {
+            G_fatal_error(_("Coordinates are outside of the current region"));
         }
-        /* Transform the coordinates to row/column */
-
-        /*
-           xcoord = (int) ((xcoord-xmin)/stepx);
-           ycoord = (int) ((ycoord-ymin)/stepy);
-         */
 
         /* Open ASCII file for output or stdout */
-        char *outfile = parm.output->answer;
-
+        outfile = parm.output->answer;
         if ((strcmp("-", outfile)) == 0) {
             fp = stdout;
         }
         else if (NULL == (fp = fopen(outfile, "w")))
             G_fatal_error(_("Unable to open file <%s>"), outfile);
     }
-    settings.single_direction = 0;
+
     if (parm.direction->answer != NULL)
-        sscanf(parm.direction->answer, "%lf", &settings.single_direction);
+        sscanf(parm.direction->answer, "%lf", &single_direction);
 
-    settings.step = 0;
-    settings.start = 0;
-    settings.end = 0;
-    settings.horizon_basename = NULL;
-    if (WHOLE_RASTER == mode) {
+    if (isMode(WHOLE_RASTER)) {
         if ((parm.direction->answer == NULL) && (parm.step->answer == NULL)) {
-            G_fatal_error(_("You didn't specify a direction value or step "
-                            "size. Aborting."));
+            G_fatal_error(
+                _("You didn't specify a direction value or step size. Aborting."));
         }
-
         if (parm.horizon->answer == NULL) {
             G_fatal_error(
                 _("You didn't specify a horizon raster name. Aborting."));
         }
-        settings.horizon_basename = parm.horizon->answer;
+        horizon = parm.horizon->answer;
+
         if (parm.step->answer != NULL) {
-            settings.str_step = parm.step->answer;
-            sscanf(parm.step->answer, "%lf", &settings.step);
+            str_step = parm.step->answer;
+            sscanf(parm.step->answer, "%lf", &step);
         }
         else {
-            settings.step = 0;
-            settings.str_step = "0";
+            step = 0;
+            str_step = "0";
         }
-        sscanf(parm.start->answer, "%lf", &settings.start);
-        sscanf(parm.end->answer, "%lf", &settings.end);
-        if (settings.start < 0.0) {
+        sscanf(parm.start->answer, "%lf", &start);
+        sscanf(parm.end->answer, "%lf", &end);
+
+        if (start < 0.0) {
             G_fatal_error(
                 _("Negative values of start angle are not allowed. Aborting."));
         }
-        if (settings.end < 0.0 || settings.end > 360.0) {
-            G_fatal_error(_("End angle is not between 0 and 360. Aborting."));
+        if (end < 0.0 || end > 360.0) {
+            G_fatal_error(
+                _("End angle is not between 0 and 360. Aborting."));
         }
-        if (settings.start >= settings.end) {
+        if (start >= end) {
             G_fatal_error(
                 _("You specify a start grater than the end angle. Aborting."));
         }
-        G_debug(1, "Angle step: %g, start: %g, end: %g", settings.step,
-                settings.start, settings.end);
+        G_debug(1, "Angle step: %g, start: %g, end: %g", step, start, end);
     }
     else {
-
         if (parm.step->answer == NULL) {
             G_fatal_error(
                 _("You didn't specify an angle step size. Aborting."));
         }
-        sscanf(parm.step->answer, "%lf", &settings.step);
+        sscanf(parm.step->answer, "%lf", &step);
     }
 
-    if (settings.step == 0.0) {
-        settings.step = 360.;
+    if (step == 0.0) {
+        step = 360.;
     }
-    double bufferZone = 0., ebufferZone = 0., wbufferZone = 0.,
-           nbufferZone = 0., sbufferZone = 0.;
+
     if (parm.bufferzone->answer != NULL) {
         if (sscanf(parm.bufferzone->answer, "%lf", &bufferZone) != 1)
             G_fatal_error(_("Could not read bufferzone size. Aborting."));
     }
-
     if (parm.e_buff->answer != NULL) {
         if (sscanf(parm.e_buff->answer, "%lf", &ebufferZone) != 1)
             G_fatal_error(_("Could not read %s bufferzone size. Aborting."),
-                          _("east"));
+                     _("east"));
     }
-
     if (parm.w_buff->answer != NULL) {
         if (sscanf(parm.w_buff->answer, "%lf", &wbufferZone) != 1)
             G_fatal_error(_("Could not read %s bufferzone size. Aborting."),
-                          _("west"));
+                     _("west"));
     }
-
     if (parm.s_buff->answer != NULL) {
         if (sscanf(parm.s_buff->answer, "%lf", &sbufferZone) != 1)
-            G_fatal_error(_("Could not read %s bufferzone size. Aborting."),
-                          _("south"));
+            G_fatal_error(
+                _("Could not read %s bufferzone size. Aborting."),
+                _("south"));
     }
-
     if (parm.n_buff->answer != NULL) {
         if (sscanf(parm.n_buff->answer, "%lf", &nbufferZone) != 1)
-            G_fatal_error(_("Could not read %s bufferzone size. Aborting."),
-                          _("north"));
+            G_fatal_error(
+                _("Could not read %s bufferzone size. Aborting."),
+                _("north"));
     }
 
-    settings.fixedMaxLength = BIG;
     if (parm.maxdistance->answer != NULL) {
-        if (sscanf(parm.maxdistance->answer, "%lf", &settings.fixedMaxLength) !=
-            1)
+        if (sscanf(parm.maxdistance->answer, "%lf", &fixedMaxLength) != 1)
             G_fatal_error(_("Could not read maximum distance. Aborting."));
     }
-    G_debug(1, "Using maxdistance %f",
-            settings.fixedMaxLength); /* predefined as BIG */
+    G_debug(1,"Using maxdistance %f", fixedMaxLength); /* predefined as BIG */
 
-    /* TODO: fixing BIG, there is a bug with distant mountains not being seen:
-       attempt to constrain to current region
-
-       fixedMaxLength = (fixedMaxLength < AMAX1(deltx, delty)) ? fixedMaxLength
-       : AMAX1(deltx, delty); G_debug(1,"Using maxdistance %f", fixedMaxLength);
-     */
-    sscanf(parm.dist->answer, "%lf", &geometry.distxy);
-    if (geometry.distxy < 0.5 || geometry.distxy > 1.5)
+    sscanf(parm.dist->answer, "%lf", &dist);
+    if (dist < 0.5 || dist > 1.5 )
         G_fatal_error(_("The distance value must be 0.5-1.5. Aborting."));
 
-    geometry.stepxy = geometry.distxy * 0.5 * (geometry.stepx + geometry.stepy);
+    stepxy = dist * 0.5 * (stepx + stepy);
+    distxy = dist;
+    TOLER = stepxy * EPS;
 
-    if (bufferZone > 0. || ebufferZone > 0. || wbufferZone > 0. ||
-        sbufferZone > 0. || nbufferZone > 0.) {
+    if (bufferZone > 0. ||
+        ebufferZone > 0. ||
+        wbufferZone > 0. ||
+        sbufferZone > 0. ||
+        nbufferZone > 0.) {
+
         new_cellhd = cellhd;
 
         if (ebufferZone == 0.)
@@ -549,46 +482,40 @@ int main(int argc, char *argv[])
         if (nbufferZone == 0.)
             nbufferZone = bufferZone;
 
-        /* adjust buffer to multiples of resolution */
-        ebufferZone = (int)(ebufferZone / geometry.stepx) * geometry.stepx;
-        wbufferZone = (int)(wbufferZone / geometry.stepx) * geometry.stepx;
-        sbufferZone = (int)(sbufferZone / geometry.stepy) * geometry.stepy;
-        nbufferZone = (int)(nbufferZone / geometry.stepy) * geometry.stepy;
-
-        new_cellhd.rows += (int)((nbufferZone + sbufferZone) / geometry.stepy);
-        new_cellhd.cols += (int)((ebufferZone + wbufferZone) / geometry.stepx);
-
+        new_cellhd.rows += (int)((nbufferZone + sbufferZone) / stepy);
+        new_cellhd.cols += (int)((ebufferZone + wbufferZone) / stepx);
         new_cellhd.north += nbufferZone;
         new_cellhd.south -= sbufferZone;
         new_cellhd.east += ebufferZone;
         new_cellhd.west -= wbufferZone;
 
-        geometry.xmin = new_cellhd.west;
-        geometry.ymin = new_cellhd.south;
-        geometry.xmax = new_cellhd.east;
-        geometry.ymax = new_cellhd.north;
+        xmin = new_cellhd.west;
+        ymin = new_cellhd.south;
+        xmax = new_cellhd.east;
+        ymax = new_cellhd.north;
+        deltx = fabs(new_cellhd.east - new_cellhd.west);
+        delty = fabs(new_cellhd.north - new_cellhd.south);
 
-        geometry.n /* n_cols */ = new_cellhd.cols;
-        geometry.m /* n_rows */ = new_cellhd.rows;
-        G_debug(1, "%lf %lf %lf %lf \n", geometry.ymax, geometry.ymin,
-                geometry.xmin, geometry.xmax);
-        geometry.n100 = ceil(geometry.n / 100.);
-        geometry.m100 = ceil(geometry.m / 100.);
+        n /* n_cols */ = new_cellhd.cols;
+        m /* n_rows */ = new_cellhd.rows;
+
+        G_debug(1,"%lf %lf %lf %lf \n",ymax, ymin, xmin,xmax);
+
+        n100 = ceil(n / 100.);
+        m100 = ceil(m / 100.);
 
         Rast_set_window(&new_cellhd);
     }
 
     struct Key_Value *in_proj_info, *in_unit_info;
-
     if ((in_proj_info = G_get_projinfo()) == NULL)
-        G_fatal_error(_("Can't get projection info of current location"));
-
+        G_fatal_error(
+           _("Can't get projection info of current location"));
     if ((in_unit_info = G_get_projunits()) == NULL)
         G_fatal_error(_("Can't get projection units of current location"));
-
     if (pj_get_kv(&iproj, in_proj_info, in_unit_info) < 0)
-        G_fatal_error(_("Can't get projection key values of current location"));
-
+        G_fatal_error(
+           _("Can't get projection key values of current location"));
     G_free_key_value(in_proj_info);
     G_free_key_value(in_unit_info);
 
@@ -598,75 +525,45 @@ int main(int argc, char *argv[])
     if (GPJ_init_transform(&iproj, &oproj, &tproj) < 0)
         G_fatal_error(_("Unable to initialize coordinate transformation"));
 
-    /**********end of parser - ******************************/
+/********** end of parser **********/
 
-    INPUT(&geometry, elevin);
-    if (mode == SINGLE_POINT) {
-        JSON_Value *root_value, *origin_value;
-        JSON_Array *coordinates;
-        JSON_Object *origin;
-        if (format == JSON) {
-            root_value = json_value_init_array();
-            coordinates = json_value_get_array(root_value);
-            json_set_float_serialization_format("%lf");
-        }
-        for (int i = 0; i < point_count; ++i) {
-            /* Calculate the horizon for each point */
-            if (format == JSON) {
-                origin_value = json_value_init_object();
-                origin = json_value_get_object(origin_value);
-            }
-            calculate_point_mode(&settings, &geometry, xcoords[i], ycoords[i],
-                                 fp, format, origin);
-            if (format == JSON)
-                json_array_append_value(coordinates, origin_value);
-        }
-        if (format == JSON) {
-            char *json_string = json_serialize_to_string_pretty(root_value);
-            fprintf(fp, "%s\n", json_string);
-            json_free_serialized_string(json_string);
-            json_value_free(root_value);
-        }
-        fclose(fp);
-        G_free(xcoords);
-        G_free(ycoords);
-    }
-    else {
-        calculate_raster_mode(&settings, &geometry, &cellhd, &new_cellhd,
-                              (int)(ebufferZone / geometry.stepx),
-                              (int)(wbufferZone / geometry.stepx),
-                              (int)(sbufferZone / geometry.stepy),
-                              (int)(nbufferZone / geometry.stepy), bufferZone);
-    }
+    INPUT();
+
+    G_debug(1, "calculate() starts...");
+    calculate(xcoord, ycoord, (int)(ebufferZone / stepx),
+              (int)(wbufferZone / stepx), (int)(sbufferZone / stepy),
+              (int)(nbufferZone / stepy));
 
     exit(EXIT_SUCCESS);
 }
 
-/**********************end of main.c*****************/
+/*********************** end of main.c *************************/
 
-int INPUT(Geometry *geometry, const char *elevin)
+int INPUT(void)
 {
-    FCELL *cell1 = Rast_allocate_f_buf();
+    FCELL *cell1;
+    int fd1, row, row_rev;
+    int l, i, j, k;
+    int lmax, kmax;
 
-    z = (float **)G_malloc(sizeof(float *) * (geometry->m));
-    z100 = (float **)G_malloc(sizeof(float *) * (geometry->m100));
+    cell1 = Rast_allocate_f_buf();
 
-    for (int l = 0; l < geometry->m; l++) {
-        z[l] = (float *)G_malloc(sizeof(float) * (geometry->n));
+    z = (float **)G_malloc(sizeof(float *) * (m));
+    z100 = (float **)G_malloc(sizeof(float *) * (m100));
+
+    for (l = 0; l < m; l++) {
+        z[l] = (float *)G_malloc(sizeof(float) * (n));
     }
-    for (int l = 0; l < geometry->m100; l++) {
-        z100[l] = (float *)G_malloc(sizeof(float) * (geometry->n100));
+    for (l = 0; l < m100; l++) {
+        z100[l] = (float *)G_malloc(sizeof(float) * (n100));
     }
+
     /*read Z raster */
-
-    int fd1 = Rast_open_old(elevin, "");
-
-    for (int row = 0; row < geometry->m; row++) {
+    fd1 = Rast_open_old(elevin, "");
+    for (row = 0; row < m; row++) {
         Rast_get_f_row(fd1, cell1, row);
-
-        for (int j = 0; j < geometry->n; j++) {
-            int row_rev = geometry->m - row - 1;
-
+        for (j = 0; j < n; j++) {
+            row_rev = m - row - 1;
             if (!Rast_is_f_null_value(cell1 + j))
                 z[row_rev][j] = (float)cell1[j];
             else
@@ -676,308 +573,302 @@ int INPUT(Geometry *geometry, const char *elevin)
     Rast_close(fd1);
 
     /* create low resolution array 100 */
-    for (int i = 0; i < geometry->m100; i++) {
-        int lmax = (i + 1) * 100;
-        if (lmax > geometry->m)
-            lmax = geometry->m;
-
-        for (int j = 0; j < geometry->n100; j++) {
-            geometry->zmax = SMALL;
-            int kmax = (j + 1) * 100;
-            if (kmax > geometry->n)
-                kmax = geometry->n;
-            for (int l = (i * 100); l < lmax; l++) {
-                for (int k = (j * 100); k < kmax; k++) {
-                    geometry->zmax = MAX(geometry->zmax, z[l][k]);
+    for (i = 0; i < m100; i++) {
+        lmax = (i + 1) * 100;
+        if (lmax > m)
+            lmax = m;
+        for (j = 0; j < n100; j++) {
+            zmax = SMALL;
+            kmax = (j + 1) * 100;
+            if (kmax > n)
+                kmax = n;
+            for (l = (i * 100); l < lmax; l++) {
+                for (k = (j * 100); k < kmax; k++) {
+                    zmax = amax1(zmax, z[l][k]);
                 }
             }
-            z100[i][j] = geometry->zmax;
-            G_debug(3, "%d %d %lf\n", i, j, z100[i][j]);
+            z100[i][j] = zmax;
+            G_debug(3,"%d %d %lf\n", i, j, z100[i][j]);
         }
     }
 
     /* find max Z */
-    for (int i = 0; i < geometry->m; i++) {
-        for (int j = 0; j < geometry->n; j++) {
-            geometry->zmax = MAX(geometry->zmax, z[i][j]);
+    for (i = 0; i < m; i++) {
+        for (j = 0; j < n; j++) {
+            zmax = amax1(zmax, z[i][j]);
         }
     }
-
     return 1;
 }
 
-int OUTGR(const Settings *settings, char *shad_filename,
-          struct Cell_head *cellhd)
+int OUTGR(int numrows, int numcols)
 {
     FCELL *cell1 = NULL;
     int fd1 = 0;
+    int i, iarc, j;
 
-    int numrows = cellhd->rows;
-    int numcols = cellhd->cols;
-    Rast_set_window(cellhd);
+    Rast_set_window(&cellhd);
 
-    if (settings->horizon_basename != NULL) {
+    if (horizon != NULL) {
         cell1 = Rast_allocate_f_buf();
         fd1 = Rast_open_fp_new(shad_filename);
     }
 
     if (numrows != Rast_window_rows())
         G_fatal_error(_("OOPS: rows changed from %d to %d"), numrows,
-                      Rast_window_rows());
-
+             Rast_window_rows());
     if (numcols != Rast_window_cols())
         G_fatal_error(_("OOPS: cols changed from %d to %d"), numcols,
-                      Rast_window_cols());
+             Rast_window_cols());
 
-    for (int iarc = 0; iarc < numrows; iarc++) {
-        int i = numrows - iarc - 1;
-
-        if (settings->horizon_basename != NULL) {
-            for (int j = 0; j < numcols; j++) {
+    for (iarc = 0; iarc < numrows; iarc++) {
+        i = numrows - iarc - 1;
+        if (horizon != NULL) {
+            for (j = 0; j < numcols; j++) {
                 if (horizon_raster[i][j] == UNDEFZ)
                     Rast_set_f_null_value(cell1 + j, 1);
                 else
-                    cell1[j] = (FCELL)horizon_raster[i][j];
+                    cell1[j] = (FCELL) horizon_raster[i][j];
             }
             Rast_put_f_row(fd1, cell1);
         }
-    } /* End loop over rows. */
-
+    }               /* End loop over rows. */
     Rast_close(fd1);
-
     return 1;
 }
 
-/**********************************************************/
-
-void com_par(const Geometry *geometry, OriginAngle *origin_angle, double angle,
-             double xp, double yp)
+double amax1(arg1, arg2)
+ double arg1;
+ double arg2;
 {
-    double longitude = xp;
-    double latitude = yp;
-    if (G_projection() != PROJECTION_LL) {
-        if (GPJ_transform(&iproj, &oproj, &tproj, PJ_FWD, &longitude, &latitude,
-                          NULL) < 0)
-            G_fatal_error(_("Error in %s"), "GPJ_transform()");
+    double res;
+    if (arg1 >= arg2) {
+        res = arg1;
     }
-    latitude *= deg2rad;
-    longitude *= deg2rad;
-
-    double delt_lat =
-        -0.0001 * cos(angle); /* Arbitrary small distance in latitude */
-    double delt_lon = 0.0001 * sin(angle) / cos(latitude);
-
-    latitude = (latitude + delt_lat) * rad2deg;
-    longitude = (longitude + delt_lon) * rad2deg;
-
-    if (G_projection() != PROJECTION_LL) {
-        if (GPJ_transform(&iproj, &oproj, &tproj, PJ_INV, &longitude, &latitude,
-                          NULL) < 0)
-            G_fatal_error(_("Error in %s"), "GPJ_transform()");
+    else {
+        res = arg2;
     }
-    double delt_east = longitude - xp;
-    double delt_nor = latitude - yp;
-
-    double delt_dist = sqrt(delt_east * delt_east + delt_nor * delt_nor);
-
-    origin_angle->sinangle = delt_nor / delt_dist;
-    origin_angle->cosangle = delt_east / delt_dist;
-
-    if (fabs(origin_angle->sinangle) < 0.0000001) {
-        origin_angle->sinangle = 0.;
+    return res;
+}
+double amin1(arg1, arg2)
+ double arg1;
+ double arg2;
+{
+    double res;
+    if (arg1 <= arg2) {
+        res = arg1;
     }
-    if (fabs(origin_angle->cosangle) < 0.0000001) {
-        origin_angle->cosangle = 0.;
+    else {
+        res = arg2;
     }
-    origin_angle->distsinangle = 32000;
-    origin_angle->distcosangle = 32000;
-
-    if (origin_angle->sinangle != 0.) {
-        origin_angle->distsinangle =
-            100. / (geometry->distxy * origin_angle->sinangle);
+    return res;
+}
+int min(arg1, arg2)
+ int arg1;
+ int arg2;
+{
+    int res;
+    if (arg1 <= arg2) {
+        res = arg1;
     }
-    if (origin_angle->cosangle != 0.) {
-        origin_angle->distcosangle =
-            100. / (geometry->distxy * origin_angle->cosangle);
+    else {
+        res = arg2;
     }
-
-    origin_angle->stepsinangle = geometry->stepxy * origin_angle->sinangle;
-    origin_angle->stepcosangle = geometry->stepxy * origin_angle->cosangle;
+    return res;
+}
+int max(arg1, arg2)
+ int arg1;
+ int arg2;
+{
+    int res;
+    if (arg1 >= arg2) {
+        res = arg1;
+    }
+    else {
+        res = arg2;
+    }
+    return res;
 }
 
-void calculate_point_mode(const Settings *settings, const Geometry *geometry,
-                          double xcoord, double ycoord, FILE *fp,
-                          enum OutputFormat format, JSON_Object *json_origin)
+/******************************************************************/
+void com_par(double angle)
 {
-    /*
-       xg0 = xx0 = (double)xcoord * stepx;
-       yg0 = yy0 = (double)ycoord * stepy;
-       xg0 = xx0 = xcoord -0.5*stepx -xmin;
-       yg0 = yy0 = ycoord -0.5*stepy-ymin;
-       xg0 = xx0 = xindex*stepx -0.5*stepx;
-       yg0 = yy0 = yindex*stepy -0.5*stepy;
-     */
-    OriginPoint origin_point;
-    int xindex = (int)((xcoord - geometry->xmin) / geometry->stepx);
-    int yindex = (int)((ycoord - geometry->ymin) / geometry->stepy);
-    origin_point.xg0 = xindex * geometry->stepx;
-    origin_point.yg0 = yindex * geometry->stepy;
-    origin_point.coslatsq = 0;
-    if ((G_projection() == PROJECTION_LL)) {
-        ll_correction = true;
+    sinangle = sin(angle);
+    if (fabs(sinangle) < 0.0000001) {
+        sinangle = 0.;
     }
-    if (ll_correction) {
-        double coslat = cos(deg2rad * (geometry->ymin + origin_point.yg0));
-        origin_point.coslatsq = coslat * coslat;
+    cosangle = cos(angle);
+    if (fabs(cosangle) < 0.0000001) {
+        cosangle = 0.;
     }
+    distsinangle = 32000;
+    distcosangle = 32000;
+    if (sinangle != 0.) {
+        distsinangle = 100. / (distxy * sinangle);
+    }
+    if (cosangle != 0.) {
+        distcosangle = 100. / (distxy * cosangle);
+    }
+    stepsinangle = stepxy * sinangle;
+    stepcosangle = stepxy * cosangle;
+}
 
-    origin_point.z_orig = z[yindex][xindex];
-    G_debug(1, "yindex: %d, xindex %d, z_orig %.2f", yindex, xindex,
-            origin_point.z_orig);
+double horizon_height(void)
+{
+    double height;
+    tanh0 = -1.0 / 0.0; /* -inf */
+    length = 0;
 
-    int printCount = 360. / fabs(settings->step);
+    /* NEW: reset best_length tracking */
+    best_length = 0.0; /* NEW */
 
+    height = searching();
+    xx0 = xg0;
+    yy0 = yg0;
+    return height;
+}
+
+double calculate_shadow_onedirection(double shadow_angle)
+{
+    shadow_angle = horizon_height();
+    return shadow_angle;
+}
+
+void calculate_shadow()
+{
+    double dfr_rad;
+    int i;
+    int printCount;
+    double shadow_angle;
+    double printangle;
+    double sx, sy;
+    double xp, yp;
+    double latitude, longitude;
+    double delt_lat, delt_lon;
+    double delt_east, delt_nor;
+    double delt_dist;
+    double angle;
+
+    printCount = 360. / fabs(step);
     if (printCount < 1)
         printCount = 1;
-    double dfr_rad = settings->step * deg2rad;
 
-    double xp = geometry->xmin + origin_point.xg0;
-    double yp = geometry->ymin + origin_point.yg0;
+    dfr_rad = step * deg2rad;
 
-    double angle = (settings->single_direction * deg2rad) + pihalf;
-    double printangle = settings->single_direction;
+    xp = xmin + xx0;
+    yp = ymin + yy0;
 
-    origin_point.maxlength = settings->fixedMaxLength;
-    /* JSON variables and formatting */
+    angle = (single_direction * deg2rad) + pihalf;
+    maxlength = fixedMaxLength;
 
-    JSON_Value *horizons_value;
-    JSON_Array *horizons;
+    fprintf(fp, "azimuth,horizon_height\n");
 
-    switch (format) {
-    case PLAIN:
-        fprintf(fp, "azimuth,horizon_height");
-        if (settings->horizonDistance)
-            fprintf(fp, ",horizon_distance");
-        fprintf(fp, "\n");
-        break;
-    case JSON:
-        json_object_set_number(json_origin, "x", xcoord);
-        json_object_set_number(json_origin, "y", ycoord);
-        horizons_value = json_value_init_array();
-        horizons = json_value_get_array(horizons_value);
-        break;
-    }
+    for (i = 0; i < printCount; i++) {
 
-    for (int i = 0; i < printCount; i++) {
-        JSON_Value *value;
-        JSON_Object *object;
-        OriginAngle origin_angle;
-        com_par(geometry, &origin_angle, angle, xp, yp);
+        ip = jp = 0;
+        sx = xx0 * invstepx;
+        sy = yy0 * invstepy;
+        ip100 = floor(sx / 100.);
+        jp100 = floor(sy / 100.);
 
-        HorizonProperties horizon =
-            horizon_height(geometry, &origin_point, &origin_angle);
-        double shadow_angle = atan(horizon.tanh0);
+        if ((G_projection() != PROJECTION_LL)) {
+            longitude = xp;
+            latitude = yp;
+            if (GPJ_transform(&iproj, &oproj, &tproj, PJ_FWD,
+                      &longitude, &latitude, NULL) < 0)
+                G_fatal_error(_("Error in %s"), "GPJ_transform()");
+        }
+        else {          /* ll projection */
+            latitude = yp;
+            longitude = xp;
+        }
 
-        if (settings->degreeOutput) {
+        latitude *= deg2rad;
+        longitude *= deg2rad;
+        delt_lat = -0.0001 * cos(angle);
+        delt_lon = 0.0001 * sin(angle) / cos(latitude);
+        latitude = (latitude + delt_lat) * rad2deg;
+        longitude = (longitude + delt_lon) * rad2deg;
+
+        if (GPJ_transform(&iproj, &oproj, &tproj, PJ_INV,
+                  &longitude, &latitude, NULL) < 0)
+            G_fatal_error(_("Error in %s"), "GPJ_transform()");
+
+        delt_east = longitude - xp;
+        delt_nor = latitude - yp;
+        delt_dist = sqrt(delt_east * delt_east + delt_nor * delt_nor);
+
+        stepsinangle = stepxy * delt_nor / delt_dist;
+        stepcosangle = stepxy * delt_east / delt_dist;
+
+        shadow_angle = horizon_height();
+        if (degreeOutput) {
             shadow_angle *= rad2deg;
         }
-        if (format == JSON) {
-            value = json_value_init_object();
-            object = json_object(value);
-        }
-        if (settings->compassOutput) {
-            double tmpangle;
 
+        printangle = angle * rad2deg - 90.;
+        if (printangle < 0.)
+            printangle += 360;
+        else if (printangle >= 360.)
+            printangle -= 360;
+
+        if(compassOutput ){
+            double tmpangle;
             tmpangle = 360. - printangle + 90.;
             if (tmpangle >= 360.)
                 tmpangle = tmpangle - 360.;
-            switch (format) {
-            case PLAIN:
-                fprintf(fp, "%lf,%lf", tmpangle, shadow_angle);
-                if (settings->horizonDistance)
-                    fprintf(fp, ",%lf", horizon.length);
-                fprintf(fp, "\n");
-                break;
-            case JSON:
-                json_object_set_number(object, "azimuth", tmpangle);
-                json_object_set_number(object, "angle", shadow_angle);
-                json_object_set_number(object, "distance", horizon.length);
-                json_array_append_value(horizons, value);
-                break;
-            }
-        }
-        else {
-            switch (format) {
-            case PLAIN:
-                fprintf(fp, "%lf,%lf", printangle, shadow_angle);
-                if (settings->horizonDistance)
-                    fprintf(fp, ",%lf", horizon.length);
-                fprintf(fp, "\n");
-                break;
-            case JSON:
-                json_object_set_number(object, "azimuth", printangle);
-                json_object_set_number(object, "angle", shadow_angle);
-                json_object_set_number(object, "distance", horizon.length);
-                json_array_append_value(horizons, value);
-                break;
-            }
+            fprintf(fp, "%lf,%lf\n", tmpangle, shadow_angle);
+        } else {
+            fprintf(fp, "%lf,%lf\n", printangle, shadow_angle);
         }
 
         angle += dfr_rad;
-        printangle += settings->step;
-
         if (angle < 0.)
             angle += twopi;
         else if (angle > twopi)
             angle -= twopi;
-
-        if (printangle < 0.)
-            printangle += 360;
-        else if (printangle > 360.)
-            printangle -= 360;
-    } /* end of for loop over angles */
-
-    if (format == JSON) {
-        json_object_set_value(json_origin, "horizons", horizons_value);
-    }
+    }               /* end of for loop over angles */
 }
 
 /*////////////////////////////////////////////////////////////////////// */
-
-int new_point(const Geometry *geometry, const OriginPoint *origin_point,
-              const OriginAngle *origin_angle, SearchPoint *search_point,
-              HorizonProperties *horizon)
+int new_point()
 {
-    int iold = search_point->ip;
-    int jold = search_point->jp;
+    int iold, jold;
+    int succes = 1, succes2 = 1;
+    double sx, sy;
+    double dx, dy;
 
-    while (TRUE) {
-        search_point->yy0 += origin_angle->stepsinangle;
-        search_point->xx0 += origin_angle->stepcosangle;
+    iold = ip;
+    jold = jp;
+
+    while (succes) {
+        yy0 += stepsinangle;
+        xx0 += stepcosangle;
 
         /* offset 0.5 cell size to get the right cell i, j */
-        double sx = search_point->xx0 * geometry->invstepx + geometry->offsetx;
-        double sy = search_point->yy0 * geometry->invstepy + geometry->offsety;
-        search_point->ip = (int)sx;
-        search_point->jp = (int)sy;
+        sx = xx0 * invstepx + offsetx;
+        sy = yy0 * invstepy + offsety;
+
+        ip = (int)sx;
+        jp = (int)sy;
 
         /* test outside of raster */
-        if ((search_point->ip < 0) || (search_point->ip >= geometry->n) ||
-            (search_point->jp < 0) || (search_point->jp >= geometry->m))
+        if ((ip < 0) ||
+            (ip >= n) ||
+            (jp < 0) ||
+            (jp >= m))
             return (3);
 
-        if ((search_point->ip != iold) || (search_point->jp != jold)) {
-            double dx = (double)search_point->ip * geometry->stepx;
-            double dy = (double)search_point->jp * geometry->stepy;
+        if ((ip != iold) ||
+            (jp != jold)) {
 
-            search_point->length =
-                distance(origin_point->xg0, dx, origin_point->yg0, dy,
-                         origin_point->coslatsq); /* dist from orig. grid point
-                                              to the current grid point */
-            int succes2 = test_low_res(geometry, origin_point, origin_angle,
-                                       search_point, horizon);
+            dx = (double)ip *stepx;
+            dy = (double)jp *stepy;
+            length = distance(xg0, dx, yg0, dy); /* dist from orig. grid point to the current grid point */
+            succes2 = test_low_res();
+
             if (succes2 == 1) {
-                search_point->zp = z[search_point->jp][search_point->ip];
+                zp = z[jp][ip];
                 return (1);
             }
         }
@@ -985,74 +876,79 @@ int new_point(const Geometry *geometry, const OriginPoint *origin_point,
     return -1;
 }
 
-int test_low_res(const Geometry *geometry, const OriginPoint *origin_point,
-                 const OriginAngle *origin_angle, SearchPoint *search_point,
-                 const HorizonProperties *horizon)
+int test_low_res()
 {
-    int iold100 = search_point->ip100;
-    int jold100 = search_point->jp100;
-    search_point->ip100 = floor(search_point->ip / 100.);
-    search_point->jp100 = floor(search_point->jp / 100.);
+    int iold100, jold100;
+    double sx, sy;
+    int delx, dely, mindel;
+    double zp100, z2, curvature_diff;
+
+    iold100 = ip100;
+    jold100 = jp100;
+
+    ip100 = floor(ip / 100.);
+    jp100 = floor(jp / 100.);
+
     /*test the new position with low resolution */
-    if ((search_point->ip100 != iold100) || (search_point->jp100 != jold100)) {
-        G_debug(2, "ip:%d jp:%d iold100:%d jold100:%d\n", search_point->ip,
-                search_point->jp, iold100, jold100);
-        /*  replace with approximate version
-           curvature_diff = EARTHRADIUS*(1.-cos(length/EARTHRADIUS));
+    if ((ip100 != iold100) ||
+        (jp100 != jold100)) {
+
+        G_debug(2,"ip:%d jp:%d iold100:%d jold100:%d\n",ip,jp, iold100,jold100);
+
+        /* replace with approximate version
+         curvature_diff = EARTHRADIUS*(1.-cos(length/EARTHRADIUS));
          */
-        double curvature_diff =
-            0.5 * search_point->length * search_point->length * invEarth;
-        double z2 = origin_point->z_orig + curvature_diff +
-                    search_point->length * horizon->tanh0;
-        double zp100 = z100[search_point->jp100][search_point->ip100];
-        G_debug(2, "ip:%d jp:%d z2:%lf zp100:%lf \n", search_point->ip,
-                search_point->jp, z2, zp100);
+        curvature_diff = 0.5 * length * length * invEarth;
+        z2 = z_orig + curvature_diff + length * tanh0;
+
+        zp100 = z100[jp100][ip100];
+
+        G_debug(2,"ip:%d jp:%d z2:%lf zp100:%lf \n",ip,jp,z2,zp100);
 
         if (zp100 <= z2)
-        /*skip to the next lowres cell */
+            /*skip to the next lowres cell */
         {
-            int delx = 32000;
-            int dely = 32000;
-            if (origin_angle->cosangle > 0.) {
-                double sx =
-                    search_point->xx0 * geometry->invstepx + geometry->offsetx;
-                delx = floor(fabs((ceil(sx / 100.) - (sx / 100.)) *
-                                  origin_angle->distcosangle));
+            delx = 32000;
+            dely = 32000;
+
+            if (cosangle > 0.) {
+                sx = xx0 * invstepx + offsetx;
+                delx =
+                    floor(fabs
+                          ((ceil(sx / 100.) - (sx / 100.)) * distcosangle));
             }
-            if (origin_angle->cosangle < 0.) {
-                double sx =
-                    search_point->xx0 * geometry->invstepx + geometry->offsetx;
-                delx = floor(fabs((floor(sx / 100.) - (sx / 100.)) *
-                                  origin_angle->distcosangle));
-            }
-            if (origin_angle->sinangle > 0.) {
-                double sy =
-                    search_point->yy0 * geometry->invstepy + geometry->offsety;
-                dely = floor(fabs((ceil(sy / 100.) - (sy / 100.)) *
-                                  origin_angle->distsinangle));
-            }
-            else if (origin_angle->sinangle < 0.) {
-                double sy =
-                    search_point->yy0 * geometry->invstepy + geometry->offsety;
-                dely = floor(fabs((floor(sy / 100.) - (sy / 100.)) *
-                                  origin_angle->distsinangle));
+            if (cosangle < 0.) {
+                sx = xx0 * invstepx + offsetx;
+                delx =
+                    floor(fabs
+                          ((floor(sx / 100.) - (sx / 100.)) * distcosangle));
             }
 
-            int mindel = MIN(delx, dely);
-            G_debug(2, "%d %d %d %lf %lf\n", search_point->ip, search_point->jp,
-                    mindel, origin_point->xg0, origin_point->yg0);
+            if (sinangle > 0.) {
+                sy = yy0 * invstepy + offsety;
+                dely =
+                    floor(fabs
+                          ((ceil(sy / 100.) - (sy / 100.)) * distsinangle));
+            }
+            else if (sinangle < 0.) {
+                sy = yy0 * invstepy + offsety;
+                dely =
+                    floor(fabs
+                          ((floor(jp / 100.) - (sy / 100.)) * distsinangle));
+            }
 
-            search_point->yy0 =
-                search_point->yy0 + (mindel * origin_angle->stepsinangle);
-            search_point->xx0 =
-                search_point->xx0 + (mindel * origin_angle->stepcosangle);
-            G_debug(2, "  %lf %lf\n", search_point->xx0, search_point->yy0);
+            mindel = min(delx, dely);
+            G_debug(2,"%d %d %d %lf %lf\n",ip, jp, mindel,xg0, yg0);
+
+            yy0 = yy0 + (mindel * stepsinangle);
+            xx0 = xx0 + (mindel * stepcosangle);
+
+            G_debug(2," %lf %lf\n",xx0,yy0);
 
             return (3);
         }
         else {
-            return (1); /* change of low res array - new cell is reaching limit
-                           for high resolution processing */
+            return (1); /* change of low res array - new cell is reaching limit for high resolution processing */
         }
     }
     else {
@@ -1060,227 +956,338 @@ int test_low_res(const Geometry *geometry, const OriginPoint *origin_point,
     }
 }
 
-HorizonProperties horizon_height(const Geometry *geometry,
-                                 const OriginPoint *origin_point,
-                                 const OriginAngle *origin_angle)
+double searching()
 {
-    SearchPoint search_point;
-    HorizonProperties horizon;
+    double z2;
+    double curvature_diff;
+    int succes = 1;
 
-    search_point.ip = 0;
-    search_point.jp = 0;
-    search_point.xx0 = origin_point->xg0;
-    search_point.yy0 = origin_point->yg0;
-    search_point.zp = origin_point->z_orig;
-    search_point.ip100 = floor(origin_point->xg0 * geometry->invstepx / 100.);
-    search_point.jp100 = floor(origin_point->yg0 * geometry->invstepy / 100.);
-    search_point.length = 0;
-
-    horizon.length = 0;
-    horizon.tanh0 = 0;
-
-    if (search_point.zp == UNDEFZ) {
-        HorizonProperties h = {0, 0};
-        return h;
-    }
+    if (zp == UNDEFZ)
+        return 0;
 
     while (1) {
-        int succes = new_point(geometry, origin_point, origin_angle,
-                               &search_point, &horizon);
-
+        succes = new_point();
         if (succes != 1) {
             break;
         }
-
         /* curvature_diff = EARTHRADIUS*(1.-cos(length/EARTHRADIUS)); */
-        double curvature_diff =
-            0.5 * search_point.length * search_point.length * invEarth;
+        curvature_diff = 0.5 * length * length * invEarth;
+        z2 = z_orig + curvature_diff + length * tanh0;
 
-        double z2 = origin_point->z_orig + curvature_diff +
-                    search_point.length * horizon.tanh0;
-
-        if (z2 < search_point.zp) {
-            horizon.tanh0 =
-                (search_point.zp - origin_point->z_orig - curvature_diff) /
-                search_point.length;
-            horizon.length = search_point.length;
+        if (z2 < zp) {
+            /* NEW: Track the length at which we update the best slope */
+            tanh0 = (zp - z_orig - curvature_diff) / length;
+            best_length = length; /* NEW */
         }
-
-        if (z2 >= geometry->zmax) {
+        if (z2 >= zmax) {
             break;
         }
-
-        if (search_point.length >= origin_point->maxlength) {
+        if (length >= maxlength) {
             break;
         }
     }
-
-    return horizon;
+    return atan(tanh0);
 }
 
 /*////////////////////////////////////////////////////////////////////// */
-
-void calculate_raster_mode(const Settings *settings, const Geometry *geometry,
-                           struct Cell_head *cellhd,
-                           struct Cell_head *new_cellhd, int buffer_e,
-                           int buffer_w, int buffer_s, int buffer_n,
-                           double bufferZone)
+void calculate(double xcoord, double ycoord, int buffer_e, int buffer_w,
+               int buffer_s, int buffer_n)
 {
+    int i, j, l, k = 0;
+    size_t decimals;
+    int xindex, yindex;
+    double shadow_angle;
+    double coslat;
+    double latitude, longitude;
+    double xp, yp;
+    double inputAngle;
+    double delt_lat, delt_lon;
+    double delt_east, delt_nor;
+    double delt_dist;
+    char msg_buff[256];
     int hor_row_start = buffer_s;
-    int hor_row_end = geometry->m - buffer_n;
-
+    int hor_row_end = m - buffer_n;
     int hor_col_start = buffer_w;
-    int hor_col_end = geometry->n - buffer_e;
+    int hor_col_end = n - buffer_e;
+    int hor_numrows = m - (buffer_s + buffer_n);
+    int hor_numcols = n - (buffer_e + buffer_w);
+    int arrayNumInt;
+    double dfr_rad, angle_deg;
 
-    int hor_numrows = geometry->m - (buffer_s + buffer_n);
-    int hor_numcols = geometry->n - (buffer_e + buffer_w);
+    xindex = (int)((xcoord - xmin) / stepx);
+    yindex = (int)((ycoord - ymin) / stepy);
 
     if ((G_projection() == PROJECTION_LL)) {
-        ll_correction = true;
+        ll_correction = TRUE;
     }
 
-    /****************************************************************/
-    /*  The loop over raster points starts here!                    */
+    if (isMode() == SINGLE_POINT) {
 
-    /****************************************************************/
+        /* single point mode */
+        xg0 = xx0 = xindex * stepx;
+        yg0 = yy0 = yindex * stepy;
 
-    if (settings->horizon_basename != NULL) {
-        horizon_raster = (float **)G_malloc(sizeof(float *) * (hor_numrows));
-        for (int l = 0; l < hor_numrows; l++) {
-            horizon_raster[l] =
-                (float *)G_malloc(sizeof(float) * (hor_numcols));
+        if (ll_correction) {
+            coslat = cos(deg2rad * (ymin + yy0));
+            coslatsq = coslat * coslat;
         }
 
-        for (int j = 0; j < hor_numrows; j++) {
-            for (int i = 0; i < hor_numcols; i++)
-                horizon_raster[j][i] = 0.;
-        }
-    }
-    double dfr_rad;
-    int arrayNumInt;
-    /* definition of horizon angle in loop */
-    char *shad_filename = NULL;
-    if (settings->step == 0.0) {
-        dfr_rad = 0;
-        arrayNumInt = 1;
-        sprintf(shad_filename, "%s", settings->horizon_basename);
+        z_orig = zp = z[yindex][xindex];
+
+        G_debug(1, "yindex: %d, xindex %d, z_orig %.2f", yindex, xindex, z_orig);
+
+        calculate_shadow();
+        fclose(fp);
     }
     else {
-        dfr_rad = settings->step * deg2rad;
-        arrayNumInt = 0;
-        for (double tmp = 0; tmp < settings->end - settings->start;
-             tmp += fabs(settings->step))
-            ++arrayNumInt;
-    }
+        /************************************************************/
+        /* The loop over raster points starts here!                 */
+        /************************************************************/
 
-    size_t decimals = G_get_num_decimals(settings->str_step);
+        if (horizon != NULL) {
+            horizon_raster = (float **)G_malloc(sizeof(float *) * (hor_numrows));
+            for (l = 0; l < hor_numrows; l++) {
+                horizon_raster[l] =
+                    (float *)G_malloc(sizeof(float) * (hor_numcols));
+            }
+            for (j = 0; j < hor_numrows; j++) {
+                for (i = 0; i < hor_numcols; i++)
+                    horizon_raster[j][i] = 0.;
+            }
 
-    for (int k = 0; k < arrayNumInt; k++) {
-        struct History history;
-
-        double angle =
-            (settings->start + settings->single_direction) * deg2rad +
-            (dfr_rad * k);
-        double angle_deg = angle * rad2deg + 0.0001;
-
-        if (settings->step != 0.0)
-            shad_filename = G_generate_basename(settings->horizon_basename,
-                                                angle_deg, 3, decimals);
-        G_message(
-            _("Calculating map %01d of %01d (angle %.2f, raster map <%s>)"),
-            (k + 1), arrayNumInt, angle_deg, shad_filename);
-
-        int j;
-
-#pragma omp parallel for schedule(static, 1) default(shared)
-        for (j = hor_row_start; j < hor_row_end; j++) {
-            G_percent(j - hor_row_start, hor_numrows - 1, 2);
-            for (int i = hor_col_start; i < hor_col_end; i++) {
-                OriginPoint origin_point;
-                OriginAngle origin_angle;
-                origin_point.xg0 = (double)i * geometry->stepx;
-
-                double xp = geometry->xmin + origin_point.xg0;
-                origin_point.yg0 = (double)j * geometry->stepy;
-
-                double yp = geometry->ymin + origin_point.yg0;
-                origin_point.coslatsq = 0;
-                if (ll_correction) {
-                    double coslat = cos(deg2rad * yp);
-                    origin_point.coslatsq = coslat * coslat;
-                }
-
-                double inputAngle = angle + pihalf;
-                inputAngle =
-                    (inputAngle >= twopi) ? inputAngle - twopi : inputAngle;
-                com_par(geometry, &origin_angle, inputAngle, xp, yp);
-
-                origin_point.z_orig = z[j][i];
-                origin_point.maxlength =
-                    (geometry->zmax - origin_point.z_orig) / TANMINANGLE;
-                origin_point.maxlength =
-                    (origin_point.maxlength < settings->fixedMaxLength)
-                        ? origin_point.maxlength
-                        : settings->fixedMaxLength;
-
-                if (origin_point.z_orig != UNDEFZ) {
-
-                    G_debug(4, "**************new line %d %d\n", i, j);
-                    HorizonProperties horizon =
-                        horizon_height(geometry, &origin_point, &origin_angle);
-                    double shadow_angle = atan(horizon.tanh0);
-
-                    if (settings->degreeOutput) {
-                        shadow_angle *= rad2deg;
-                    }
-                    horizon_raster[j - buffer_s][i - buffer_w] = shadow_angle;
-
-                } /* undefs */
-            } /* end of loop over columns */
-        } /* end of parallel section */
-
-        G_debug(1, "OUTGR() starts...");
-        OUTGR(settings, shad_filename, cellhd);
-
-        /* empty array */
-        for (int j = 0; j < hor_numrows; j++) {
-            for (int i = 0; i < hor_numcols; i++)
-                horizon_raster[j][i] = 0.;
+            /* NEW: allocate the map-units raster if requested */
+            if (mapunitsOutput) { /* NEW */
+                horizon_raster_mu = (float **)G_malloc(sizeof(float *) * (hor_numrows)); /* NEW */
+                for (l = 0; l < hor_numrows; l++) { /* NEW */
+                    horizon_raster_mu[l] = (float *)G_malloc(sizeof(float) * (hor_numcols)); /* NEW */
+                } /* NEW */
+                for (j = 0; j < hor_numrows; j++) { /* NEW */
+                    for (i = 0; i < hor_numcols; i++) /* NEW */
+                        horizon_raster_mu[j][i] = 0.; /* NEW */
+                } /* NEW */
+            } /* NEW */
         }
 
-        /* return back the buffered region */
-        if (bufferZone > 0.)
-            Rast_set_window(new_cellhd);
+        /* definition of horizon angle in loop */
+        if (step == 0.0) {
+            dfr_rad = 0;
+            arrayNumInt = 1;
+            /* NOTE: in original code this was unsafe; make sure we allocate */
+            shad_filename = G_store(horizon); /* safer than sprintf to unallocated ptr */
+        }
+        else {
+            dfr_rad = step * deg2rad;
+            arrayNumInt = (int)((end - start) / fabs(step));
+        }
 
-        /* write metadata */
-        Rast_short_history(shad_filename, "raster", &history);
+        decimals = G_get_num_decimals(str_step);
 
-        char msg_buff[256];
-        sprintf(msg_buff, "Angular height of terrain horizon, map %01d of %01d",
-                (k + 1), arrayNumInt);
-        Rast_put_cell_title(shad_filename, msg_buff);
+        for (k = 0; k < arrayNumInt; k++) {
 
-        if (settings->degreeOutput)
-            Rast_write_units(shad_filename, "degrees");
-        else
-            Rast_write_units(shad_filename, "radians");
+            struct History history;
 
-        Rast_command_history(&history);
+            angle = (start + single_direction) * deg2rad + (dfr_rad * k);
+            angle_deg = angle * rad2deg + 0.0001;
 
-        /* insert a blank line */
-        Rast_append_history(&history, "");
+            if (step != 0.0)
+                shad_filename = G_generate_basename(horizon, angle_deg, 3, decimals);
 
-        Rast_append_format_history(
-            &history,
-            "Horizon view from azimuth angle %.2f degrees CCW from East",
-            angle * rad2deg);
+            /* NEW: build the map-units raster name with suffix */
+            if (mapunitsOutput) { /* NEW */
+                if (step != 0.0) /* NEW */
+                    shad_filename_mu = G_asprintf("%s_height", shad_filename); /* NEW */
+                else /* NEW */
+                    shad_filename_mu = G_asprintf("%s_height", horizon); /* NEW */
+            } /* NEW */
 
-        Rast_write_history(shad_filename, &history);
-        G_free(shad_filename);
+            G_message(_("Calculating map %01d of %01d (angle %.2f, raster map <%s>)"),
+                      (k + 1), arrayNumInt, angle_deg, shad_filename);
+
+            for (j = hor_row_start; j < hor_row_end; j++) {
+
+                G_percent(j - hor_row_start, hor_numrows - 1, 2);
+
+                shadow_angle = 15 * deg2rad;
+
+                for (i = hor_col_start; i < hor_col_end; i++) {
+
+                    ip100 = floor(i / 100.);
+                    jp100 = floor(j / 100.);
+                    ip = jp = 0;
+
+                    xg0 = xx0 = (double)i *stepx;
+                    xp = xmin + xx0;
+
+                    yg0 = yy0 = (double)j *stepy;
+                    yp = ymin + yy0;
+
+                    length = 0;
+
+                    if (ll_correction) {
+                        coslat = cos(deg2rad * yp);
+                        coslatsq = coslat * coslat;
+                    }
+
+                    longitude = xp;
+                    latitude = yp;
+
+                    if (GPJ_transform(&iproj, &oproj, &tproj, PJ_FWD,
+                              &longitude, &latitude, NULL) < 0)
+                        G_fatal_error(_("Error in %s"), "GPJ_transform()");
+
+                    latitude *= deg2rad;
+                    longitude *= deg2rad;
+
+                    inputAngle = angle + pihalf;
+                    inputAngle =
+                        (inputAngle >=
+                         twopi) ? inputAngle - twopi : inputAngle;
+
+                    delt_lat = -0.0001 * cos(inputAngle); /* Arbitrary small distance in latitude */
+                    delt_lon = 0.0001 * sin(inputAngle) / cos(latitude);
+
+                    latitude = (latitude + delt_lat) * rad2deg;
+                    longitude = (longitude + delt_lon) * rad2deg;
+
+                    if ((G_projection() != PROJECTION_LL)) {
+                        if (GPJ_transform(&iproj, &oproj, &tproj, PJ_INV,
+                                  &longitude, &latitude, NULL) < 0)
+                            G_fatal_error(_("Error in %s"), "GPJ_transform()");
+                    }
+
+                    delt_east = longitude - xp;
+                    delt_nor = latitude - yp;
+                    delt_dist =
+                        sqrt(delt_east * delt_east + delt_nor * delt_nor);
+
+                    sinangle = delt_nor / delt_dist;
+                    if (fabs(sinangle) < 0.0000001) {
+                        sinangle = 0.;
+                    }
+                    cosangle = delt_east / delt_dist;
+                    if (fabs(cosangle) < 0.0000001) {
+                        cosangle = 0.;
+                    }
+
+                    distsinangle = 32000;
+                    distcosangle = 32000;
+                    if (sinangle != 0.) {
+                        distsinangle = 100. / (distxy * sinangle);
+                    }
+                    if (cosangle != 0.) {
+                        distcosangle = 100. / (distxy * cosangle);
+                    }
+
+                    stepsinangle = stepxy * sinangle;
+                    stepcosangle = stepxy * cosangle;
+
+                    z_orig = zp = z[j][i];
+
+                    maxlength = (zmax - z_orig) / TANMINANGLE;
+                    maxlength =
+                        (maxlength < fixedMaxLength) ? maxlength : fixedMaxLength;
+
+                    if (z_orig != UNDEFZ) {
+
+                        G_debug(4,"****************new line %d %d\n", i, j);
+
+                        shadow_angle = horizon_height();
+
+                        /* Write angle in deg if requested */
+                        if (degreeOutput) {
+                            shadow_angle *= rad2deg;
+                        }
+
+                        horizon_raster[j - buffer_s][i - buffer_w] =
+                            shadow_angle;
+
+                        /* NEW: compute and store vertical map-units height */
+                        if (mapunitsOutput) { /* NEW */
+                            float mu_val = (float) UNDEFZ; /* NEW default NULL */ /* NEW */
+                            if (best_length > 0.0 && isfinite(tanh0)) { /* NEW */
+                                double curvature_diff = 0.5 * best_length * best_length * invEarth; /* NEW */
+                                double vheight = tanh0 * best_length + curvature_diff; /* NEW */
+                                mu_val = (float) vheight; /* NEW (same units as z_orig) */ /* NEW */
+                            } /* NEW */
+                            horizon_raster_mu[j - buffer_s][i - buffer_w] = mu_val; /* NEW */
+                        } /* NEW */
+
+                    }   /* undefs */
+                }
+            }
+
+            G_debug(1, "OUTGR() starts...");
+            /* Write angle raster */
+            OUTGR(cellhd.rows, cellhd.cols);
+
+            /* reset angle array */
+            for (j = 0; j < hor_numrows; j++) {
+                for (i = 0; i < hor_numcols; i++)
+                    horizon_raster[j][i] = 0.;
+            }
+
+            /* return back the buffered region */
+            if (bufferZone > 0.)
+                Rast_set_window(&new_cellhd);
+
+            /* write metadata for angle raster */
+            Rast_short_history(shad_filename, "raster", &history);
+            sprintf(msg_buff,
+                    "Angular height of terrain horizon, map %01d of %01d",
+                    (k + 1), arrayNumInt);
+            Rast_put_cell_title(shad_filename, msg_buff);
+            if (degreeOutput)
+                Rast_write_units(shad_filename, "degrees");
+            else
+                Rast_write_units(shad_filename, "radians");
+            Rast_command_history(&history);
+            Rast_append_history(&history, "");
+            Rast_append_format_history(
+                &history,
+                "Horizon view from azimuth angle %.2f degrees CCW from East",
+                angle * rad2deg);
+            Rast_write_history(shad_filename, &history);
+
+            /* NEW: write the map-units raster + metadata if requested */
+            if (mapunitsOutput) { /* NEW */
+                /* Switch global pointer and name to reuse OUTGR */
+                float **saved_ptr = horizon_raster; /* NEW */
+                horizon_raster = horizon_raster_mu; /* NEW */
+                char *saved_name = shad_filename; /* NEW */
+                shad_filename = shad_filename_mu; /* NEW */
+
+                OUTGR(cellhd.rows, cellhd.cols); /* NEW */
+
+                /* reset mu array */ /* NEW */
+                for (j = 0; j < hor_numrows; j++) { /* NEW */
+                    for (i = 0; i < hor_numcols; i++) /* NEW */
+                        horizon_raster_mu[j][i] = 0.; /* NEW */
+                } /* NEW */
+
+                if (bufferZone > 0.) /* NEW */
+                    Rast_set_window(&new_cellhd); /* NEW */
+
+                Rast_short_history(shad_filename, "raster", &history); /* NEW */
+                sprintf(msg_buff, /* NEW */
+                        "Vertical height to terrain horizon (map units), map %01d of %01d", /* NEW */
+                        (k + 1), arrayNumInt); /* NEW */
+                Rast_put_cell_title(shad_filename, msg_buff); /* NEW */
+                Rast_write_units(shad_filename, "map units"); /* NEW */
+                Rast_command_history(&history); /* NEW */
+                Rast_append_history(&history, ""); /* NEW */
+                Rast_append_format_history( /* NEW */
+                    &history, /* NEW */
+                    "Vertical horizon height from azimuth angle %.2f degrees CCW from East", /* NEW */
+                    angle * rad2deg); /* NEW */
+                Rast_write_history(shad_filename, &history); /* NEW */
+
+                /* restore globals and free mu name */ /* NEW */
+                shad_filename = saved_name; /* NEW */
+                horizon_raster = saved_ptr; /* NEW */
+                G_free(shad_filename_mu); /* NEW */
+            } /* NEW */
+
+            G_free(shad_filename);
+        }
     }
-
-    /* free memory */
-    for (int l = 0; l < hor_numrows; l++)
-        G_free(horizon_raster[l]);
-    G_free(horizon_raster);
 }


### PR DESCRIPTION
Add an option to output a second map when running r.horizon in raster mode, which outputs horizon height in map units, useful for rockfall risk assessment. For example, a pixel below a vertical cliff has a 90° horizon in the azimuth direction of the cliff. This feature is intended to produce a second map that outputs the horizon height, so risk assessments can distinguish between a small or large cliff, which affects the kinetic energy of rockfalls.  