### PR TITLE
GUI: Add Copy drop-down menu and Paste parameters button to module dialogs

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -618,7 +618,7 @@ class TaskFrame(wx.Frame):
         item_script = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (Script API)"))
         item_tools = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (Tools API)"))
         item_pygrass = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (PyGRASS)"))
-        item_json = self.copyMenu.Append(wx.ID_ANY, _("Copy as JSON"))
+        item_json = self.copyMenu.Append(wx.ID_ANY, _("Copy as JSON settings"))
 
         # Bind menu items
         self.Bind(wx.EVT_MENU, self.OnCopyCommand, item_shell)
@@ -638,31 +638,18 @@ class TaskFrame(wx.Frame):
         # Get standard button dimensions to ensure the arrow segment matches
         standard_size = self.btn_copy.GetBestSize()
         btn_h = standard_size.height
-        arrow_btn_w = 24
+        arrow_btn_w = 23
 
-        # 2. Create a truly transparent 16x16 chevron icon using RGBA
-        icon_size = 16
-        # Start with a fully transparent bitmap (alpha=0)
+        icon_size = 23
         bmp = wx.Bitmap.FromRGBA(icon_size, icon_size, red=0, green=0, blue=0, alpha=0)
 
         mdc = wx.MemoryDC(bmp)
-        gc = wx.GCDC(mdc)  # GCDC provides smoother (anti-aliased) lines
+        renderer = wx.RendererNative.Get()
 
-        # Draw the "v" shape (chevron)
-        # Use system button text color for automatic Light/Dark mode support
-        text_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNTEXT)
-        gc.SetPen(wx.Pen(text_color, 2))
+        rect = wx.Rect(0, 0, icon_size, icon_size)
 
-        # On Windows, text baseline is 2 pixels higher, so we shift the arrow up
-        y_offset = -2 if sys.platform.startswith("win") else 0
+        renderer.DrawDropArrow(self.panel, mdc, rect, wx.CONTROL_FLAT)
 
-        # Coordinates for perfect centering in a 16x16 canvas:
-        # We start the arms at 8 and the tip at 13.
-        # This aligns the tip with the baseline of the letters.
-        gc.DrawLine(4, 8 + y_offset, 8, 13 + y_offset)
-        gc.DrawLine(8, 13 + y_offset, 12, 8 + y_offset)
-
-        del gc
         mdc.SelectObject(wx.NullBitmap)
 
         # 3. The Arrow Button segment
@@ -686,7 +673,9 @@ class TaskFrame(wx.Frame):
 
         # Paste button
         # Create the Paste button to populate the dialog from a JSON string
-        self.btn_paste = Button(parent=self.panel, id=wx.ID_ANY, label=_("Paste"))
+        self.btn_paste = Button(
+            parent=self.panel, id=wx.ID_ANY, label=_("Paste JSON settings")
+        )
         self.btn_paste.SetToolTip(
             _("Paste parameters from JSON string in the clipboard")
         )
@@ -1039,6 +1028,23 @@ class TaskFrame(wx.Frame):
             data = json.loads(tdo.GetText())
             if not isinstance(data, dict):
                 raise ValueError(_("Pasted data is not a valid JSON object."))
+
+            pasted_module = data.get("module")
+            current_module = self.task.get_name()
+
+            if pasted_module and pasted_module != current_module:
+                confirm = wx.MessageBox(
+                    _(
+                        "You are pasting settings from module '%(pasted)s' into module '%(current)s'. "
+                        "Only matching parameters will be updated. Continue?"
+                    )
+                    % {"pasted": pasted_module, "current": current_module},
+                    _("Module Mismatch"),
+                    wx.YES_NO | wx.ICON_WARNING,
+                )
+                if confirm != wx.YES:
+                    return
+
             new_params = data.get("params", data)
             if not isinstance(new_params, dict):
                 raise ValueError(_("Pasted parameters are not a valid JSON object."))
@@ -1133,8 +1139,17 @@ class TaskFrame(wx.Frame):
             else:
                 self.SetStatusText(_("No matching parameters found in clipboard."))
 
