### PR TITLE
[WIP] CLI: Add basic command alias mapping for `grass run`

### DIFF
--- a/python/grass/app/cli.py
+++ b/python/grass/app/cli.py
@@ -31,6 +31,11 @@ from grass.grassdb.create import create_mapset
 from grass.exceptions import ScriptError
 from grass.tools import Tools
 
+COMMAND_MAP = {
+    "list": "g.list",
+    "slope": "r.slope.aspect",
+}
+
 # Special flags supported besides help and --json which does not need special handling:
 SPECIAL_FLAGS = [
     "--interface-description",
@@ -43,7 +48,8 @@ SPECIAL_FLAGS = [
 
 
 def subcommand_run_tool(args, tool_args: list, print_help: bool) -> int:
-    command = [args.tool, *tool_args]
+    resolved_tool = COMMAND_MAP.get(args.tool, args.tool)
+    command = [resolved_tool, *tool_args]
     with ExitStack() as stack:
         if args.project:
             project_path = Path(args.project)

--- a/python/grass/app/cli.py
+++ b/python/grass/app/cli.py
@@ -24,17 +24,24 @@ import subprocess
 from contextlib import ExitStack
 from pathlib import Path
 
-
 import grass.script as gs
 from grass.app.data import lock_mapset, unlock_mapset, MapsetLockingException
 from grass.grassdb.create import create_mapset
 from grass.exceptions import ScriptError
 from grass.tools import Tools
 
+
+# --- Alias Mapping (PoC) ---
 COMMAND_MAP = {
     "list": "g.list",
     "slope": "r.slope.aspect",
 }
+
+
+def resolve_tool_name(tool_name: str) -> str:
+    """Resolve user-friendly tool aliases to actual GRASS module names."""
+    return COMMAND_MAP.get(tool_name, tool_name)
+
 
 # Special flags supported besides help and --json which does not need special handling:
 SPECIAL_FLAGS = [
@@ -43,13 +50,12 @@ SPECIAL_FLAGS = [
     "--wps-process-description",
     "--script",
 ]
-# To make this list shorter, we don't support outdated special flags:
-# --help-text --html-description --rst-description
 
 
 def subcommand_run_tool(args, tool_args: list, print_help: bool) -> int:
-    resolved_tool = COMMAND_MAP.get(args.tool, args.tool)
+    resolved_tool = resolve_tool_name(args.tool)
     command = [resolved_tool, *tool_args]
+
     with ExitStack() as stack:
         if args.project:
             project_path = Path(args.project)
@@ -58,29 +64,26 @@ def subcommand_run_tool(args, tool_args: list, print_help: bool) -> int:
             project_name = "project"
             project_path = Path(tmp_dir_name) / project_name
             gs.create_project(project_path, crs=args.crs)
+
         with gs.setup.init(project_path) as session:
             tools = Tools(
                 session=session, capture_output=False, consistent_return_value=True
             )
+
             try:
-                # From here, we return the subprocess return code regardless of its
-                # value. Error states are handled through exceptions.
                 if print_help:
-                    # We consumed the help flag, so we need to add it explicitly.
                     return tools.call_cmd([*command, "--help"]).returncode
+
                 if any(item in command for item in SPECIAL_FLAGS):
-                    # This is here basically because of how --json behaves,
-                    # two JSON flags are accepted, but --json currently overridden by
-                    # other special flags, so later use of --json in tools will fail
-                    # with the other flags active.
                     return tools.call_cmd(command).returncode
+
                 return tools.run_cmd(command).returncode
+
             except subprocess.CalledProcessError as error:
                 return error.returncode
 
 
 def subcommand_create_project(args) -> int:
-    """Translates args to function parameters"""
     try:
         gs.create_project(
             path=args.path,
@@ -108,29 +111,9 @@ def add_mapset_subparser(subparsers):
 
     subparser = mapset_subparsers.add_parser("lock", help="lock a mapset")
     subparser.add_argument("mapset_path", type=str)
-    subparser.add_argument(
-        "--process-id",
-        metavar="PID",
-        type=int,
-        default=1,
-        help=_(
-            "process ID of the process locking the mapset (a mapset can be "
-            "automatically unlocked if there is no process with this PID)"
-        ),
-    )
-    subparser.add_argument(
-        "--timeout",
-        metavar="TIMEOUT",
-        type=float,
-        default=30,
-        help=_("mapset locking timeout in seconds"),
-    )
-    subparser.add_argument(
-        "-f",
-        "--force-remove-lock",
-        action="store_true",
-        help=_("remove lock if present"),
-    )
+    subparser.add_argument("--process-id", metavar="PID", type=int, default=1)
+    subparser.add_argument("--timeout", metavar="TIMEOUT", type=float, default=30)
+    subparser.add_argument("-f", "--force-remove-lock", action="store_true")
     subparser.set_defaults(func=subcommand_lock_mapset)
 
     subparser = mapset_subparsers.add_parser("unlock", help="unlock a mapset")
@@ -197,97 +180,61 @@ def add_project_subparser(subparsers):
 
     create_parser = project_subparsers.add_parser("create", help="create project")
     create_parser.add_argument("path", help="path to the new project")
-    create_parser.add_argument(
-        "--crs",
-        help="CRS for the project",
-    )
-    create_parser.add_argument(
-        "--proj4",
-        help="if given, create new project based on Proj4 definition",
-    )
-    create_parser.add_argument(
-        "--wkt",
-        help=(
-            "if given, create new project based on WKT definition "
-            "(can be path to PRJ file or WKT string)"
-        ),
-    )
-    create_parser.add_argument(
-        "--datum",
-        help="GRASS format datum code",
-    )
-    create_parser.add_argument(
-        "--datum-trans",
-        dest="datum_trans",
-        help="datum transformation parameters (used for epsg and proj4)",
-    )
-    create_parser.add_argument(
-        "--description",
-        help="description of the project",
-    )
-    create_parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="overwrite existing project",
-    )
+    create_parser.add_argument("--crs")
+    create_parser.add_argument("--proj4")
+    create_parser.add_argument("--wkt")
+    create_parser.add_argument("--datum")
+    create_parser.add_argument("--datum-trans", dest="datum_trans")
+    create_parser.add_argument("--description")
+    create_parser.add_argument("--overwrite", action="store_true")
     create_parser.set_defaults(func=subcommand_create_project)
 
 
 def main(args=None, program=None):
-    # Top-level parser
     if program is None:
         program = os.path.basename(sys.argv[0])
         if program == "__main__.py":
             program = f"{Path(sys.executable).name} -m grass.app"
+
     parser = argparse.ArgumentParser(
-        description="Experimental low-level CLI interface to GRASS. Consult developers before using it.",
+        description="Experimental low-level CLI interface to GRASS.",
         prog=program,
     )
-    subparsers = parser.add_subparsers(
-        title="subcommands", dest="subcommand", required=True
-    )
 
-    # Subcommand parsers
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     run_subparser = subparsers.add_parser(
         "run",
         help="run a tool",
         add_help=False,
-        epilog="Tool name is followed by its parameters.",
     )
+
     run_subparser.add_argument("tool", type=str, nargs="?", help="name of a tool")
     run_subparser.add_argument("--help", action="store_true")
-    run_subparser.add_argument("--crs", type=str, help="CRS to use for computations")
-    run_subparser.add_argument(
-        "--project", type=str, help="project to use for computations"
-    )
+    run_subparser.add_argument("--crs", type=str)
+    run_subparser.add_argument("--project", type=str)
     run_subparser.set_defaults(func=subcommand_run_tool)
 
     add_project_subparser(subparsers)
     add_mapset_subparser(subparsers)
 
-    subparser = subparsers.add_parser(
-        "help", help="show HTML documentation for a tool or topic"
-    )
+    subparser = subparsers.add_parser("help")
     subparser.add_argument("page", type=str)
     subparser.set_defaults(func=subcommand_show_help)
 
-    subparser = subparsers.add_parser(
-        "man", help="show man page for a tool or topic using"
-    )
+    subparser = subparsers.add_parser("man")
     subparser.add_argument("page", type=str)
     subparser.set_defaults(func=subcommand_show_man)
 
-    # Parsing
     parsed_args, other_args = parser.parse_known_args(args)
-    # Standard help already exited, but we need to handle tools separately.
+
     if parsed_args.subcommand == "run":
         if parsed_args.tool is None and parsed_args.help:
             run_subparser.print_help()
             return 0
         if parsed_args.tool is None:
             run_subparser.print_usage()
-            # argparse gives 2 without parameters, so we behave the same.
             return 2
         return parsed_args.func(parsed_args, other_args, print_help=parsed_args.help)
+
     return parsed_args.func(parsed_args)

--- a/python/grass/app/tests/grass_app_cli_alias_test.py
+++ b/python/grass/app/tests/grass_app_cli_alias_test.py
@@ -1,0 +1,7 @@
+from grass.app.cli import resolve_tool_name
+
+
+def test_resolve_tool_name_aliases():
+    assert resolve_tool_name("list") == "g.list"
+    assert resolve_tool_name("slope") == "r.slope.aspect"
+    assert resolve_tool_name("r.info") == "r.info"

--- a/python/grass/app/tests/grass_app_cli_test.py
+++ b/python/grass/app/tests/grass_app_cli_test.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from grass.app.cli import main
+from grass.app.cli import main, resolve_tool_name
 
 
 def test_cli_help_runs():
@@ -55,6 +55,13 @@ def test_subcommand_run_tool_regular_run():
 def test_subcommand_run_tool_failure_run():
     """Check that a tool produces non-zero return code"""
     assert main(["run", "g.region", "raster=does_not_exist"]) == 1
+
+
+def test_resolve_tool_name_aliases():
+    """Check that experimental alias mapping resolves to module names"""
+    assert resolve_tool_name("list") == "g.list"
+    assert resolve_tool_name("slope") == "r.slope.aspect"
+    assert resolve_tool_name("r.info") == "r.info"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Hi,

This PR introduces a small proof-of-concept for command alias mapping in the experimental CLI (`grass run`).

Motivation:
Currently, users need to know full GRASS module names such as `r.slope.aspect` or `g.list`. This can be unintuitive, especially for new users or quick workflows.

This PR explores a simple alias layer that maps shorter commands to existing modules.

Current implementation:
- `slope` → `r.slope.aspect`
- `list` → `g.list`

Example usage:
grass run slope elevation=elev_lid792_1m slope=out_slope aspect=out_aspect
grass run list type=raster

This is intentionally minimal and meant as a starting point for discussion.

Before this PR, I built a local prototype which mapped simplified commands and verified an end-to-end workflow including region setup, raster analysis, and GeoTIFF output.

Questions:
1. Does this approach align with the intended CLI design?
2. Should alias mapping be handled at this level or differently?
3. Is this a good direction to extend further for the Subcommand CLI project?

Thanks,
Arth