### PR TITLE
r.geomorphon: changed the JSON output to use parson lib

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,13 +73,12 @@ jobs:
       - name: Build
         run: |
           cmake --build build --verbose -j"$(nproc)"
-      - name: Install and add to PATH
+      - name: Install
         run: |
           cmake --install "${GITHUB_WORKSPACE}/build" --verbose
-          GRASS_BIN=$(dirname "$(which grass)")
-          echo "$GRASS_BIN" >> ${GITHUB_PATH}
-          export PATH="$GRASS_BIN:$PATH"
-          which grass  # to verify it works
+      - name: Add the bin directory to PATH
+        run: |
+          echo "${HOME}/install/bin" >> "${GITHUB_PATH}"
       - name: Print installed versions
         if: always()
         run: .github/workflows/print_versions.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,8 +77,8 @@ jobs:
         run: |
           cmake --install "${GITHUB_WORKSPACE}/build" --verbose
           GRASS_BIN=$(dirname "$(which grass)")
-          echo "$GRASS_BIN" >> "${GITHUB_PATH}"
-          export PATH="GRASS_BIN:$PATH"
+          echo "$GRASS_BIN" >> ${GITHUB_PATH}
+          export PATH="$GRASS_BIN:$PATH"
           which grass  # to verify it works
       - name: Print installed versions
         if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,8 @@ jobs:
           cmake --install "${GITHUB_WORKSPACE}/build" --verbose
       - name: Add the bin directory to PATH
         run: |
-          echo "${HOME}/install/bin" >> "${GITHUB_PATH}"
+          GRASS_BIN=$(dirname $(which grass))
+          echo "$GRASS_BIN" >> "${GITHUB_PATH}"
       - name: Print installed versions
         if: always()
         run: .github/workflows/print_versions.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,13 +73,13 @@ jobs:
       - name: Build
         run: |
           cmake --build build --verbose -j"$(nproc)"
-      - name: Install
+      - name: Install and add to PATH
         run: |
           cmake --install "${GITHUB_WORKSPACE}/build" --verbose
-      - name: Add the bin directory to PATH
-        run: |
           GRASS_BIN=$(dirname "$(which grass)")
           echo "$GRASS_BIN" >> "${GITHUB_PATH}"
+          export PATH="GRASS_BIN:$PATH"
+          which grass  # to verify it works
       - name: Print installed versions
         if: always()
         run: .github/workflows/print_versions.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,7 @@ jobs:
           cmake --install "${GITHUB_WORKSPACE}/build" --verbose
       - name: Add the bin directory to PATH
         run: |
-          GRASS_BIN=$(dirname $(which grass))
+          GRASS_BIN=$(dirname "$(which grass)")
           echo "$GRASS_BIN" >> "${GITHUB_PATH}"
       - name: Print installed versions
         if: always()

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -241,7 +241,7 @@ build_program_in_subdir(
   grass_bitmap
   ${LIBM})
 
-build_program_in_subdir(r.geomorphon DEPENDS grass_gis grass_raster grass_gmath
+build_program_in_subdir(r.geomorphon DEPENDS grass_gis grass_raster grass_gmath grass_parson
                         ${LIBM})
 
 build_program_in_subdir(r.grow.distance DEPENDS grass_gis grass_raster ${LIBM})

--- a/raster/r.geomorphon/Makefile
+++ b/raster/r.geomorphon/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.geomorphon
 
-LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.geomorphon/profile.c
+++ b/raster/r.geomorphon/profile.c
@@ -317,9 +317,8 @@ static unsigned write_json(FILE *f)
                 if (G_json_object_set_null(obj, token[i].key) != G_JSONSuccess)
                     goto cleanup;
             }
-            else if (G_json_object_set_number(obj, token[i].key,
-                                              token[i].dbl_val) !=
-                     G_JSONSuccess)
+            else if (G_json_object_set_number(
+                         obj, token[i].key, token[i].dbl_val) != G_JSONSuccess)
                 goto cleanup;
             continue;
         default:

--- a/raster/r.geomorphon/profile.c
+++ b/raster/r.geomorphon/profile.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <grass/gjson.h>
 #include "local_proto.h"
 
 #define JSON_MIN_INDENT 1
