### PR TITLE
lib: fix reading GRASS vrts with multiple threads

### DIFF
--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -170,10 +170,8 @@ void Rast_close_vrt(struct R_vrt *vrt)
  * move to get_row.c as read_data_vrt() ? */
 int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 {
-    struct fileinfo *fcb = &R__.fileinfo[fd];
-    struct R_vrt *vrt = fcb->vrt;
-struct R_vrt *vrt;
-struct tileinfo *ti;
+    struct R_vrt *vrt;
+    struct tileinfo *ti;
     struct Cell_head *rd_window = &R__.rd_window;
     double rown, rows;
     int i, j;
@@ -182,8 +180,8 @@ struct tileinfo *ti;
     size_t size = Rast_cell_size(data_type);
 
     // R__.fileinfo can be reallocated by concurrent open/close calls,
-    // se we extract the vrt pointer under the same lock that protects the I/O below.
-    // This expects callers to open the raster once per thread before
+    // so we extract the vrt pointer under the same lock that protects the I/O
+    // below. This expects callers to open the raster once per thread before
     // entering any parallel code.
 #pragma omp critical(raster_vrt_read)
     {
@@ -201,9 +199,9 @@ struct tileinfo *ti;
     /* parallelised reading of the real raster maps
      * constituting a GRASS virtual raster
      * causes IO read errors and segmentation faults:
-     * enforce reading of the different rasters in only one thread */
-    // Serialize the entire open/read/close cycle for each tile
-    // because they all access the non-thread-safe global R__.fileinfo array.
+     * enforce reading of the different rasters in only one thread
+     * Serialize the entire open/read/close cycle for each tile
+     * because they all access the non-thread-safe global R__.fileinfo array. */
 #pragma omp critical(raster_vrt_read)
     for (i = 0; i < vrt->tlist->n_values; i++) {
         struct tileinfo *p = &ti[vrt->tlist->value[i]];


### PR DESCRIPTION
# Description
Parallelised reading of the real raster maps constituting a GRASS virtual raster causes IO read errors and segmentation faults. This PR enforces reading of the different rasters in only one thread.

Someone with better knowledge of OpenMP directives than me should have a look at this PR. At least for me this PR fixes the read errors.

# How to reproduce
1. create tiles with  `r.tile`
2. build a GRASS vrt from these tiles with `r.buildvrt`
3. run `r.univar` on this vrt with nprocs > 1

This also fixes #6616
