### PR TITLE
macOS: update libLAS to latest for GDAL 3.12 support

### DIFF
--- a/macos/files/liblas-install.sh
+++ b/macos/files/liblas-install.sh
@@ -11,7 +11,7 @@
 #
 #############################################################################
 
-liblas_commit="6ada875661c46842433a13f28637f8d3d2c393bc"
+liblas_commit="0756b73ed41211d1bb8d9b96c6767f2350d8fe2b"
 liblas_zipfile_name="libLAS_${liblas_commit}.zip"
 liblas_zipfile_url="https://github.com/libLAS/libLAS/archive/${liblas_commit}.zip"
 liblas_source_dir_name="libLAS-${liblas_commit}"
@@ -45,49 +45,19 @@ mkdir -p "$liblas_build_dir"
 
 unzip "$liblas_zipfile" -d "$cache_dir" &> /dev/null
 
-# patch needed for using now outdated GDAL api
 patch -d "$liblas_source_dir" -p0 << EOF
---- src/gt_wkt_srs.cpp.orig	2020-12-14 19:56:40.000000000 +0100
-+++ src/gt_wkt_srs.cpp	2021-03-27 19:31:30.000000000 +0100
-@@ -299,7 +299,6 @@
-                 oSRS.SetFromUserInput(pszWKT);
-                 oSRS.SetExtension( "PROJCS", "PROJ4",
-                                    "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs" );
--                oSRS.FixupOrdering();
-                 CPLFree(pszWKT);
-                 pszWKT = NULL;
-                 oSRS.exportToWkt(&pszWKT);
-@@ -505,7 +504,6 @@
-         {
-             char	*pszWKT;
-             oSRS.morphFromESRI();
--            oSRS.FixupOrdering();
-             if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
-                 return pszWKT;
-         }
-@@ -1107,7 +1105,6 @@
- /* ==================================================================== */
-     char	*pszWKT;
-
--    oSRS.FixupOrdering();
-
-     if( oSRS.exportToWkt( &pszWKT ) == OGRERR_NONE )
-         return pszWKT;
-
-EOF
-
-# patch for missing architecture in endian detection
-patch -d "$liblas_source_dir" -p0 << EOF
---- include/liblas/detail/endian.hpp.orig	2021-01-20 18:24:39.000000000 +0100
-+++ include/liblas/detail/endian.hpp	2022-09-27 18:21:23.000000000 +0200
-@@ -88,6 +88,7 @@
-    || defined(_M_ALPHA) || defined(__amd64) \\
-    || defined(__amd64__) || defined(_M_AMD64) \\
-    || defined(__x86_64) || defined(__x86_64__) \\
-+   || defined(__arm64) || defined(__arm64__) \\
-    || defined(_M_X64)
-
- # define LIBLAS_LITTLE_ENDIAN
+--- CMakeLists.txt.orig	2025-11-08 16:34:42
++++ CMakeLists.txt	2026-04-11 15:36:21
+@@ -231,9 +231,6 @@
+   endif ()
+ endif ()
+ if (GDAL_FOUND)
+-  SET(CMAKE_CXX_STANDARD 11)
+-  SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+-  SET(CMAKE_CXX_EXTENSIONS OFF)
+   include_directories(${GDAL_INCLUDE_DIR})
+   add_definitions(-DHAVE_GDAL=1)
+   set(WITH_GDAL TRUE)
 EOF
 
 LIBLAS_CONFIGURE_FLAGS="


### PR DESCRIPTION
Update macOS build script dependency package libLAS version to latest (from master) for GDAL 3.12 support.

https://github.com/libLAS/libLAS/commit/0756b73ed41211d1bb8d9b96c6767f2350d8fe2b