### PR TITLE
macOS: use default config dir consistently

### DIFF
--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -136,7 +136,7 @@ static const char *GRASS_copyright UNUSED = "GRASS GNU GPL licensed Software";
 #define WKT_FILE         "PROJ_WKT"
 #define SRID_FILE        "PROJ_SRID"
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(__APPLE__)
 #define CONFIG_DIR "GRASS8"
 #else
 #define CONFIG_DIR ".grass8"

--- a/lib/gis/home.c
+++ b/lib/gis/home.c
@@ -107,14 +107,19 @@ const char *G_config_path(void)
         return config_path;
 
     config_dir = getenv("GRASS_CONFIG_DIR");
-    if (!config_dir)
+    if (!config_dir) {
 #ifdef __MINGW32__
         config_dir = getenv("APPDATA");
 #else
         config_dir = G_home();
 #endif
-
+    }
+#if defined(__APPLE__)
+    snprintf(buf, GPATH_MAX, "%s%c%s%c%s", config_dir, HOST_DIRSEP, "Library",
+             HOST_DIRSEP, CONFIG_DIR);
+#else
     snprintf(buf, GPATH_MAX, "%s%c%s", config_dir, HOST_DIRSEP, CONFIG_DIR);
+#endif
     config_path = G_store(buf);
 
 #if 0

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -392,6 +392,16 @@ def create_grass_config_dir() -> str:
                         "Failed to create configuration directory '{}' with error: {}"
                     ).format(directory, e.strerror)
                 )
+        # TODO: remove with next major or minor release after GRASS 8.5 (8.6 or 9.0)
+        old_mac_dir = os.path.join(os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}")
+        if MACOS and Path(old_mac_dir).is_dir():
+            try:
+                shutil.copy(os.path.join(old_mac_dir, "rc"), directory)
+                shutil.copy(os.path.join(old_mac_dir, "wx.json"), directory)
+                shutil.copytree(os.path.join(old_mac_dir, "toolboxes"), directory)
+            except Exception:
+                pass
+
     return directory
 
 

--- a/macos/files/grass.sh.in
+++ b/macos/files/grass.sh.in
@@ -14,7 +14,6 @@
 #
 #############################################################################
 
-# script_dir=$(dirname "$(dirname "$0")")
 app_dir="$(cd "$(dirname "$0")/../.."; pwd -P)"
 
 # Mac app only startup shell - complete rewrite for starting from a GRASS.app
@@ -22,22 +21,14 @@ app_dir="$(cd "$(dirname "$0")/../.."; pwd -P)"
 
 trap "echo 'User break!' ; exit" 2 3 9 15
 
-export GISBASE=$app_dir/Contents/Resources
+export GISBASE=${app_dir}/Contents/Resources
 grass_ver=$(cut -d . -f 1-2 "$GISBASE/etc/VERSIONNUMBER")
+grass_ver_major=$(cut -d . -f 1 "$GISBASE/etc/VERSIONNUMBER")
 
-export GISBASE_USER="$HOME/Library/GRASS/$grass_ver"
-export GISBASE_SYSTEM="/Library/GRASS/$grass_ver"
+GISBASE_USER="$HOME/Library/GRASS/GRASS${grass_ver_major}"
+GISBASE_SYSTEM="/Library/GRASS/GRASS${grass_ver_major}"
 
-# add some OS X style app support paths, and create user one if missing.
-mkdir -p "$GISBASE_USER/Addons/bin"
-mkdir -p "$GISBASE_USER/Addons/scripts"
-if [ ! "$GRASS_ADDON_BASE" ] ; then
-	GRASS_ADDON_BASE="$GISBASE_USER/Addons"
-fi
-export GRASS_ADDON_BASE
-
-mkdir -p "$GISBASE_USER/Addons/etc"
-addpath="$GISBASE_USER/Addons/etc:$GISBASE_SYSTEM/Addons/etc"
+addpath="$GISBASE_USER/Addons${grass_ver}/etc:$GISBASE_SYSTEM/Addons${grass_ver}/etc"
 if [ "$GRASS_ADDON_ETC" ] ; then
 	GRASS_ADDON_ETC="$GRASS_ADDON_ETC:$addpath"
 else
@@ -45,12 +36,9 @@ else
 fi
 export GRASS_ADDON_ETC
 
-mkdir -p "$GISBASE_USER/Addons/lib"
-mkdir -p "$GISBASE_USER/Addons/docs/html"
-
 # user fontcap files
 if [ ! "$GRASS_FONT_CAP" ] ; then
-	GRASS_FONT_CAP="$GISBASE_USER/Addons/etc/fontcap"
+    GRASS_FONT_CAP="$GISBASE_USER/fontcap${grass_ver}"
 fi
 export GRASS_FONT_CAP
 

--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -209,9 +209,7 @@ def get_grass_config_dir_for_version(major_version, minor_version, *, env):
     if WINDOWS:
         config_dirname = f"GRASS{major_version}"
     elif MACOS:
-        config_dirname = os.path.join(
-            "Library", "GRASS", f"{major_version}.{minor_version}"
-        )
+        config_dirname = os.path.join("Library", "GRASS", f"GRASS{major_version}")
     else:
         config_dirname = f".grass{major_version}"
 
@@ -238,7 +236,11 @@ def append_left_addon_paths(paths, config_dir, env):
     # addons (base)
     addon_base = env.get("GRASS_ADDON_BASE")
     if not addon_base:
-        name = "addons" if not MACOS else "Addons"
+        name = (
+            "addons"
+            if not MACOS
+            else f"Addons{resource_paths.GRASS_VERSION_MAJOR}.{resource_paths.GRASS_VERSION_MINOR}"
+        )
         addon_base = os.path.join(config_dir, name)
         env["GRASS_ADDON_BASE"] = addon_base
 


### PR DESCRIPTION
Default configuration directory on mac: `~/Library/GRASS/GRASS{major version}`. For 8.4, and probably a few releases before, *nix default `~/.grass{major version}` was used. This restores the "old" behaviour for mac, with a few moderations. Addons directory name is now versioned, based on major and minor version, but separated from general configurations.

For convenient upgrade experience from 8.4, old configuration files are copied to the new location, on first use.

Closes #7305.

cc @cmbarton 