-        except (json.JSONDecodeError, ValueError) as e:
-            wx.MessageBox(_("Paste Error: {}").format(e), _("Error"), wx.ICON_ERROR)
+        except json.JSONDecodeError:
+            wx.MessageBox(
+                _(
+                    "The clipboard does not contain valid JSON data. "
+                    "Please ensure you have copied the settings correctly."
+                ),
+                _("Invalid Data"),
+                wx.ICON_ERROR,
+            )
+        except ValueError as e:
+            wx.MessageBox(str(e), _("Paste Error"), wx.ICON_ERROR)
 
     def _toClipboard(self, text):
         """Stores text string into the system clipboard"""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -920,7 +920,7 @@ class TaskFrame(wx.Frame):
         for item in cmdlist[1:]:
             if item.startswith("--"):
                 val = item.lstrip("-")
-                if val in ("overwrite", "o"):
+                if val in {"overwrite", "o"}:
                     python_params.append("overwrite=True")
                 elif val == "verbose":
                     python_params.append("verbose=True")

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -620,6 +620,18 @@ class TaskFrame(wx.Frame):
         )
         self.btn_clipboard.Bind(wx.EVT_BUTTON, self.OnCopyCommand)
 
+        # copy in python syntax
+        self.btn_copy_python = Button(
+            parent=self.panel, id=wx.ID_ANY, label=_("Copy in Python")
+        )
+        self.btn_copy_python.SetToolTip(
+            _("Copy the command in Python gs.run_command() syntax")
+        )
+        btnsizer.Add(
+            self.btn_copy_python, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER, border=10
+        )
+        self.btn_copy_python.Bind(wx.EVT_BUTTON, self.OnCopyPython)
+
         # help
         self.btn_help = Button(parent=self.panel, id=wx.ID_HELP)
         self.btn_help.SetToolTip(_("Show manual page of the command (Ctrl+H)"))
@@ -888,6 +900,67 @@ class TaskFrame(wx.Frame):
             wx.TheClipboard.SetData(cmddata)
             wx.TheClipboard.Close()
             self.SetStatusText(_("'%s' copied to clipboard") % (cmdstring))
+
+    def OnCopyPython(self, event):
+        """Copy the command in Python syntax with keyword handling"""
+        import keyword
+
+        cmdlist = self.createCmd(ignoreErrors=True)
+        if not cmdlist or len(cmdlist) < 1:
+            return
+
+        module_name = cmdlist[0]
+        module_name = module_name.removesuffix(".py")
+
+        flags = ""
+        python_params = []
+        # Dictionary for keys that Python can't handle as direct arguments
+        illegal_keys = {}
+
+        for item in cmdlist[1:]:
+            if item.startswith("--"):
+                val = item.lstrip("-")
+                if val in ("overwrite", "o"):
+                    python_params.append("overwrite=True")
+                elif val == "verbose":
+                    python_params.append("verbose=True")
+                elif val == "quiet":
+                    python_params.append("quiet=True")
+                else:
+                    python_params.append(f"{val}=True")
+            elif item.startswith("-"):
+                flags += item.lstrip("-")
+            elif "=" in item:
+                k, v = item.split("=", 1)
+                # If key is a keyword (from, in) or contains dots/dashes,
+                # put it into the 'illegal' dictionary
+                if keyword.iskeyword(k) or not k.isidentifier():
+                    illegal_keys[k] = v
+                else:
+                    python_params.append(f"{k}={v!r}")
+
+        # Build the command string
+        py_cmd = f"gs.run_command('{module_name}'"
+
+        if flags:
+            py_cmd += f", flags='{flags}'"
+
+        if python_params:
+            py_cmd += ", " + ", ".join(python_params)
+
+        if illegal_keys:
+            # Safe unpacking: **{'from': 'val', 'to': 'val'}
+            py_cmd += f", **{illegal_keys!r}"
+
+        py_cmd += ")"
+
+        # Copy to clipboard
+        cmddata = wx.TextDataObject()
+        cmddata.SetText(py_cmd)
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(cmddata)
+            wx.TheClipboard.Close()
+            self.SetStatusText(_("Python syntax copied to clipboard"))
 
     def OnCancel(self, event):
         """Cancel button pressed"""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -61,7 +61,6 @@ from threading import Thread
 from pathlib import Path
 
 import json
-import keyword
 import wx
 
 import wx.lib.colourselect as csel
@@ -957,8 +956,7 @@ class TaskFrame(wx.Frame):
         module_name = cmd[0]
 
         # Build the command string
-        py_cmd = f"gs.run_command('{module_name}', "
-        py_cmd += self._get_formatted_params(cmd)
+        py_cmd = f"gs.run_command('{module_name}', " + gtask.cmd_to_python_args(cmd)
 
         # Copy to clipboard
         self._toClipboard(py_cmd)
