### PR TITLE
CI: branch collision handling for translation templates updates

### DIFF
--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -1,6 +1,8 @@
 ---
 name: Periodic update
 
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API, or on a schedule.
 on:
   workflow_dispatch:
     inputs:
@@ -9,18 +11,23 @@ on:
         default: false
         description: If true, also update .po files.
   schedule:
+    # At 15:32 (UTC) on Saturday.
+    # See https://crontab.guru/#32_15_*_*_SAT
     - cron: "32 15 * * SAT"
 
 permissions: {}
 
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   update-configure:
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       pull-requests: write
 
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Create URL to the run output
         id: vars
@@ -28,17 +35,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: "Check that autoconf scripts are up-to-date:"
         run: |
           rm -f config.guess config.sub
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.guess && chmod +x config.guess
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.sub && chmod +x config.sub
-
+      # Display changes, only to follow along in the logs.
       - run: git diff -- config.guess config.sub
       - name: Double check if files are modified
         run: git status --ignored
-
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
@@ -51,7 +56,7 @@ jobs:
             If the two files are deleted in this PR, please check the logs of the workflow here:
             [Workflow run summary](${{ steps.vars.outputs.run-url }})
 
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pill-request) GitHub action
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
       - name: Check outputs
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
@@ -60,23 +65,20 @@ jobs:
         env:
           STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
           STEPS_CPR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.cpr.outputs.pull-request-url }}
-
   update-i18n:
-    # the type of runner that the job will run on
-
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       pull-requests: write
 
-    # preventing overlapping runs
+    # Preventing overlapping runs
     concurrency:
       group: periodic-i18n
       cancel-in-progress: false
 
-    # steps represent a sequence of tasks that will be executed as part of the job
-
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Create URL to the run output
         id: vars
@@ -84,7 +86,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Install dependencies
         run: |
           sudo apt update
@@ -92,7 +93,6 @@ jobs:
             gettext \
             libgdal-dev \
             libproj-dev
-
       - name: Configure grass with minimal packages
         run: |
           ./configure \
@@ -102,44 +102,37 @@ jobs:
             --without-freetype \
             --without-opengl \
             --without-pdal
-
       - name: Build grass core
         run: make -j"$(nproc)"
-
-      - name: Create .pot files
+      - name: Create .pot files (containing original messages)
         run: cd locale && make pot
-
-      - name: Merge new messages
+      - name: Merge new messages (Done by Weblate plugin)
+        # Default false, but will be true if manually chosen. See https://stackoverflow.com/a/73495922
         if: ${{ inputs.update_po || false }}
         run: cd locale && make update-po
-
       - name: Verify the .po files
         run: cd locale && make verify
-
       - name: Preview changed files
         run: git diff | head -n2000
-
+      # The POT-Creation-Date gets updated by xgettext with the latest
+      # version-controlled modification time among all the given input files.
       - name: Preview changed files, except for the POT-Creation-Date
         run: |
           git diff --ignore-matching-lines=^\"POT-Creation-Date:  | head -n2000
-
       - name: Get if files were updated
         id: changed-files
         continue-on-error: true
         run: |
           git diff --exit-code --quiet --ignore-matching-lines=^\"POT-Creation-Date:
-
       - name: Translation files were changed
         if: ${{ steps.changed-files.outcome == 'failure' }}
         run: echo "Translation files were changed"
-
       - name: Translation files were not changed
         if: ${{ steps.changed-files.outcome == 'success' }}
         run: echo "Translation files were not changed"
-
       - name: Double check if files are modified
         run: git status --ignored
-
+      # if the changed files step fails (files differ), then open a PR with updated translations
       - name: Create Pull Request
         if: ${{ steps.changed-files.outcome == 'failure' }}
         id: cpr
@@ -153,7 +146,7 @@ jobs:
             if the option was selected.
             [Workflow run summary](${{ steps.vars.outputs.run-url }})
 
-            Automated changes by create-pull-request GitHub action
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
 
       - name: Check outputs
         if: ${{ steps.changed-files.outcome == 'failure' && steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -73,11 +73,6 @@ jobs:
       contents: write
       pull-requests: write
 
-    # Preventing overlapping runs
-    concurrency:
-      group: periodic-i18n
-      cancel-in-progress: false
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Create URL to the run output

--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -1,8 +1,6 @@
 ---
 name: Periodic update
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API, or on a schedule.
 on:
   workflow_dispatch:
     inputs:
@@ -11,23 +9,18 @@ on:
         default: false
         description: If true, also update .po files.
   schedule:
-    # At 15:32 (UTC) on Saturday.
-    # See https://crontab.guru/#32_15_*_*_SAT
     - cron: "32 15 * * SAT"
 
 permissions: {}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   update-configure:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       pull-requests: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Create URL to the run output
         id: vars
@@ -35,15 +28,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: "Check that autoconf scripts are up-to-date:"
         run: |
           rm -f config.guess config.sub
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.guess && chmod +x config.guess
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.sub && chmod +x config.sub
-      # Display changes, only to follow along in the logs.
+
       - run: git diff -- config.guess config.sub
       - name: Double check if files are modified
         run: git status --ignored
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
@@ -56,7 +51,7 @@ jobs:
             If the two files are deleted in this PR, please check the logs of the workflow here:
             [Workflow run summary](${{ steps.vars.outputs.run-url }})
 
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pill-request) GitHub action
       - name: Check outputs
         if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
@@ -65,15 +60,23 @@ jobs:
         env:
           STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
           STEPS_CPR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.cpr.outputs.pull-request-url }}
