### PR TITLE
grass.script: Add Python type hints to core.py

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1839,7 +1839,7 @@ def parse_color(
 # check GRASS_OVERWRITE
 
 
-def overwrite():
+def overwrite() -> bool:
     """Return True if existing files may be overwritten"""
     owstr = "GRASS_OVERWRITE"
     return owstr in os.environ and os.environ[owstr] != "0"
@@ -1848,7 +1848,7 @@ def overwrite():
 # check GRASS_VERBOSE
 
 
-def verbosity():
+def verbosity() -> int:
     """Return the verbosity level selected by GRASS_VERBOSE
 
     Currently, there are 5 levels of verbosity:
@@ -2212,7 +2212,7 @@ def debug_level(force: bool = False, *, env: _Env = None):
 # TODO: Remove the pygrass backwards compatibility version of it?
 
 
-def legal_name(s):
+def legal_name(s: str) -> bool:
     """Checks if the string contains only allowed characters.
 
     This is the Python implementation of :func:`G_legal_filename()` function.


### PR DESCRIPTION
## Description
This PR is a small housekeeping contribution to modernize the Python API by adding missing type hints to several utility functions in `grass.script.core`.

### Changes made:
- Added `-> bool` to `overwrite()`
- Added `-> int` to `verbosity()`
- Added `s: str` and `-> bool` to `legal_name(s)`

These changes improve static analysis and IDE autocomplete support without altering any underlying logic.

## Motivation and Context
As part of preparing for GSoC 2026, I am exploring the GRASS GIS codebase. While reviewing the Python API, I noticed that while some functions (like `parser()`) have been updated with modern type hints, several utility functions at the bottom of `core.py` have not yet been transitioned.

## How Has This Been Tested?
These are strictly non-functional type hint additions. The code has been reviewed to ensure no runtime logic is modified.