@@ -973,8 +971,7 @@ class TaskFrame(wx.Frame):
         # e.g., v.distance -> v_distance, v.in.ascii -> v_in_ascii
         module_name = cmd[0].replace(".", "_")
 
-        py_cmd = f"Tools().{module_name}("
-        py_cmd += self._get_formatted_params(cmd)
+        py_cmd = f"Tools().{module_name}(" + gtask.cmd_to_python_args(cmd)
 
         self._toClipboard(py_cmd)
 
@@ -986,8 +983,7 @@ class TaskFrame(wx.Frame):
 
         module_name = cmd[0]
 
-        py_cmd = f"Module('{module_name}', "
-        py_cmd += self._get_formatted_params(cmd)
+        py_cmd = f"Module('{module_name}', " + gtask.cmd_to_python_args(cmd)
 
         self._toClipboard(py_cmd)
 
@@ -997,7 +993,7 @@ class TaskFrame(wx.Frame):
         if not cmd or len(cmd) < 1:
             return
 
-        data = {"module": cmd[0], "params": self._extract_params_dict(cmd)}
+        data = {"module": cmd[0], "params": gtask.cmd_to_dict(cmd)}
         self._toClipboard(json.dumps(data, indent=4))
         self.SetStatusText(_("JSON copied to clipboard"))
 
@@ -1012,7 +1008,11 @@ class TaskFrame(wx.Frame):
 
         try:
             data = json.loads(tdo.GetText())
+            if not isinstance(data, dict):
+                raise ValueError(_("Pasted data is not a valid JSON object."))
             new_params = data.get("params", data)
+            if not isinstance(new_params, dict):
+                raise ValueError(_("Pasted parameters are not a valid JSON object."))
             target_flags_str = new_params.get("flags", "")
             found_any = False
 
@@ -1104,82 +1104,8 @@ class TaskFrame(wx.Frame):
             else:
                 self.SetStatusText(_("No matching parameters found in clipboard."))
 
-        except Exception as e:
+        except (json.JSONDecodeError, ValueError) as e:
             wx.MessageBox(_("Paste Error: {}").format(e), _("Error"), wx.ICON_ERROR)
-
-    def _get_formatted_params(self, cmd):
-        """Helper to format parameters for Python calls, handling illegal keywords"""
-        flags = ""
-        python_params = []
-        # Dictionary for keys that Python can't handle as direct arguments
-        illegal_keys = {}
-
-        for item in cmd[1:]:
-            if item.startswith("--"):
-                val = item.lstrip("-")
-                if val in {"overwrite", "o"}:
-                    python_params.append("overwrite=True")
-                elif val == "verbose":
-                    python_params.append("verbose=True")
-                elif val == "quiet":
-                    python_params.append("quiet=True")
-                else:
-                    python_params.append(f"{val}=True")
-            elif item.startswith("-"):
-                flags += item.lstrip("-")
-            elif "=" in item:
-                k, v = item.split("=", 1)
-                # If key is a keyword (from, in) or contains dots/dashes,
-                # put it into the 'illegal' dictionary
-                if keyword.iskeyword(k) or not k.isidentifier():
-                    illegal_keys[k] = v
-                else:
-                    python_params.append(f"{k}={v!r}")
-
-        # Build the command string
-        py_cmd = ""
-
-        if flags:
-            py_cmd += f"flags='{flags}'"
-
-        if python_params:
-            py_cmd += ", " + ", ".join(python_params)
-
-        if illegal_keys:
-            # Safe unpacking: **{'from': 'val', 'to': 'val'}
-            py_cmd += f", **{illegal_keys!r}"
-
-        py_cmd += ")"
-        return py_cmd
-
-    def _extract_params_dict(self, cmd):
-        """Extracts a dictionary of parameters from the cmd list (skips flags)"""
-
-        flags = ""
-        python_params = []
-
-        for item in cmd[1:]:
-            if item.startswith("--"):
-                val = item.lstrip("-")
-                if val in {"overwrite", "o"}:
-                    python_params.append("overwrite=True")
-                elif val == "verbose":
-                    python_params.append("verbose=True")
-                elif val == "quiet":
-                    python_params.append("quiet=True")
-                else:
-                    python_params.append(f"{val}=True")
-            elif item.startswith("-"):
-                flags += item.lstrip("-")
-            elif "=" in item:
-                k, v = item.split("=", 1)
-                python_params.append(f"{k}={v}")
-        params = {"flags": flags}
-        for item in python_params:
-            if "=" in item:
-                k, v = item.split("=", 1)
-                params[k] = v
-        return params
 
     def _toClipboard(self, text):
         """Stores text string into the system clipboard"""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -60,6 +60,8 @@ import codecs
 from threading import Thread
 from pathlib import Path
 
