### PR TITLE
CQ: fix -Wmismatched-dealloc and -Wuse-after-free warnings

### DIFF
--- a/db/drivers/ogr/cursor.c
+++ b/db/drivers/ogr/cursor.c
@@ -90,8 +90,9 @@ void free_cursor(cursor *c)
     if (c->hLayer)
         OGR_DS_ReleaseResultSet(hDs, c->hLayer);
 
+    dbToken tok = c->token;
     G_free(c->cols);
     G_free(c);
 
-    db_drop_token(c->token);
+    db_drop_token(tok);
 }

--- a/lib/imagery/sig.c
+++ b/lib/imagery/sig.c
@@ -458,24 +458,24 @@ char **I_sort_signatures_by_semantic_label(struct Signature *S,
 
     /* Clean up */
     for (unsigned int j = R->nfiles; j--;)
-        free(group_semantic_labels[j]);
-    free(group_semantic_labels);
-    free(new_order);
-    free(match1);
-    free(match2);
-    free(new_semantic_labels);
+        G_free(group_semantic_labels[j]);
+    G_free(group_semantic_labels);
+    G_free(new_order);
+    G_free(match1);
+    G_free(match2);
+    G_free(new_semantic_labels);
     for (unsigned int c = S->nsigs; c--;) {
-        free(new_means[c]);
+        G_free(new_means[c]);
         for (unsigned int i = S->nbands; i--;)
-            free(new_vars[c][i]);
-        free(new_vars[c]);
+            G_free(new_vars[c][i]);
+        G_free(new_vars[c]);
     }
-    free(new_means);
-    free(new_vars);
+    G_free(new_means);
+    G_free(new_vars);
 
     if (mc1 || mc2) {
         return mismatches;
     }
-    free(mismatches);
+    G_free(mismatches);
     return NULL;
 }

--- a/lib/imagery/sigset.c
+++ b/lib/imagery/sigset.c
@@ -619,28 +619,28 @@ char **I_SortSigSetBySemanticLabel(struct SigSet *S, const struct Ref *R)
     /* Clean up */
     for (unsigned int j = R->nfiles; j--;)
         free(group_semantic_labels[j]);
-    free(group_semantic_labels);
-    free(new_order);
-    free(match1);
-    free(match2);
-    free(new_semantic_labels);
+    G_free(group_semantic_labels);
+    G_free(new_order);
+    G_free(match1);
+    G_free(match2);
+    G_free(new_semantic_labels);
     for (unsigned int c = S->nclasses; c--;) {
         for (unsigned int s = S->ClassSig[c].nsubclasses; s--;) {
-            free(new_means[c][s]);
+            G_free(new_means[c][s]);
             for (unsigned int i = S->nbands; i--;)
-                free(new_vars[c][s][i]);
-            free(new_vars[c][s]);
+                G_free(new_vars[c][s][i]);
+            G_free(new_vars[c][s]);
         }
-        free(new_means[c]);
-        free(new_vars[c]);
+        G_free(new_means[c]);
+        G_free(new_vars[c]);
     }
 
-    free(new_means);
-    free(new_vars);
+    G_free(new_means);
+    G_free(new_vars);
 
     if (mc1 || mc2) {
         return mismatches;
     }
-    free(mismatches);
+    G_free(mismatches);
     return NULL;
 }

--- a/lib/ogsf/gvd.c
+++ b/lib/ogsf/gvd.c
@@ -220,7 +220,7 @@ int gvd_vect(geovect *gv, geosurf *gs, int do_fast)
             /* 3D line */
             else {
                 G_debug(5, "gvd_vect(): 3D vector line");
-                points = (Point3 *)malloc(sizeof(Point3));
+                points = (Point3 *)G_malloc(sizeof(Point3));
 
                 gsd_bgnline();
                 for (k = 0; k < gln->npts; k++) {
@@ -233,7 +233,7 @@ int gvd_vect(geovect *gv, geosurf *gs, int do_fast)
                     gsd_vert_func(points[0]);
                 }
                 gsd_endline();
-                free(points);
+                G_free(points);
             }
         }
         /* polygon */
@@ -244,7 +244,7 @@ int gvd_vect(geovect *gv, geosurf *gs, int do_fast)
 
                 /* We want at least 3 points */
                 if (gln->npts >= 3) {
-                    points = (Point3 *)malloc(2 * sizeof(Point3));
+                    points = (Point3 *)G_malloc(2 * sizeof(Point3));
                     glEnable(GL_NORMALIZE);
 
                     glEnable(GL_COLOR_MATERIAL);

--- a/lib/vector/Vlib/map.c
+++ b/lib/vector/Vlib/map.c
@@ -349,7 +349,7 @@ int Vect_rename(const char *in, const char *out)
     }
 
     Vect_close(&Map);
-    free(fields);
+    G_free(fields);
 
     return 0;
 }

--- a/raster/r.gwflow/main.c
+++ b/raster/r.gwflow/main.c
@@ -442,7 +442,7 @@ int main(int argc, char *argv[])
         } while (max_norm > 0.01 && inner_count < innerit);
 
         if (tmp_vect)
-            free(tmp_vect);
+            G_free(tmp_vect);
     }
 
     /*release the memory */

--- a/vector/v.lrs/lib/lrs.c
+++ b/vector/v.lrs/lib/lrs.c
@@ -575,7 +575,7 @@ int LR_get_nearest_offset(dbDriver *driver, char *table_name, char *lcat_col,
         }
     }
 
-    free(rseg);
+    G_free(rseg);
 
     /* Was any segment found ? */
     if (seg_found == 0) { /* no */

--- a/vector/v.net.visibility/visibility.c
+++ b/vector/v.net.visibility/visibility.c
@@ -237,8 +237,8 @@ void construct_visibility(struct Point *points, int num_points,
     struct Point *p_infinity, *p_ninfinity;
     int i;
 
-    p_ninfinity = (struct Point *)malloc(sizeof(struct Point));
-    p_infinity = (struct Point *)malloc(sizeof(struct Point));
+    p_ninfinity = (struct Point *)G_malloc(sizeof(struct Point));
+    p_infinity = (struct Point *)G_malloc(sizeof(struct Point));
 
     p_ninfinity->x = PORT_DOUBLE_MAX;
     p_ninfinity->y = -PORT_DOUBLE_MAX;


### PR DESCRIPTION
Fix `-Wmismatched-dealloc` and `-Wuse-after-free` warnings, which appear with #7172.