### PR TITLE
r.sim: rename niterations to duration to better reflect what the parameter is for

### DIFF
--- a/doc/jupyter_intro.md
+++ b/doc/jupyter_intro.md
@@ -217,7 +217,7 @@ tools.r_sim_water(
     dx="dx",
     dy="dy",
     depth="depth",
-    niterations=30)
+    duration=30)
 
 # Create a time series
 tools.t_create(

--- a/doc/jupyter_intro_images.ipynb
+++ b/doc/jupyter_intro_images.ipynb
@@ -226,7 +226,7 @@
     "    dx=\"dx\",\n",
     "    dy=\"dy\",\n",
     "    depth=\"depth\",\n",
-    "    niterations=30,\n",
+    "    duration=30,\n",
     "    overwrite=True,\n",
     ")"
    ]

--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -330,7 +330,7 @@ r.sim.sediment|flux:sediment_flux
 r.sim.sediment|manin:man
 r.sim.sediment|maninval:man_value
 r.sim.sediment|nwalk:nwalkers
-r.sim.sediment|niter:niterations
+r.sim.sediment|niterations:duration
 r.sim.sediment|outiter:output_step
 r.sim.sediment|outwalk:walkers_output
 r.sim.sediment|tauin:shear_stress
@@ -348,7 +348,7 @@ r.sim.water|infil:infil
 r.sim.water|infil_val:infil_value
 r.sim.water|manin:man
 r.sim.water|manin_val:man_value
-r.sim.water|niter:niterations
+r.sim.water|niterations:duration
 r.sim.water|nwalk:nwalkers
 r.sim.water|outiter:output_step
 r.sim.water|outwalk:walkers_output

--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -234,11 +234,12 @@ int main(int argc, char *argv[])
     parm.nwalk->guisection = _("Parameters");
 
     parm.niter = G_define_option();
-    parm.niter->key = "niterations";
+    parm.niter->key = "duration";
     parm.niter->type = TYPE_INTEGER;
     parm.niter->answer = NITER;
     parm.niter->required = NO;
-    parm.niter->description = _("Time used for iterations [minutes]");
+    parm.niter->description =
+        _("Duration of the simulated water flow [minutes]");
     parm.niter->guisection = _("Parameters");
 
     parm.mintimestep = G_define_option();

--- a/raster/r.sim/r.sim.sediment/r.sim.sediment.html
+++ b/raster/r.sim/r.sim.sediment/r.sim.sediment.html
@@ -31,7 +31,7 @@ transport capacity limited erosion/deposition raster map
 can be viewed while the simulation continues. Sediment flow rate raster map
 <i>sediment_flux</i> [kg/ms], and net erosion/deposition raster map [kg/m<sup>2</sup>s]
 can take longer time depending on time step and simulation time.
-Simulation time is controlled by <i>niterations</i> [minutes] parameter.
+Simulation time is controlled by <i>duration</i> [minutes] parameter.
 <!-- Output files can be saved during simulation using <i>outiter</i> parameter
 defining simulation time step for writing output files. This option requires
 time series flag <i>-t</i>. Files are saved with suffix   containing

--- a/raster/r.sim/r.sim.sediment/r.sim.sediment.md
+++ b/raster/r.sim/r.sim.sediment/r.sim.sediment.md
@@ -31,7 +31,7 @@ almost immediately and can be viewed while the simulation continues.
 Sediment flow rate raster map *sediment_flux* \[kg/ms\], and net
 erosion/deposition raster map \[kg/m^2s\] can take longer time
 depending on time step and simulation time. Simulation time is
-controlled by *niterations* \[minutes\] parameter. If the resulting
+controlled by *duration* \[minutes\] parameter. If the resulting
 erosion/deposition map is noisy, higher number of walkers, given by
 *nwalkers* should be used.  
 

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -237,11 +237,12 @@ int main(int argc, char *argv[])
     parm.nwalk->guisection = _("Parameters");
 
     parm.niter = G_define_option();
-    parm.niter->key = "niterations";
+    parm.niter->key = "duration";
     parm.niter->type = TYPE_INTEGER;
     parm.niter->answer = NITER;
     parm.niter->required = NO;