+import json
+import keyword
 import wx
 
 import wx.lib.colourselect as csel
@@ -610,27 +612,64 @@ class TaskFrame(wx.Frame):
             self.Bind(wx.EVT_MENU, self.OnRun, id=wx.ID_OK)
             accelTableList.append((wx.ACCEL_CTRL, ord("R"), wx.ID_OK))
 
-        # copy
-        self.btn_clipboard = Button(parent=self.panel, id=wx.ID_ANY, label=_("Copy"))
-        self.btn_clipboard.SetToolTip(
-            _("Copy the current command string to the clipboard")
-        )
-        btnsizer.Add(
-            self.btn_clipboard, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER, border=10
-        )
-        self.btn_clipboard.Bind(wx.EVT_BUTTON, self.OnCopyCommand)
+        # --- Split Copy Button ---
+        self.copyMenu = wx.Menu()
+        # Note: We include Shell command in the menu too, for clarity
+        item_shell = self.copyMenu.Append(wx.ID_ANY, _("Copy as Shell command"))
+        item_script = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (Script API)"))
+        item_tools = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (Tools API)"))
+        item_pygrass = self.copyMenu.Append(wx.ID_ANY, _("Copy as Python (PyGRASS)"))
+        item_json = self.copyMenu.Append(wx.ID_ANY, _("Copy as JSON"))
 
