### PR TITLE
tools: implement dynamic jupyter utils tests using session_with_data

### DIFF
--- a/python/grass/jupyter/tests/grass_jupyter_utils_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_utils_test.py
@@ -24,20 +24,23 @@ def test_get_region(session_with_data):
 
 def test_get_rendering_size():
     """Test rendering size calculations."""
-    region = {"n": 4, "s": 0, "e": 8, "w": 0}
+    wide_region = {"n": 4, "s": 0, "e": 8, "w": 0}
+    tall_region = {"n": 8, "s": 0, "e": 4, "w": 0}
 
     # both provided
     assert get_rendering_size({}, 800, 600) == (800, 600)
 
     # width only
-    width, height = get_rendering_size(region, 800, None)
-    assert width == 800
-    assert height == 400
+    assert get_rendering_size(wide_region, 800, None) == (800, 400)
 
     # height only
-    width, height = get_rendering_size(region, None, 400)
-    assert width == 800
-    assert height == 400
+    assert get_rendering_size(wide_region, None, 400) == (800, 400)
+
+    # neither provided - wide region
+    assert get_rendering_size(wide_region, None, None) == (600, 300)
+
+    # neither provided - tall region
+    assert get_rendering_size(tall_region, None, None) == (200, 400)
 
 
 @pytest.mark.parametrize(

--- a/python/grass/jupyter/tests/utils_test.py
+++ b/python/grass/jupyter/tests/utils_test.py
@@ -1,0 +1,53 @@
+"""Tests for grass.jupyter.utils."""
+
+import pytest
+import grass.script as gs
+from grass.jupyter.utils import (
+    get_region,
+    get_rendering_size,
+    get_map_name_from_d_command,
+)
+
+
+def test_get_region(session_with_data):
+    """get_region() should match GRASS region output."""
+    env = session_with_data.env
+
+    expected = gs.region(env=env)
+    result = get_region(env=env)
+
+    assert result["north"] == pytest.approx(expected["n"])
+    assert result["south"] == pytest.approx(expected["s"])
+    assert result["east"] == pytest.approx(expected["e"])
+    assert result["west"] == pytest.approx(expected["w"])
+
+
+def test_get_rendering_size():
+    """Test rendering size calculations."""
+    region = {"n": 4, "s": 0, "e": 8, "w": 0}
+
+    # both provided
+    assert get_rendering_size({}, 800, 600) == (800, 600)
+
+    # width only
+    width, height = get_rendering_size(region, 800, None)
+    assert width == 800
+    assert height == 400
+
+    # height only
+    width, height = get_rendering_size(region, None, 400)
+    assert width == 800
+    assert height == 400
+
+
+@pytest.mark.parametrize(
+    ("cmd", "kwargs", "expected"),
+    [
+        ("d.rast", {"map": "elevation"}, "elevation"),
+        ("d.rgb", {"red": "red_band"}, "red_band"),
+        ("d.legend", {"raster": "elevation"}, "elevation"),
+    ],
+)
+def test_get_map_name_from_d_command(cmd, kwargs, expected):
+    """Test map name extraction from display commands."""
+    assert get_map_name_from_d_command(cmd, **kwargs) == expected


### PR DESCRIPTION
Reopening and updating after feedback on #7198.

### Updates in this iteration

* Refactored repeated logic from mapping classes into a centralized `utils.py`.
* Reworked the testing approach to use the `session_with_data` fixture instead of mocks or hardcoded values.
* `test_get_region` now dynamically validates output against the native backend (`gs.region()`), so it works consistently both locally and with the CI North Carolina dataset.
* Added parametrized tests for display command parsing using `@pytest.mark.parametrize`.
* All tests are passing cleanly against a compiled GRASS 8.6.0dev build.

### Local test run

<img width="918" height="295" alt="Screenshot 2026-03-27 015513" src="https://github.com/user-attachments/assets/17a60e2f-e45e-4d6d-9073-0bad478b6901" />