+
   update-i18n:
-    # The type of runner that the job will run on
+    # the type of runner that the job will run on
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       pull-requests: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    # preventing overlapping runs
+    concurrency:
+      group: periodic-i18n
+      cancel-in-progress: false
+
+    # steps represent a sequence of tasks that will be executed as part of the job
+
     steps:
       - name: Create URL to the run output
         id: vars
@@ -81,6 +84,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -88,6 +92,7 @@ jobs:
             gettext \
             libgdal-dev \
             libproj-dev
+
       - name: Configure grass with minimal packages
         run: |
           ./configure \
@@ -97,50 +102,59 @@ jobs:
             --without-freetype \
             --without-opengl \
             --without-pdal
+
       - name: Build grass core
         run: make -j"$(nproc)"
-      - name: Create .pot files (containing original messages)
+
+      - name: Create .pot files
         run: cd locale && make pot
-      - name: Merge new messages (Done by Weblate plugin)
-        # Default false, but will be true if manually chosen. See https://stackoverflow.com/a/73495922
+
+      - name: Merge new messages
         if: ${{ inputs.update_po || false }}
         run: cd locale && make update-po
+
       - name: Verify the .po files
         run: cd locale && make verify
+
       - name: Preview changed files
         run: git diff | head -n2000
-      # The POT-Creation-Date gets updated by xgettext with the latest
-      # version-controlled modification time among all the given input files.
+
       - name: Preview changed files, except for the POT-Creation-Date
         run: |
           git diff --ignore-matching-lines=^\"POT-Creation-Date:  | head -n2000
+
       - name: Get if files were updated
         id: changed-files
         continue-on-error: true
         run: |
           git diff --exit-code --quiet --ignore-matching-lines=^\"POT-Creation-Date:
+
       - name: Translation files were changed
         if: ${{ steps.changed-files.outcome == 'failure' }}
         run: echo "Translation files were changed"
+
       - name: Translation files were not changed
         if: ${{ steps.changed-files.outcome == 'success' }}
         run: echo "Translation files were not changed"
+
       - name: Double check if files are modified
         run: git status --ignored
+
       - name: Create Pull Request
         if: ${{ steps.changed-files.outcome == 'failure' }}
         id: cpr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           commit-message: "locale: Update translation files"
-          branch: periodic/update-i18n
-          title: "locale: Update translation files"
+          branch: periodic/update-i18n-${{ github.run_id }}
+          title: "locale: Update translation files (${{ github.run_number }})"
           body: |
             This updates the .pot template files, as well as all language-specific .po files
             if the option was selected.
             [Workflow run summary](${{ steps.vars.outputs.run-url }})
 
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+            Automated changes by create-pull-request GitHub action
+
       - name: Check outputs
         if: ${{ steps.changed-files.outcome == 'failure' && steps.cpr.outputs.pull-request-number }}
         run: |


### PR DESCRIPTION
This PR resolves the issuue #7115 ... related to the `update-i18n` job in the `Periodic update` workflow.

Previously, the workflow used a static branch name:
```
periodic/update-i18n
```

This meant that every time the workflow ran, it reused the same branch to create or update a Pull Request. As a result, only one translation update PR could exist at a time. If the workflow was triggered again (either by schedule or manually) while a previous PR was still open, the same branch would be reused and the existing PR would be updated or overwritten.

### What was changed
The branch name used by the `create-pull-request` action has been updated to include a unique identifier:
```
periodic/update-i18n-${{ github.run_id }}
```

so this ensures that
- each workflow run creates it's own branch
- multiple translation PRs can coexist at the same time... without interfering with one another
- no existing PR is unintentionally overwritten

### Verification
The workflow was manually triggered manually on a fork repo, and the branches were different each time. Each run created a distinct branch and corresponding Pull Request, confirming that branch names no longer collide.

<img width="963" height="127" alt="image" src="https://github.com/user-attachments/assets/9fb1ab7b-d613-499a-894a-3caee2a095fa" />

<img width="952" height="162" alt="image" src="https://github.com/user-attachments/assets/51fcd93e-e02c-44b3-aeeb-fd1e0333984d" />

#### Note:
> Assistance from AI was used for understanding the issue and hinting towards a solution