-        # copy in python syntax
-        self.btn_copy_python = Button(
-            parent=self.panel, id=wx.ID_ANY, label=_("Copy in Python")
+        # Bind menu items
+        self.Bind(wx.EVT_MENU, self.OnCopyCommand, item_shell)
+        self.Bind(wx.EVT_MENU, self.OnCopyPython, item_script)
+        self.Bind(wx.EVT_MENU, self.OnCopyPythonTools, item_tools)
+        self.Bind(wx.EVT_MENU, self.OnCopyPygrass, item_pygrass)
+        self.Bind(wx.EVT_MENU, self.OnCopyJSON, item_json)
+
+        # --- Split Copy Button Section ---
+        # A horizontal sizer to combine the main button and the arrow button
+        copy_sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        # 1. Main Copy button (triggers Shell command copy by default)
+        self.btn_copy = Button(parent=self.panel, id=wx.ID_ANY, label=_("Copy"))
+        self.btn_copy.SetToolTip(_("Copy as Shell command"))
+        self.btn_copy.Bind(wx.EVT_BUTTON, self.OnCopyCommand)
+
+        # 2. Arrow button (triggers the dropdown menu)
+        # Using a fixed width (25) ensures it looks like a standard menu arrow
+        self.btn_copy_menu = Button(
+            parent=self.panel, id=wx.ID_ANY, label="▼", size=(25, -1)
         )
-        self.btn_copy_python.SetToolTip(
-            _("Copy the command in Python gs.run_command() syntax")
-        )
+        self.btn_copy_menu.SetToolTip(_("More copy formats"))
+        self.btn_copy_menu.Bind(wx.EVT_BUTTON, self.OnShowCopyMenu)
+
+        # Add both buttons to the internal horizontal sizer.
+        # We use wx.EXPAND to force both buttons to have the same height.
+        copy_sizer.Add(self.btn_copy, proportion=0, flag=wx.EXPAND)
+        copy_sizer.Add(self.btn_copy_menu, proportion=0, flag=wx.EXPAND)
+
+        # Add the combined split-button to the main button sizer.
+        # We use wx.ALIGN_CENTER_VERTICAL here to align it with other buttons (Run, Help, etc.)
         btnsizer.Add(
-            self.btn_copy_python, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER, border=10
+            copy_sizer, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=10
         )
-        self.btn_copy_python.Bind(wx.EVT_BUTTON, self.OnCopyPython)
+
+        # Paste button
+        # Create the Paste button to populate the dialog from a JSON string
+        self.btn_paste = Button(parent=self.panel, id=wx.ID_ANY, label=_("Paste"))
+        self.btn_paste.SetToolTip(
+            _("Paste parameters from JSON string in the clipboard")
+        )
+        self.btn_paste.Bind(wx.EVT_BUTTON, self.OnPaste)
+
+        btnsizer.Add(
+            self.btn_paste,
+            proportion=0,
+            flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL,
+            border=10,
+        )
 
         # help
         self.btn_help = Button(parent=self.panel, id=wx.ID_HELP)
@@ -883,6 +922,13 @@ class TaskFrame(wx.Frame):
         event = wxCmdAbort(aborted=True)
         wx.PostEvent(self._gconsole, event)
 
+    def OnShowCopyMenu(self, event):
+        """Show the copy formats popup menu"""
+        button = event.GetEventObject()
+        pos = button.GetPosition()
+        size = button.GetSize()
+        self.panel.PopupMenu(self.copyMenu, wx.Point(pos.x, pos.y + size.height))
+
     def OnCopyCommand(self, event):
         """Copy the command"""
         cmddata = wx.TextDataObject()
@@ -903,21 +949,172 @@ class TaskFrame(wx.Frame):
 
     def OnCopyPython(self, event):
         """Copy the command in Python syntax with keyword handling"""
-        import keyword
 
-        cmdlist = self.createCmd(ignoreErrors=True)
-        if not cmdlist or len(cmdlist) < 1:
+        cmd = self.createCmd(ignoreErrors=True)
+        if not cmd or len(cmd) < 1:
             return
 
-        module_name = cmdlist[0]
-        module_name = module_name.removesuffix(".py")
+        module_name = cmd[0]
 
+        # Build the command string
+        py_cmd = f"gs.run_command('{module_name}', "
+        py_cmd += self._get_formatted_params(cmd)
+
+        # Copy to clipboard
+        self._toClipboard(py_cmd)
+
+    def OnCopyPythonTools(self, event):
+        """Copy command in Tools API syntax"""
+        cmd = self.createCmd(ignoreErrors=True)
+        if not cmd or len(cmd) < 1:
+            return
+
+        # Replace dots with underscores to match the Tools API method names
+        # e.g., v.distance -> v_distance, v.in.ascii -> v_in_ascii
+        module_name = cmd[0].replace(".", "_")
+
+        py_cmd = f"Tools().{module_name}("
+        py_cmd += self._get_formatted_params(cmd)
+
+        self._toClipboard(py_cmd)
+
+    def OnCopyPygrass(self, event):
+        """Copy command in PyGRASS syntax"""
+        cmd = self.createCmd(ignoreErrors=True)
+        if not cmd or len(cmd) < 1:
+            return
+
+        module_name = cmd[0]
+
+        py_cmd = f"Module('{module_name}', "
+        py_cmd += self._get_formatted_params(cmd)
+
+        self._toClipboard(py_cmd)
+
+    def OnCopyJSON(self, event):
+        """Copy parameters as JSON string"""
+        cmd = self.createCmd(ignoreErrors=True)
+        if not cmd or len(cmd) < 1:
+            return
+
+        data = {"module": cmd[0], "params": self._extract_params_dict(cmd)}
+        self._toClipboard(json.dumps(data, indent=4))
+        self.SetStatusText(_("JSON copied to clipboard"))
+
+    def OnPaste(self, event):
+        """Populate dialog fields from JSON string in the clipboard"""
+        tdo = wx.TextDataObject()
+        if not (wx.TheClipboard.Open() and wx.TheClipboard.GetData(tdo)):
+            if wx.TheClipboard.IsOpened():
+                wx.TheClipboard.Close()
+            return
+        wx.TheClipboard.Close()
+
+        try:
+            data = json.loads(tdo.GetText())
+            new_params = data.get("params", data)
+            target_flags_str = new_params.get("flags", "")
+            found_any = False
+
+            # Process both Parameters and Flags in one unified logic
+            for porf in self.task.params + self.task.flags:
+                name = porf.get("name")
+                is_flag = porf in self.task.flags
+
+                # Determine the value to set
+                val = None
+                if name in new_params:
+                    val = new_params[name]
+                elif is_flag:
+                    # Absent flags default to False unless found in the 'flags' string
+                    val = bool(
+                        len(name) == 1 and name in target_flags_str.replace("-", "")
+                    )
+                else:
+                    # Absent parameters revert to their standard default values
+                    val = porf.get("default", "")
+
+                if val is None:
+                    continue
+
+                # Update internal task state
+                clean_val = str(val) if not isinstance(val, bool) else val
+                porf["value"] = val
+
+                # Update GUI Widgets
+                for w_id in porf.get("wxId", []):
+                    if not w_id:
+                        continue
+                    win = self.FindWindowById(w_id)
+                    if not win or win.GetName() == "ModelParam":
+                        continue
+
+                    # Specialized Widget Handling
+                    if isinstance(win, wx.CheckBox):
+                        if not is_flag and porf.get("prompt") == "color":
+                            win.SetValue(clean_val == "none")
+                        elif not is_flag:  # Multi-selection checkboxes
+                            try:
+                                idx = porf["wxId"].index(w_id)
+                                values = porf.get("values", [])
+                                if idx < len(values):
+                                    win.SetValue(
+                                        str(values[idx]) in str(clean_val).split(",")
+                                    )
+                            except (ValueError, IndexError):
+                                pass
+                        else:  # Standard Boolean Flag
+                            win.SetValue(
+                                val
+                                if isinstance(val, bool)
+                                else str(val).lower() in ("true", "1", "yes")
+                            )
+
+                    elif isinstance(win, wx.SpinCtrl):
+                        try:
+                            win.SetValue(int(float(clean_val)))
+                        except ValueError:
+                            pass
+
+                    elif (
+                        win.GetName() == "GetColour"
+                        and clean_val
+                        and clean_val != "none"
+                    ):
+                        col, lab = utils.color_resolve(clean_val)
+                        if hasattr(win, "SetColour"):
+                            win.SetColour(col)
+                            if hasattr(win, "SetLabel"):
+                                win.SetLabel(lab)
+                            win.Refresh()
+                    elif isinstance(win, wx.Choice):
+                        win.SetStringSelection(str(clean_val))
+                    elif hasattr(win, "SetValue"):
+                        # Standard TextCtrl / ComboBox
+                        try:
+                            win.SetValue(str(clean_val))
+                        except (TypeError, ValueError):
+                            pass
+
+                    found_any = True
+
+            if found_any:
+                self.updateValuesHook()
+                self.SetStatusText(_("Parameters pasted from clipboard."))
+            else:
+                self.SetStatusText(_("No matching parameters found in clipboard."))
+
+        except Exception as e:
+            wx.MessageBox(_("Paste Error: {}").format(e), _("Error"), wx.ICON_ERROR)
+
+    def _get_formatted_params(self, cmd):
+        """Helper to format parameters for Python calls, handling illegal keywords"""
         flags = ""
         python_params = []
         # Dictionary for keys that Python can't handle as direct arguments
         illegal_keys = {}
 
-        for item in cmdlist[1:]:
+        for item in cmd[1:]:
             if item.startswith("--"):
                 val = item.lstrip("-")
                 if val in {"overwrite", "o"}:
@@ -940,10 +1137,10 @@ class TaskFrame(wx.Frame):
                     python_params.append(f"{k}={v!r}")
 
         # Build the command string
-        py_cmd = f"gs.run_command('{module_name}'"
+        py_cmd = ""
 
         if flags:
-            py_cmd += f", flags='{flags}'"
+            py_cmd += f"flags='{flags}'"
 
         if python_params:
             py_cmd += ", " + ", ".join(python_params)
@@ -953,14 +1150,44 @@ class TaskFrame(wx.Frame):
             py_cmd += f", **{illegal_keys!r}"
 
         py_cmd += ")"
+        return py_cmd
 
-        # Copy to clipboard
-        cmddata = wx.TextDataObject()
-        cmddata.SetText(py_cmd)
-        if wx.TheClipboard.Open():
-            wx.TheClipboard.SetData(cmddata)
-            wx.TheClipboard.Close()
-            self.SetStatusText(_("Python syntax copied to clipboard"))
+    def _extract_params_dict(self, cmd):
+        """Extracts a dictionary of parameters from the cmd list (skips flags)"""
+
+        flags = ""
+        python_params = []
+
+        for item in cmd[1:]:
+            if item.startswith("--"):
+                val = item.lstrip("-")
+                if val in {"overwrite", "o"}:
+                    python_params.append("overwrite=True")
+                elif val == "verbose":
+                    python_params.append("verbose=True")
+                elif val == "quiet":
+                    python_params.append("quiet=True")
+                else:
+                    python_params.append(f"{val}=True")
+            elif item.startswith("-"):
+                flags += item.lstrip("-")
+            elif "=" in item:
+                k, v = item.split("=", 1)
+                python_params.append(f"{k}={v}")
+        params = {"flags": flags}
+        for item in python_params:
+            if "=" in item:
+                k, v = item.split("=", 1)
+                params[k] = v
+        return params
+
+    def _toClipboard(self, text):
+        """Stores text string into the system clipboard"""
+        if not wx.TheClipboard.IsOpened():
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject(text))
+                wx.TheClipboard.Close()
+                self.SetStatusText(_("%s copied to clipboard") % text)
 
     def OnCancel(self, event):
         """Cancel button pressed"""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -627,7 +627,6 @@ class TaskFrame(wx.Frame):
         self.Bind(wx.EVT_MENU, self.OnCopyPygrass, item_pygrass)
         self.Bind(wx.EVT_MENU, self.OnCopyJSON, item_json)
 