-    parm.niter->description = _("Time used for iterations [minutes]");
+    parm.niter->description =
+        _("Duration of the simulated water flow [minutes]");
     parm.niter->guisection = _("Parameters");
 
     parm.mintimestep = G_define_option();

--- a/raster/r.sim/r.sim.water/r.sim.water.html
+++ b/raster/r.sim/r.sim.water/r.sim.water.html
@@ -88,7 +88,7 @@ analysed using the output error raster file [m]. This error is a function of the
 of particles used in the simulation and can be reduced by increasing the number of walkers
 given by parameter <b>nwalkers</b>.
 <!--(<font color="#ff0000"> toto treba upresnit/zmenit, lebo nwalk ide prec</font>). -->
-Duration of simulation is controlled by the <b>niterations</b> parameter. The default value
+Duration of simulation is controlled by the <b>duration</b> parameter. The default value
 is 10 minutes, reaching the steady-state may require much longer time,
 depending on the time step, complexity of terrain, land cover and size of the area.
 Output walker, water depth and discharge maps can be saved during simulation using

--- a/raster/r.sim/r.sim.water/r.sim.water.md
+++ b/raster/r.sim/r.sim.water/r.sim.water.md
@@ -75,7 +75,7 @@ solution can be analysed using the output error raster file \[m\]. This
 error is a function of the number of particles used in the simulation
 and can be reduced by increasing the number of walkers given by
 parameter **nwalkers**. Duration of simulation is controlled by the
-**niterations** parameter. The default value is 10 minutes, reaching the
+**duration** parameter. The default value is 10 minutes, reaching the
 steady-state may require much longer time, depending on the time step,
 complexity of terrain, land cover and size of the area. Output walker,
 water depth and discharge maps can be saved during simulation using the

--- a/raster/r.sim/r.sim.water/testsuite/test_r_sim_water.py
+++ b/raster/r.sim/r.sim.water/testsuite/test_r_sim_water.py
@@ -172,7 +172,7 @@ class TestRSimWater(TestCase):
             infil=self.infil,
             depth=self.depth,
             discharge=self.discharge,
-            niterations=15,
+            duration=15,
             output_step=5,
             diffusion_coeff=0.9,
             hmax=0.25,

--- a/raster/r.sim/test/test.sh
+++ b/raster/r.sim/test/test.sh
@@ -7,12 +7,12 @@
 
 g.region rural_1m res=2 -p
 v.surf.rst -d input=elev_lid792_bepts elevation=elev_lid792_2m slope=dx_2m aspect=dy_2m tension=15 smooth=1.5 npmin=150
-r.sim.water -t elevation=elev_lid792_2m dx=dx_2m dy=dy_2m rain_value=50 infil_value=0 man_value=0.05 depth=wdp_2m discharge=disch_2m nwalkers=100000 niterations=120 output_step=20
+r.sim.water -t elevation=elev_lid792_2m dx=dx_2m dy=dy_2m rain_value=50 infil_value=0 man_value=0.05 depth=wdp_2m discharge=disch_2m nwalkers=100000 duration=120 output_step=20
 r.mapcalc "tranin = 0.001"
 r.mapcalc "detin = 0.001"
 r.mapcalc "tauin = 0.01"
 g.copy rast=wdp_2m.120,wdp_2m
-r.sim.sediment elevation=elev_lid792_2m dx=dx_2m dy=dy_2m water_depth=wdp_2m detachment_coeff=detin transport_coeff=tranin shear_stress=tauin man_value=0.05 nwalkers=1000000 niterations=120 transport_capacity=tcapacity tlimit_erosion_deposition=erdepmax sediment_flux=sedflow erosion_deposition=erdepsimwe
+r.sim.sediment elevation=elev_lid792_2m dx=dx_2m dy=dy_2m water_depth=wdp_2m detachment_coeff=detin transport_coeff=tranin shear_stress=tauin man_value=0.05 nwalkers=1000000 duration=120 transport_capacity=tcapacity tlimit_erosion_deposition=erdepmax sediment_flux=sedflow erosion_deposition=erdepsimwe
 
 g.copy rast=disch_2m.120,disch_2m
 


### PR DESCRIPTION
In r.sim.water and r.sim.sediment the parameter niterations is not actually number of iterations, but duration in minutes- the number of iterations is computed from it internally. So this just renames the parameter in a backwards compatible way.