@@ -251,46 +252,96 @@ static const char *format_token_common(const struct token *t)
  */
 static unsigned write_json(FILE *f)
 {
-    unsigned i, indent = JSON_MIN_INDENT;
+    unsigned i;
+    G_JSON_Value *root_value = NULL;
+    G_JSON_Object *obj = NULL;
+    G_JSON_Object *obj_stack[MAX_STACK_ELEMS];
+    unsigned obj_depth = 0;
+    char *serialized = NULL;
+    unsigned ok = 0;
 
-    WRITE_VAL(f, "%s\n", "{");
+    root_value = G_json_value_init_object();
+    if (!root_value)
+        goto cleanup;
+    obj = G_json_object(root_value);
+    if (!obj)
+        goto cleanup;
+
     for (i = 0; i < size; i++) {
-        const char *val;
-
-        /* Add a comma unless there is no data tokens immediately after. */
-        const char *comma =
-            (i + 1 == size) || (i + 1 < size && token[i + 1].type == T_ESO)
-                ? ""
-                : ",";
-
         switch (token[i].type) {
-        case T_SSO:
-            WRITE_INDENT(f, indent);
-            indent++;
-            WRITE_VAL(f, "\"%s\": {\n", token[i].key);
+        case T_SSO: {
+            G_JSON_Value *sub_value;
+            G_JSON_Object *sub_obj;
+
+            if (obj_depth == MAX_STACK_ELEMS)
+                goto cleanup;
+            sub_value = G_json_value_init_object();
+            if (!sub_value)
+                goto cleanup;
+            if (G_json_object_set_value(obj, token[i].key, sub_value) !=
+                G_JSONSuccess) {
+                G_json_value_free(sub_value);
+                goto cleanup;
+            }
+            sub_obj = G_json_object(sub_value);
+            if (!sub_obj)
+                goto cleanup;
+            obj_stack[obj_depth++] = obj;
+            obj = sub_obj;
             continue;
+        }
         case T_ESO:
-            if (indent == JSON_MIN_INDENT)
-                return 0;
-            indent--;
-            WRITE_INDENT(f, indent);
-            WRITE_VAL(f, "}%s\n", comma);
+            if (obj_depth == 0)
+                goto cleanup;
+            obj = obj_stack[--obj_depth];
+            continue;
+        case T_BLN:
+            if (G_json_object_set_boolean(obj, token[i].key,
+                                          token[i].int_val ? 1 : 0) !=
+                G_JSONSuccess)
+                goto cleanup;
+            continue;
+        case T_INT:
+            if (G_json_object_set_number(obj, token[i].key, token[i].int_val) !=
+                G_JSONSuccess)
+                goto cleanup;
+            continue;
+        case T_STR:
+            if (G_json_object_set_string(obj, token[i].key, token[i].str_val) !=
+                G_JSONSuccess)
+                goto cleanup;
+            continue;
+        case T_DBL:
+        case T_MTR:
+            if (isnan(token[i].dbl_val)) {
+                if (G_json_object_set_null(obj, token[i].key) != G_JSONSuccess)
+                    goto cleanup;
+            }
+            else if (G_json_object_set_number(obj, token[i].key,
+                                              token[i].dbl_val) !=
+                     G_JSONSuccess)
+                goto cleanup;
             continue;
         default:
-            val = quote_val(token[i].type, format_token_common(token + i));
-            break;
+            goto cleanup;
         }
-        if (!val)
-            return 0;
-        WRITE_INDENT(f, indent);
-        WRITE_VAL(f, "\"%s\": ", token[i].key);
-        WRITE_VAL(f, "%s", val);
-        WRITE_VAL(f, "%s\n", comma);
     }
-    if (indent != JSON_MIN_INDENT || overflow)
-        return 0;
-    WRITE_VAL(f, "%s\n", "}");
-    return 1;
+    if (obj_depth != 0 || overflow)
+        goto cleanup;
+
+    serialized = G_json_serialize_to_string_pretty(root_value);
+    if (!serialized)
+        goto cleanup;
+    if (fprintf(f, "%s\n", serialized) < 0)
+        goto cleanup;
+    ok = 1;
+
+cleanup:
+    if (serialized)
+        G_json_free_serialized_string(serialized);
+    if (root_value)
+        G_json_value_free(root_value);
+    return ok;
 }
 
 static unsigned write_yaml(FILE *f)


### PR DESCRIPTION
I see there is an existing PR for this issue, but it has been inactive for some time...
This PR provides an updated implementation to move this issue forward.
This pr addresses #6970 

I replaced the manual json formatting in `profile.c` with the grass parson wrapper (`gjson`). instead of printing json line by line using fprintf-style logic, i now create a root json object in memory and build the structure using the `G_json_*` api.

I created the required json objects and arrays, add the key–value pairs to them, and then attach everything to the root object to preserve the original nesting structure. after the full structure is built, it is serialized using the pretty serializer and written to output.

The output remains functionally the same as before, but the implementation is now structured, easier to maintain, and aligned with grass's internal json utilities.

Please let me know if any other changes are required...
> AI assistance (chatgpt) was used to understand parts of the Parson/G_json API. All changes were reviewed, tested and validated by me to ensure correctness and alignment with GRASS standards.

###  Output before parson integration (manual JSON)
<img width="732" height="439" alt="image" src="https://github.com/user-attachments/assets/52aa57d4-ea08-42aa-89b1-cbb172c4e2ad" />

### Output after parson integration
<img width="850" height="755" alt="image" src="https://github.com/user-attachments/assets/c4492a3e-f1ed-418e-a149-53b246cbeee2" />