-        # --- Split Copy Button Section ---
         # A horizontal sizer to combine the main button and the arrow button
         copy_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -636,24 +635,54 @@ class TaskFrame(wx.Frame):
         self.btn_copy.SetToolTip(_("Copy as Shell command"))
         self.btn_copy.Bind(wx.EVT_BUTTON, self.OnCopyCommand)
 
-        # 2. Arrow button (triggers the dropdown menu)
-        # Using a fixed width (25) ensures it looks like a standard menu arrow
+        # Get standard button dimensions to ensure the arrow segment matches
+        standard_size = self.btn_copy.GetBestSize()
+        btn_h = standard_size.height
+        arrow_btn_w = 24
+
+        # 2. Create a truly transparent 16x16 chevron icon using RGBA
+        icon_size = 16
+        # Start with a fully transparent bitmap (alpha=0)
+        bmp = wx.Bitmap.FromRGBA(icon_size, icon_size, red=0, green=0, blue=0, alpha=0)
+
+        mdc = wx.MemoryDC(bmp)
+        gc = wx.GCDC(mdc)  # GCDC provides smoother (anti-aliased) lines
+
+        # Draw the "v" shape (chevron)
+        # Use system button text color for automatic Light/Dark mode support
+        text_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNTEXT)
+        gc.SetPen(wx.Pen(text_color, 2))
+
+        # On Windows, text baseline is 2 pixels higher, so we shift the arrow up
+        y_offset = -2 if sys.platform.startswith("win") else 0
+
+        # Coordinates for perfect centering in a 16x16 canvas:
+        # We start the arms at 8 and the tip at 13.
+        # This aligns the tip with the baseline of the letters.
+        gc.DrawLine(4, 8 + y_offset, 8, 13 + y_offset)
+        gc.DrawLine(8, 13 + y_offset, 12, 8 + y_offset)
+
+        del gc
+        mdc.SelectObject(wx.NullBitmap)
+
+        # 3. The Arrow Button segment
+        # Using a standard Button class to inherit native hover and click effects
         self.btn_copy_menu = Button(
-            parent=self.panel, id=wx.ID_ANY, label="▼", size=(25, -1)
+            parent=self.panel, id=wx.ID_ANY, size=(arrow_btn_w, btn_h)
         )
