### PR TITLE
temporal: add explicit return True in shift()

### DIFF
--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2086,6 +2086,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         if connection_state_changed:
             dbif.close()
+        return True
 
     @staticmethod
     def snap_map_list(maps):


### PR DESCRIPTION
Follow-up to #7228

shift() method returns None on success but signature declares -> bool.
Add explicit return True to match the documented contract.

Currently works because caller uses `is False` strict check,
but correct behavior should return bool as documented.