### PR TITLE
locale: update Bengali translations for various messages in grasslibs_bn.po

### DIFF
--- a/locale/po/grasslibs_bn.po
+++ b/locale/po/grasslibs_bn.po
@@ -61,7 +61,7 @@ msgstr "অজ্ঞাত Cairo সারফেসের ধরন"
 msgid "Failed to initialize Cairo surface (width: %d, height: %d): %s"
 msgstr "Cairo সারফেস ইনিশিয়ালাইজ করতে ব্যর্থ (প্রস্থ: %d, উচ্চতা: %d): %s"
 
-#, c-format
+#,fuzzy, c-format
 msgid "Unable to open file: %s"
 msgstr "ফাইল খুলতে অক্ষম: %s"
 


### PR DESCRIPTION
Description
Updated the Bengali translation file (locale/po/grasslibs_bn.po) for the grasslibs component. Translated several previously empty strings and corrected  translations to improve the localization of GRASS GIS for Bengali-speaking users.

Motivation and context
This change increases the translation coverage of the core GRASS libraries. It solves the issue of untranslated or incorrectly translated English strings appearing in the UI for Bengali users, thereby providing a more accessible and better user experience.

How has this been tested?
Ensured valid PO file syntax and verified that all C-format placeholders (like %s, %d) were kept intact and correctly placed in the Bengali translations.


Types of changes

Updated the Bengali translation file (locale/po/grasslibs_bn.po) 