+        self.btn_copy_menu.SetBitmap(bmp)
         self.btn_copy_menu.SetToolTip(_("More copy formats"))
         self.btn_copy_menu.Bind(wx.EVT_BUTTON, self.OnShowCopyMenu)
 
-        # Add both buttons to the internal horizontal sizer.
-        # We use wx.EXPAND to force both buttons to have the same height.
-        copy_sizer.Add(self.btn_copy, proportion=0, flag=wx.EXPAND)
-        copy_sizer.Add(self.btn_copy_menu, proportion=0, flag=wx.EXPAND)
+        # 4. Using a small negative border to pull the buttons closer on Windows.
+        btn_glue = -1 if sys.platform.startswith("win") else 0
 
-        # Add the combined split-button to the main button sizer.
-        # We use wx.ALIGN_CENTER_VERTICAL here to align it with other buttons (Run, Help, etc.)
-        btnsizer.Add(
-            copy_sizer, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=10
-        )
+        # 5. Assembly
+        copy_sizer.Add(self.btn_copy, 0, wx.EXPAND)
+        copy_sizer.Add(self.btn_copy_menu, 0, wx.EXPAND | wx.LEFT, border=btn_glue)
+
+        # Final addition to the main button row with standard 10px outer margin
+        btnsizer.Add(copy_sizer, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=10)
 
         # Paste button
         # Create the Paste button to populate the dialog from a JSON string
