### PR TITLE
r.category: preserving raster title

### DIFF
--- a/raster/r.category/main.c
+++ b/raster/r.category/main.c
@@ -241,8 +241,8 @@ int main(int argc, char *argv[])
             }
 
             Rast_init_cats("", &cats);
-		/* Preserves existing metadata (like title)*/
-	    Rast_read_cats(name, G_mapset(), &cats);
+            /* Preserves existing metadata (like title)*/
+            Rast_read_cats(name, G_mapset(), &cats);
 
             for (;;) {
                 char buf[1024];


### PR DESCRIPTION
Fixes #7199 

I was able to reproduce the issue locally where the raster title set using r.support gets removed after running r.category. 
in code categories were initialized with empty title and was overwritten by existing raster title, fixed this issue by reading the existing metadata before modifying it, thus preserving the raster title.

I tested the fix locally multiple times with many scenarios to ensure title remains unchanged after applying categories