@@ -1067,7 +1096,7 @@ class TaskFrame(wx.Frame):
                             win.SetValue(
                                 val
                                 if isinstance(val, bool)
-                                else str(val).lower() in ("true", "1", "yes")
+                                else str(val).lower() in {"true", "1", "yes"}
                             )
 
                     elif isinstance(win, wx.SpinCtrl):

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -22,6 +22,7 @@ for details.
 import os
 import re
 import sys
+import keyword
 import xml.etree.ElementTree as ET
 from xml.parsers import expat
 
@@ -673,3 +674,85 @@ def cmdstring_to_tuple(cmd):
     :return: command as tuple
     """
     return cmdlist_to_tuple(split(cmd))
+
+
+def cmd_to_python_args(cmd):
+    """Format parameters for Python calls, handling illegal keywords.
+
+    :param cmd: list of command arguments (e.g. ['v.distance', 'from=map1', 'to=map2'])
+    :return: string of formatted Python arguments ending with a closing parenthesis ')'
+    """
+    flags = ""
+    python_params = []
+    # Dictionary for keys that Python can't handle as direct arguments
+    illegal_keys = {}
+
+    for item in cmd[1:]:
+        if item.startswith("--"):
+            val = item.lstrip("-")
+            if val in {"overwrite", "o"}:
+                python_params.append("overwrite=True")
+            elif val == "verbose":
+                python_params.append("verbose=True")
+            elif val == "quiet":
+                python_params.append("quiet=True")
+            else:
+                python_params.append(f"{val}=True")
+        elif item.startswith("-"):
+            flags += item.lstrip("-")
+        elif "=" in item:
+            k, v = item.split("=", 1)
+            # If key is a keyword (from, in) or contains dots/dashes,
+            # put it into the 'illegal' dictionary
+            if keyword.iskeyword(k) or not k.isidentifier():
+                illegal_keys[k] = v
+            else:
+                python_params.append(f"{k}={v!r}")
+
+    # Build the command string
+    args = []
+
+    if flags:
+        args.append(f"flags='{flags}'")
+
+    args.extend(python_params)
+
+    if illegal_keys:
+        # Safe unpacking: **{'from': 'val', 'to': 'val'}
+        args.append(f"**{illegal_keys!r}")
+
+    return ", ".join(args) + ")"
+
+
+def cmd_to_dict(cmd):
+    """Extract a dictionary of parameters from the cmd list.
+
+    :param cmd: list of command arguments
+    :return: dictionary of parameters and flags
+    """
+    flags = ""
+    python_params = []
+
+    for item in cmd[1:]:
+        if item.startswith("--"):
+            val = item.lstrip("-")
+            if val in {"overwrite", "o"}:
+                python_params.append("overwrite=True")
+            elif val == "verbose":
+                python_params.append("verbose=True")
+            elif val == "quiet":
+                python_params.append("quiet=True")
+            else:
+                python_params.append(f"{val}=True")
+        elif item.startswith("-"):
+            flags += item.lstrip("-")
+        elif "=" in item:
+            k, v = item.split("=", 1)
+            python_params.append(f"{k}={v}")
+
+    params = {"flags": flags}
+    for item in python_params:
+        if "=" in item:
+            k, v = item.split("=", 1)
+            params[k] = v
+    return params

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -306,8 +306,8 @@ class processTask:
         self.task.name = self.root.get("name", default="unknown")
 
         # keywords
-        for keyword in self._get_node_text(self.root, "keywords").split(","):
-            self.task.keywords.append(keyword.strip())
+        for kw in self._get_node_text(self.root, "keywords").split(","):
+            self.task.keywords.append(kw.strip())
 
         self.task.label = self._get_node_text(self.root, "label")
         self.task.description = self._get_node_text(self.root, "description")


### PR DESCRIPTION
## Description

*Note: This PR description was updated post-merge to accurately reflect the final, expanded scope of the implemented features.*

This PR enhances the user experience in the GRASS GUI module dialogs by introducing advanced options for copying and pasting module configurations. It streamlines the transition between GUI workflows, command-line execution, and Python scripting.

### Key Features

* **Advanced Copy Drop-down:** Enhances the existing Copy button by adding a drop-down arrow that reveals multiple export formats.
* **Copy Options Included:** Shell command, Python (Script API), Python (Tools API), Python (PyGRASS), and JSON settings.
* **Paste JSON Settings Button:** Adds a dedicated, standalone button that allows users to instantly populate the module dialog inputs by pasting previously exported JSON settings.
