### PR TITLE
lib: prefix macros UNUSED and FALLTHROUGH

### DIFF
--- a/db/drivers/dbf/dbfexe.c
+++ b/db/drivers/dbf/dbfexe.c
@@ -343,7 +343,7 @@ void get_col_def(SQLPSTMT *st, int col, int *type, int *width, int *decimals)
     }
 }
 
-void eval_val(int tab, int row, int col UNUSED, SQLPVALUE *inval,
+void eval_val(int tab, int row, int col G_UNUSED, SQLPVALUE *inval,
               SQLPVALUE *val)
 {
 

--- a/db/drivers/dbf/driver.c
+++ b/db/drivers/dbf/driver.c
@@ -18,7 +18,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     init_error();
     return DB_OK;

--- a/db/drivers/dbf/listtab.c
+++ b/db/drivers/dbf/listtab.c
@@ -18,7 +18,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_list_tables(dbString **tlist, int *tcount, int system UNUSED)
+int db__driver_list_tables(dbString **tlist, int *tcount, int system G_UNUSED)
 {
     dbString *list;
     int i;

--- a/db/drivers/mysql/driver.c
+++ b/db/drivers/mysql/driver.c
@@ -16,7 +16,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     init_error();
     return DB_OK;

--- a/db/drivers/mysql/listtab.c
+++ b/db/drivers/mysql/listtab.c
@@ -18,7 +18,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_list_tables(dbString **tlist, int *tcount, int system UNUSED)
+int db__driver_list_tables(dbString **tlist, int *tcount, int system G_UNUSED)
 {
     int i;
     dbString *list;

--- a/db/drivers/ogr/driver.c
+++ b/db/drivers/ogr/driver.c
@@ -25,7 +25,7 @@
 
    \return DB_OK on success
  */
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     init_error();
     return DB_OK;

--- a/db/drivers/ogr/listtab.c
+++ b/db/drivers/ogr/listtab.c
@@ -30,7 +30,7 @@
    \return DB_OK on success
    \return DB_FAILED on failure
  */
-int db__driver_list_tables(dbString **tlist, int *tcount, int system UNUSED)
+int db__driver_list_tables(dbString **tlist, int *tcount, int system G_UNUSED)
 {
     int i, nlayers;
     dbString *list;

--- a/db/drivers/postgres/db.c
+++ b/db/drivers/postgres/db.c
@@ -19,7 +19,7 @@
 #include "globals.h"
 #include "proto.h"
 
-static void notice_processor(void *arg UNUSED, const char *message)
+static void notice_processor(void *arg G_UNUSED, const char *message)
 {
     /* print notice messages only on verbose level */
     if (G_verbose() > G_verbose_std()) {

--- a/db/drivers/postgres/driver.c
+++ b/db/drivers/postgres/driver.c
@@ -2,7 +2,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     init_error();
     return DB_OK;

--- a/db/drivers/sqlite/driver.c
+++ b/db/drivers/sqlite/driver.c
@@ -15,7 +15,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     init_error();
 

--- a/db/drivers/sqlite/main.c
+++ b/db/drivers/sqlite/main.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     exit(db_driver(argc, argv));
 }
 
-int sqlite_busy_callback(void *arg UNUSED, int n_calls)
+int sqlite_busy_callback(void *arg G_UNUSED, int n_calls)
 {
     static time_t start_time = 0;
     time_t curr_time;

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -470,11 +470,11 @@ int scan_ref(char *buf)
     case 2:
         if (!(xmatch(word2) || ymatch(word2)))
             return 0;
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     case 1:
         if (xmatch(word1) || ymatch(word1))
             return 1;
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     case EOF:
     default:
         return 0;

--- a/display/d.path/select.c
+++ b/display/d.path/select.c
@@ -11,7 +11,7 @@
 
 #define WDTH 5
 
-int display(struct Map_info *Map UNUSED, struct line_pnts *Points,
+int display(struct Map_info *Map G_UNUSED, struct line_pnts *Points,
             const struct color_rgb *color, int first, int last, int be_bold)
 {
     int from, to;

--- a/display/d.rhumbline/plot.c
+++ b/display/d.rhumbline/plot.c
@@ -5,7 +5,7 @@
 #include "local_proto.h"
 
 void plot(double lon1, double lat1, double lon2, double lat2, int line_color,
-          int text_color UNUSED)
+          int text_color G_UNUSED)
 {
     int nsteps = 1000;
     int i;

--- a/display/d.vect.thematic/area.c
+++ b/display/d.vect.thematic/area.c
@@ -16,7 +16,7 @@
 int dareatheme(struct Map_info *Map, struct cat_list *Clist,
                dbCatValArray *cvarr, double *breaks, int nbreaks,
                const struct color_rgb *colors, const struct color_rgb *bcolor,
-               int chcat, struct Cell_head *window, int default_width UNUSED)
+               int chcat, struct Cell_head *window, int default_width G_UNUSED)
 {
 
     int num, area, isle, n_isles, n_points;

--- a/display/d.vect.thematic/display.c
+++ b/display/d.vect.thematic/display.c
@@ -139,7 +139,7 @@ int display_lines(struct Map_info *Map, struct cat_list *Clist, int chcat,
 }
 
 int draw_line(int ltype, int line, const struct line_pnts *Points,
-              const struct line_cats *Cats, int chcat, double size UNUSED,
+              const struct line_cats *Cats, int chcat, double size G_UNUSED,
               int default_width, const struct cat_list *Clist, SYMBOL *Symb,
               RGBA_Color *primary_color, int *n_points, int *n_lines,
               int *n_centroids, int *n_boundaries, int *n_faces,

--- a/display/d.vect.thematic/plot1.c
+++ b/display/d.vect.thematic/plot1.c
@@ -38,10 +38,10 @@ struct rgb_color palette[16] = {
 /* *************************************************************** */
 /* *************************************************************** */
 /* *************************************************************** */
-int plot1(struct Map_info *Map, int type, int area UNUSED,
+int plot1(struct Map_info *Map, int type, int area G_UNUSED,
           struct cat_list *Clist, const struct color_rgb *color,
           const struct color_rgb *fcolor, int chcat, SYMBOL *Symb,
-          int size UNUSED, int id_flag, int table_colors_flag,
+          int size G_UNUSED, int id_flag, int table_colors_flag,
           int cats_color_flag, char *rgb_column, int default_width,
           char *width_column, double width_scale)
 {

--- a/imagery/i.atcorr/geomcond.cpp
+++ b/imagery/i.atcorr/geomcond.cpp
@@ -360,7 +360,7 @@ void GeomCond::parse()
     }
     case 4:
         campm = 1.0f; /* avhrr PM, case 4 must fall through to case 5 */
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     case 5: /* avhrr PM and avhrr AM */
     {
         cin >> month;

--- a/imagery/i.eb.netrad/r_net.c
+++ b/imagery/i.eb.netrad/r_net.c
@@ -5,8 +5,8 @@
 
 #define PI M_PI
 
-double r_net(double bbalb, double ndvi UNUSED, double tempk, double dtair,
-             double e0, double tsw, double doy, double utc UNUSED,
+double r_net(double bbalb, double ndvi G_UNUSED, double tempk, double dtair,
+             double e0, double tsw, double doy, double utc G_UNUSED,
              double sunzangle)
 {
 

--- a/imagery/i.evapo.mh/mh_original.c
+++ b/imagery/i.evapo.mh/mh_original.c
@@ -5,7 +5,7 @@
 
 /*Hargreaves et al, 1985. */
 double mh_original(double ra, double tavg, double tmax, double tmin,
-                   double p UNUSED)
+                   double p G_UNUSED)
 {
     double td, result;
 

--- a/imagery/i.evapo.pm/functions.c
+++ b/imagery/i.evapo.pm/functions.c
@@ -97,8 +97,8 @@ DCELL calc_ETp(DCELL T, DCELL Z, DCELL u2, DCELL Rn, int night, DCELL Rh,
     return ETp;
 }
 
-DCELL calc_openwaterETp(DCELL T, DCELL Z, DCELL u2, DCELL Rn, int day UNUSED,
-                        DCELL Rh, DCELL hc UNUSED)
+DCELL calc_openwaterETp(DCELL T, DCELL Z, DCELL u2, DCELL Rn, int day G_UNUSED,
+                        DCELL Rh, DCELL hc G_UNUSED)
 {
     DCELL ea, delta, gamma, lambda;
     DCELL P, ed, ETaero, ETp;

--- a/imagery/i.gensig/alloc.c
+++ b/imagery/i.gensig/alloc.c
@@ -24,14 +24,14 @@ double **matrix(int nrl, int nrh, int ncl, int nch)
     return m;
 }
 
-int free_vector(double *v, int nl, int nh UNUSED)
+int free_vector(double *v, int nl, int nh G_UNUSED)
 {
     G_free((char *)(v + nl));
 
     return 0;
 }
 
-int free_matrix(double **m, int nrl, int nrh, int ncl, int nch UNUSED)
+int free_matrix(double **m, int nrl, int nrh, int ncl, int nch G_UNUSED)
 {
     int i;
 

--- a/imagery/i.ortho.photo/lib/cam_info.c
+++ b/imagery/i.ortho.photo/lib/cam_info.c
@@ -60,8 +60,9 @@ int I_read_cam_info(FILE *fd, struct Ortho_Camera_File_Ref *cam_info)
     return 1;
 }
 
-int I_new_fid_point(struct Ortho_Camera_File_Ref *cam_info UNUSED,
-                    char fid_id[30] UNUSED, double Xf UNUSED, double Yf UNUSED)
+int I_new_fid_point(struct Ortho_Camera_File_Ref *cam_info G_UNUSED,
+                    char fid_id[30] G_UNUSED, double Xf G_UNUSED,
+                    double Yf G_UNUSED)
 {
     return 0;
 }

--- a/imagery/i.ortho.photo/lib/orthoref.c
+++ b/imagery/i.ortho.photo/lib/orthoref.c
@@ -612,7 +612,7 @@ int I_compute_ortho_equations(struct Ortho_Control_Points *cpz,
 /* given ground coordinates (e1,n1,z1) and the solution from above */
 /* compute the photo coordinate (e2,n2) position */
 int I_ortho_ref(double e1, double n1, double z1, double *e2, double *n2,
-                double *z2 UNUSED, struct Ortho_Camera_File_Ref *cam_info,
+                double *z2 G_UNUSED, struct Ortho_Camera_File_Ref *cam_info,
                 double XC, double YC, double ZC, MATRIX M)
 {
     MATRIX UVW, XYZ;
@@ -684,7 +684,7 @@ int I_ortho_ref(double e1, double n1, double z1, double *e2, double *n2,
 /* and the solution from I_compute_ortho_equation */
 /* compute ground position (e2,n2) */
 int I_inverse_ortho_ref(double e1, double n1, double z1, double *e2, double *n2,
-                        double *z2 UNUSED,
+                        double *z2 G_UNUSED,
                         struct Ortho_Camera_File_Ref *cam_info, double XC,
                         double YC, double ZC, MATRIX M)
 {

--- a/imagery/i.segment/watershed.c
+++ b/imagery/i.segment/watershed.c
@@ -14,7 +14,7 @@
 #include <grass/rbtree.h>  /* Red Black Tree library functions */
 #include "iseg.h"
 
-int watershed(struct globals *globals UNUSED)
+int watershed(struct globals *globals G_UNUSED)
 {
     G_fatal_error(_("Watershed is not yet implemented"));
 

--- a/include/Make/Doxyfile_arch_html.in
+++ b/include/Make/Doxyfile_arch_html.in
@@ -2257,7 +2257,7 @@ PREDEFINED             = HAVE_GEOS \
                          HAVE_TIFFIO_H \
                          NOPG_UNUSED= \
                          NO_NLS_UNUSED= \
-                         UNUSED=
+                         G_UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/Make/Doxyfile_arch_latex.in
+++ b/include/Make/Doxyfile_arch_latex.in
@@ -2257,7 +2257,7 @@ PREDEFINED             = HAVE_GEOS \
                          HAVE_TIFFIO_H \
                          NOPG_UNUSED= \
                          NO_NLS_UNUSED= \
-                         UNUSED=
+                         G_UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -49,14 +49,14 @@
 static const char *GRASS_copyright G_UNUSED = "GRASS GNU GPL licensed Software";
 
 /*!
-    \def FALLTHROUGH
+    \def G_FALLTHROUGH
     \brief A macro for a fallthrough statement attribute
  */
 #if (defined(__GNUC__) && __GNUC__ >= 7) || \
     (defined(__clang__) && __clang_major__ >= 12)
-#define FALLTHROUGH __attribute__((__fallthrough__))
+#define G_FALLTHROUGH __attribute__((__fallthrough__))
 #else
-#define FALLTHROUGH ((void)0)
+#define G_FALLTHROUGH ((void)0)
 #endif
 
 /* GRASS version, GRASS date, git short hash of last change in GRASS headers

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -36,17 +36,17 @@
 #endif
 
 /*!
-    \def UNUSED
+    \def G_UNUSED
     \brief A macro for an attribute, if attached to a variable,
            indicating that the variable is not used
 */
 #if (defined(__GNUC__) || defined(__APPLE__)) && !defined(_MSC_VER)
-#define UNUSED __attribute__((unused))
+#define G_UNUSED __attribute__((unused))
 #else
-#define UNUSED
+#define G_UNUSED
 #endif
 
-static const char *GRASS_copyright UNUSED = "GRASS GNU GPL licensed Software";
+static const char *GRASS_copyright G_UNUSED = "GRASS GNU GPL licensed Software";
 
 /*!
     \def FALLTHROUGH

--- a/include/grass/iostream/embuffer.h
+++ b/include/grass/iostream/embuffer.h
@@ -137,7 +137,7 @@ public:
     {
         return (x.k == y.k);
     }
-    friend merge_key operator+(const merge_key &x, const merge_key &y UNUSED)
+    friend merge_key operator+(const merge_key &x, const merge_key &y G_UNUSED)
     {
         assert(0);
         return x;
@@ -533,7 +533,7 @@ em_buffer<T, Key>::~em_buffer()
 // memory (by a previous get_stream call, for instance) in order to
 // find its length
 template <class T, class Key>
-void em_buffer<T, Key>::check_name(unsigned int i UNUSED)
+void em_buffer<T, Key>::check_name(unsigned int i G_UNUSED)
 {
 
 #ifdef EMBUF_CHECK_NAME

--- a/include/grass/iostream/empq.h
+++ b/include/grass/iostream/empq.h
@@ -161,7 +161,7 @@ public:
 
     // create an em_pqueue capable to store <= N elements
     em_pqueue();
-    em_pqueue(long N UNUSED) { em_pqueue(); }; // N not used
+    em_pqueue(long N G_UNUSED) { em_pqueue(); }; // N not used
 
 #ifdef SAVE_MEMORY
     // create an empq, initialize its pq with im and insert amis in

--- a/include/grass/iostream/empq_adaptive.h
+++ b/include/grass/iostream/empq_adaptive.h
@@ -57,7 +57,7 @@ private:
 public:
     /* start in INMEM regim by allocating im of size precisely twice the
        size of the (pqueue within) the em_pqueue; */
-    EMPQueueAdaptive(long N UNUSED) : EMPQueueAdaptive() {};
+    EMPQueueAdaptive(long N G_UNUSED) : EMPQueueAdaptive() {};
     EMPQueueAdaptive();
     EMPQueueAdaptive(size_t inMem);
     ~EMPQueueAdaptive();

--- a/lib/calc/calc.c
+++ b/lib/calc/calc.c
@@ -12,7 +12,7 @@ int columns;
 
 /****************************************************************************/
 
-static void handle_fpe(int n UNUSED)
+static void handle_fpe(int n G_UNUSED)
 {
     floating_point_exception = 1;
     floating_point_exception_occurred = 1;

--- a/lib/calc/xif.c
+++ b/lib/calc/xif.c
@@ -9,7 +9,7 @@
  if(a,b,c,d)  d,c,b  b if a is positive, c if a is zero, d if a is negative
 ********************************************************************/
 
-static int f_if_i(int argc, const int *argt UNUSED, void **args)
+static int f_if_i(int argc, const int *argt G_UNUSED, void **args)
 {
     CELL *res = args[0];
     DCELL *arg1 = args[1];
@@ -89,7 +89,7 @@ static int f_if_i(int argc, const int *argt UNUSED, void **args)
     return 0;
 }
 
-static int f_if_f(int argc, const int *argt UNUSED, void **args)
+static int f_if_f(int argc, const int *argt G_UNUSED, void **args)
 {
     FCELL *res = args[0];
     DCELL *arg1 = args[1];
@@ -164,7 +164,7 @@ static int f_if_f(int argc, const int *argt UNUSED, void **args)
     return 0;
 }
 
-static int f_if_d(int argc, const int *argt UNUSED, void **args)
+static int f_if_d(int argc, const int *argt G_UNUSED, void **args)
 {
     DCELL *res = args[0];
     DCELL *arg1 = args[1];

--- a/lib/db/dbmi_driver/d_mkdir.c
+++ b/lib/db/dbmi_driver/d_mkdir.c
@@ -48,7 +48,7 @@ int db_driver_mkdir(const char *path, int mode, int parentdirs)
 
 /* make a directory if it doesn't exist */
 /* this routine could be made more intelligent as to why it failed */
-static int make_dir(const char *path, int mode UNUSED)
+static int make_dir(const char *path, int mode G_UNUSED)
 {
     if (db_isdir(path) == DB_OK)
         return DB_OK;

--- a/lib/db/stubs/add_col.c
+++ b/lib/db/stubs/add_col.c
@@ -4,7 +4,8 @@
 /*!
    This function calls db_procedure_not_implemented().
  */
-int db__driver_add_column(dbString *tableName UNUSED, dbColumn *column UNUSED)
+int db__driver_add_column(dbString *tableName G_UNUSED,
+                          dbColumn *column G_UNUSED)
 {
     db_procedure_not_implemented("db_add_column");
     return DB_FAILED;

--- a/lib/db/stubs/bindupdate.c
+++ b/lib/db/stubs/bindupdate.c
@@ -7,7 +7,7 @@
    \return
    \param
  */
-int db__driver_bind_update(dbCursor *cursor UNUSED)
+int db__driver_bind_update(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_bind_update");
     return DB_FAILED;

--- a/lib/db/stubs/close_cursor.c
+++ b/lib/db/stubs/close_cursor.c
@@ -4,7 +4,7 @@
 /*!
    This function calls db_procedure_not_implemented().
  */
-int db__driver_close_cursor(dbCursor *cursor UNUSED)
+int db__driver_close_cursor(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_close_cursor");
     return DB_FAILED;

--- a/lib/db/stubs/create_index.c
+++ b/lib/db/stubs/create_index.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_create_index(dbIndex *index UNUSED)
+int db__driver_create_index(dbIndex *index G_UNUSED)
 {
     return DB_OK;
 }

--- a/lib/db/stubs/create_table.c
+++ b/lib/db/stubs/create_table.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_create_table(dbTable *table UNUSED)
+int db__driver_create_table(dbTable *table G_UNUSED)
 {
     db_procedure_not_implemented("db_create_table");
     return DB_FAILED;

--- a/lib/db/stubs/createdb.c
+++ b/lib/db/stubs/createdb.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_create_database(dbHandle *handle UNUSED)
+int db__driver_create_database(dbHandle *handle G_UNUSED)
 {
     db_procedure_not_implemented("db_create_database");
     return DB_FAILED;

--- a/lib/db/stubs/delete.c
+++ b/lib/db/stubs/delete.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_delete(dbCursor *cursor UNUSED)
+int db__driver_delete(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_delete");
     return DB_FAILED;

--- a/lib/db/stubs/deletedb.c
+++ b/lib/db/stubs/deletedb.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_delete_database(dbHandle *handle UNUSED)
+int db__driver_delete_database(dbHandle *handle G_UNUSED)
 {
     db_procedure_not_implemented("db_delete_database");
     return DB_FAILED;

--- a/lib/db/stubs/desc_table.c
+++ b/lib/db/stubs/desc_table.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_describe_table(dbString *name UNUSED, dbTable **table UNUSED)
+int db__driver_describe_table(dbString *name G_UNUSED, dbTable **table G_UNUSED)
 {
     db_procedure_not_implemented("db_describe_table");
     return DB_FAILED;

--- a/lib/db/stubs/drop_col.c
+++ b/lib/db/stubs/drop_col.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_drop_column(dbString *tableName UNUSED,
-                           dbString *columnName UNUSED)
+int db__driver_drop_column(dbString *tableName G_UNUSED,
+                           dbString *columnName G_UNUSED)
 {
     db_procedure_not_implemented("db_drop_column");
     return DB_FAILED;

--- a/lib/db/stubs/drop_index.c
+++ b/lib/db/stubs/drop_index.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_drop_index(dbString *name UNUSED)
+int db__driver_drop_index(dbString *name G_UNUSED)
 {
     db_procedure_not_implemented("db_drop_index");
     return DB_FAILED;

--- a/lib/db/stubs/drop_table.c
+++ b/lib/db/stubs/drop_table.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_drop_table(dbString *name UNUSED)
+int db__driver_drop_table(dbString *name G_UNUSED)
 {
     db_procedure_not_implemented("db_drop_table");
     return DB_FAILED;

--- a/lib/db/stubs/execute.c
+++ b/lib/db/stubs/execute.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_execute_immediate(dbString *SQLstatement UNUSED)
+int db__driver_execute_immediate(dbString *SQLstatement G_UNUSED)
 {
     db_procedure_not_implemented("db_execute_immediate");
     return DB_FAILED;

--- a/lib/db/stubs/fetch.c
+++ b/lib/db/stubs/fetch.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_fetch(dbCursor *cursor UNUSED, int position UNUSED,
-                     int *more UNUSED)
+int db__driver_fetch(dbCursor *cursor G_UNUSED, int position G_UNUSED,
+                     int *more G_UNUSED)
 {
     db_procedure_not_implemented("db_fetch");
     return DB_FAILED;

--- a/lib/db/stubs/finddb.c
+++ b/lib/db/stubs/finddb.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_find_database(dbHandle *handle UNUSED, int *found UNUSED)
+int db__driver_find_database(dbHandle *handle G_UNUSED, int *found G_UNUSED)
 {
     db_procedure_not_implemented("db_find_database");
     return DB_FAILED;

--- a/lib/db/stubs/init.c
+++ b/lib/db/stubs/init.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
+int db__driver_init(int argc G_UNUSED, char *argv[] G_UNUSED)
 {
     return DB_OK;
 }

--- a/lib/db/stubs/insert.c
+++ b/lib/db/stubs/insert.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_insert(dbCursor *cursor UNUSED)
+int db__driver_insert(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_insert");
     return DB_FAILED;

--- a/lib/db/stubs/list_index.c
+++ b/lib/db/stubs/list_index.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_list_indexes(dbString *tableName UNUSED,
-                            dbIndex **indexes UNUSED, int *count UNUSED)
+int db__driver_list_indexes(dbString *tableName G_UNUSED,
+                            dbIndex **indexes G_UNUSED, int *count G_UNUSED)
 {
     db_procedure_not_implemented("db_list_indexes");
     return DB_FAILED;

--- a/lib/db/stubs/list_tables.c
+++ b/lib/db/stubs/list_tables.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_list_tables(dbString **names UNUSED, int *count UNUSED,
-                           int system UNUSED)
+int db__driver_list_tables(dbString **names G_UNUSED, int *count G_UNUSED,
+                           int system G_UNUSED)
 {
     db_procedure_not_implemented("db_list_tables");
     return DB_FAILED;

--- a/lib/db/stubs/listdb.c
+++ b/lib/db/stubs/listdb.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_list_databases(dbString *path UNUSED, int npaths UNUSED,
-                              dbHandle **handles UNUSED, int *num UNUSED)
+int db__driver_list_databases(dbString *path G_UNUSED, int npaths G_UNUSED,
+                              dbHandle **handles G_UNUSED, int *num G_UNUSED)
 {
     db_procedure_not_implemented("db_list_databases");
     return DB_FAILED;

--- a/lib/db/stubs/open_insert.c
+++ b/lib/db/stubs/open_insert.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_open_insert_cursor(dbCursor *cursor UNUSED)
+int db__driver_open_insert_cursor(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_open_insert_cursor");
     return DB_FAILED;

--- a/lib/db/stubs/open_select.c
+++ b/lib/db/stubs/open_select.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_open_select_cursor(dbString *select UNUSED,
-                                  dbCursor *cursor UNUSED, int mode UNUSED)
+int db__driver_open_select_cursor(dbString *select G_UNUSED,
+                                  dbCursor *cursor G_UNUSED, int mode G_UNUSED)
 {
     db_procedure_not_implemented("db_open_select_cursor");
     return DB_FAILED;

--- a/lib/db/stubs/open_update.c
+++ b/lib/db/stubs/open_update.c
@@ -1,9 +1,9 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_open_update_cursor(dbString *name UNUSED,
-                                  dbString *select UNUSED,
-                                  dbCursor *cursor UNUSED, int mode UNUSED)
+int db__driver_open_update_cursor(dbString *name G_UNUSED,
+                                  dbString *select G_UNUSED,
+                                  dbCursor *cursor G_UNUSED, int mode G_UNUSED)
 {
     db_procedure_not_implemented("db_open_update_cursor");
     return DB_FAILED;

--- a/lib/db/stubs/opendb.c
+++ b/lib/db/stubs/opendb.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_open_database(dbHandle *handle UNUSED)
+int db__driver_open_database(dbHandle *handle G_UNUSED)
 {
     db_procedure_not_implemented("db_open_database");
     return DB_FAILED;

--- a/lib/db/stubs/priv.c
+++ b/lib/db/stubs/priv.c
@@ -1,8 +1,8 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_grant_on_table(dbString *tableName UNUSED, int priv UNUSED,
-                              int to UNUSED)
+int db__driver_grant_on_table(dbString *tableName G_UNUSED, int priv G_UNUSED,
+                              int to G_UNUSED)
 {
     return DB_OK;
 }

--- a/lib/db/stubs/rows.c
+++ b/lib/db/stubs/rows.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_get_num_rows(dbCursor *cursor UNUSED)
+int db__driver_get_num_rows(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_get_num_rows");
     return -1;

--- a/lib/db/stubs/update.c
+++ b/lib/db/stubs/update.c
@@ -1,7 +1,7 @@
 #include <grass/dbmi.h>
 #include <grass/dbstubs.h>
 
-int db__driver_update(dbCursor *cursor UNUSED)
+int db__driver_update(dbCursor *cursor G_UNUSED)
 {
     db_procedure_not_implemented("db_update");
     return DB_FAILED;

--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -175,7 +175,7 @@ void D_close_driver(void)
 
   \todo To be removed
 */
-int D_save_command(const char *cmd UNUSED)
+int D_save_command(const char *cmd G_UNUSED)
 {
     return 0;
 }

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -23,7 +23,7 @@
 #if defined(HAVE_LIBINTL_H) && defined(USE_NLS)
 #define NO_NLS_UNUSED
 #else
-#define NO_NLS_UNUSED UNUSED
+#define NO_NLS_UNUSED G_UNUSED
 #endif
 
 void G_init_locale(void)

--- a/lib/gis/wind_limits.c
+++ b/lib/gis/wind_limits.c
@@ -29,7 +29,7 @@
  * \return 1 no change
  * \return 0 changed
  */
-int G_limit_east(double *east UNUSED, int proj UNUSED)
+int G_limit_east(double *east G_UNUSED, int proj G_UNUSED)
 {
     return 1;
 }
@@ -48,7 +48,7 @@ int G_limit_east(double *east UNUSED, int proj UNUSED)
  * \return 1 no change
  * \return 0 changed
  */
-int G_limit_west(double *west UNUSED, int proj UNUSED)
+int G_limit_west(double *west G_UNUSED, int proj G_UNUSED)
 {
     return 1;
 }

--- a/lib/gis/worker.c
+++ b/lib/gis/worker.c
@@ -168,13 +168,13 @@ void G_finish_workers(void)
 
 /****************************************************************************/
 
-void G_begin_execute(void (*func)(void *), void *closure, void **ref UNUSED,
-                     int force UNUSED)
+void G_begin_execute(void (*func)(void *), void *closure, void **ref G_UNUSED,
+                     int force G_UNUSED)
 {
     (*func)(closure);
 }
 
-void G_end_execute(void **ref UNUSED)
+void G_end_execute(void **ref G_UNUSED)
 {
 }
 

--- a/lib/gmath/solvers_direct.c
+++ b/lib/gmath/solvers_direct.c
@@ -183,7 +183,7 @@ void G_math_gauss_elimination(double **A, double *b, int rows)
  * system, otherwise set it to NULL \param rows int \return void
  *
  * */
-void G_math_lu_decomposition(double **A, double *b UNUSED, int rows)
+void G_math_lu_decomposition(double **A, double *b G_UNUSED, int rows)
 {
 
     int i, j, k;

--- a/lib/gpde/n_les_assemble.c
+++ b/lib/gpde/n_les_assemble.c
@@ -424,9 +424,9 @@ N_les_callback_2d *N_alloc_les_callback_2d(void)
  * \return N_data_star *
  *
  * */
-N_data_star *N_callback_template_3d(void *data UNUSED, N_geom_data *geom,
-                                    int col UNUSED, int row UNUSED,
-                                    int depth UNUSED)
+N_data_star *N_callback_template_3d(void *data G_UNUSED, N_geom_data *geom,
+                                    int col G_UNUSED, int row G_UNUSED,
+                                    int depth G_UNUSED)
 {
     N_data_star *star = N_alloc_7star();
 
@@ -462,8 +462,8 @@ N_data_star *N_callback_template_3d(void *data UNUSED, N_geom_data *geom,
  * \return N_data_star *
  *
  * */
-N_data_star *N_callback_template_2d(void *data UNUSED, N_geom_data *geom,
-                                    int col UNUSED, int row UNUSED)
+N_data_star *N_callback_template_2d(void *data G_UNUSED, N_geom_data *geom,
+                                    int col G_UNUSED, int row G_UNUSED)
 {
     N_data_star *star = N_alloc_9star();
 

--- a/lib/lidar/zones.c
+++ b/lib/lidar/zones.c
@@ -562,7 +562,7 @@ void P_Aux_to_Raster(double **matrix, int fd)
 }
 
 /*------------------------------------------------------------------------------------------------*/
-void P_Aux_to_Vector(struct Map_info *Map UNUSED, struct Map_info *Out,
+void P_Aux_to_Vector(struct Map_info *Map G_UNUSED, struct Map_info *Out,
                      dbDriver *driver, char *tab_name)
 {
 

--- a/lib/nviz/change_view.c
+++ b/lib/nviz/change_view.c
@@ -321,7 +321,7 @@ void Nviz_init_rotation(void)
    \param lateral type of movement
 
  */
-void Nviz_flythrough(nv_data *data UNUSED, float *fly_info, int *scale,
+void Nviz_flythrough(nv_data *data G_UNUSED, float *fly_info, int *scale,
                      int lateral)
 {
     float dir[3], from[4], cur_from[4], cur_dir[4];

--- a/lib/nviz/cplanes_obj.c
+++ b/lib/nviz/cplanes_obj.c
@@ -90,7 +90,7 @@ int Nviz_draw_cplane(nv_data *data, int bound1, int bound2)
    \param surf1 first surface id
    \param surf2 second surface id
  */
-void cp_draw(nv_data *data, int current UNUSED, int surf1, int surf2)
+void cp_draw(nv_data *data, int current G_UNUSED, int surf1, int surf2)
 {
     int i, nsurfs;
     int surf_min = 0, surf_max = 0, temp;
@@ -248,7 +248,7 @@ int Nviz_get_cplane_translation(nv_data *data, int id, float *dx, float *dy,
 
    \param type type of fence (FC_ABOVE, FC_BELOW, FC_BLEND, FC_GREY, FC_OFF)
  */
-int Nviz_set_fence_color(nv_data *data UNUSED, int type)
+int Nviz_set_fence_color(nv_data *data G_UNUSED, int type)
 {
     GS_set_fencecolor(type);
 

--- a/lib/nviz/lights.c
+++ b/lib/nviz/lights.c
@@ -183,7 +183,7 @@ int Nviz_new_light(nv_data *data)
 
    \param data nviz data [unused]
  */
-void Nviz_draw_model(nv_data *data UNUSED)
+void Nviz_draw_model(nv_data *data G_UNUSED)
 {
     GS_set_draw(GSD_FRONT);
     GS_ready_draw();

--- a/lib/nviz/map_obj.c
+++ b/lib/nviz/map_obj.c
@@ -263,7 +263,7 @@ int Nviz_set_attr(int id, int type, int desc, int src, const char *str_value,
 
             break;
         }
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     default: {
         return 0;
     }

--- a/lib/nviz/position.c
+++ b/lib/nviz/position.c
@@ -117,7 +117,7 @@ int Nviz_set_focus_map(int type, int id)
    \param data nviz data [unused]
    \param x,y,z focus coordinates
  */
-int Nviz_get_focus(nv_data *data UNUSED, float *x, float *y, float *z)
+int Nviz_get_focus(nv_data *data G_UNUSED, float *x, float *y, float *z)
 {
     float realto[3];
 
@@ -138,7 +138,7 @@ int Nviz_get_focus(nv_data *data UNUSED, float *x, float *y, float *z)
    \param data nviz data [unused]
    \param x, y, z focus coordinates
  */
-int Nviz_set_focus(nv_data *data UNUSED, float x, float y, float z)
+int Nviz_set_focus(nv_data *data G_UNUSED, float x, float y, float z)
 {
     float realto[3];
 
@@ -157,7 +157,7 @@ int Nviz_set_focus(nv_data *data UNUSED, float x, float y, float z)
 
    \param data nviz data [unused]
  */
-int Nviz_has_focus(nv_data *data UNUSED)
+int Nviz_has_focus(nv_data *data G_UNUSED)
 {
     float realto[3];
 
@@ -183,7 +183,7 @@ float Nviz_get_xyrange(nv_data *data)
    \param data nviz data [unused]
    \param min,max z range
  */
-int Nviz_get_zrange(nv_data *data UNUSED, float *min, float *max)
+int Nviz_get_zrange(nv_data *data G_UNUSED, float *min, float *max)
 {
     GS_get_zrange_nz(min, max);
     return 1;
@@ -194,7 +194,7 @@ int Nviz_get_zrange(nv_data *data UNUSED, float *min, float *max)
 
    \param data nviz data [unused]
  */
-float Nviz_get_longdim(nv_data *data UNUSED)
+float Nviz_get_longdim(nv_data *data G_UNUSED)
 {
     float dim;
 

--- a/lib/nviz/render.c
+++ b/lib/nviz/render.c
@@ -154,8 +154,8 @@ void Nviz_destroy_render_window(struct render_window *rwin)
    \return 0 on success
    \return -1 on error
  */
-int Nviz_create_render_window(struct render_window *rwin, void *display UNUSED,
-                              int width, int height)
+int Nviz_create_render_window(struct render_window *rwin,
+                              void *display G_UNUSED, int width, int height)
 {
 #if defined(OPENGL_X11)
     int attributeList[] = {GLX_RGBA,

--- a/lib/ogsf/gk.c
+++ b/lib/ogsf/gk.c
@@ -561,8 +561,8 @@ double lin_interp(float dt, float val1, float val2)
 
    \return interval value
  */
-double get_2key_neighbors(int nvk, float time, float range UNUSED,
-                          int loop UNUSED, Keylist *karray[], Keylist **km1,
+double get_2key_neighbors(int nvk, float time, float range G_UNUSED,
+                          int loop G_UNUSED, Keylist *karray[], Keylist **km1,
                           Keylist **kp1)
 {
     int i;

--- a/lib/ogsf/gpd.c
+++ b/lib/ogsf/gpd.c
@@ -212,7 +212,7 @@ void gpd_obj(geosurf *gs, gvstyle *style, Point3 pt)
    \return 0 on failure
    \return 1 on success
  */
-int gpd_2dsite(geosite *gp, geosurf *gs, int do_fast UNUSED)
+int gpd_2dsite(geosite *gp, geosurf *gs, int do_fast G_UNUSED)
 {
     float site[4], konst;
     int src, check;
@@ -309,7 +309,7 @@ int gpd_2dsite(geosite *gp, geosurf *gs, int do_fast UNUSED)
    \return 0 on success
    \return 1 on failure
  */
-int gpd_3dsite(geosite *gp, float xo, float yo, int do_fast UNUSED)
+int gpd_3dsite(geosite *gp, float xo, float yo, int do_fast G_UNUSED)
 {
     float site[4], tz;
     int check;

--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -849,7 +849,7 @@ int Gs_get_cat_label(const char *filename, int drow, int dcol, char *catstr)
    \return -1 on error
    \return ?
  */
-int Gs_save_3dview(const char *vname, geoview *gv, geodisplay *gd UNUSED,
+int Gs_save_3dview(const char *vname, geoview *gv, geodisplay *gd G_UNUSED,
                    struct Cell_head *w, geosurf *defsurf)
 {
     const char *mapset;
@@ -948,7 +948,7 @@ int Gs_save_3dview(const char *vname, geoview *gv, geodisplay *gd UNUSED,
 
    \return 1
  */
-int Gs_load_3dview(const char *vname, geoview *gv, geodisplay *gd UNUSED,
+int Gs_load_3dview(const char *vname, geoview *gv, geodisplay *gd G_UNUSED,
                    struct Cell_head *w, const geosurf *defsurf)
 {
     const char *mapset;

--- a/lib/ogsf/gsd_cplane.c
+++ b/lib/ogsf/gsd_cplane.c
@@ -244,7 +244,7 @@ void gsd_cplane_settrans(int num, float tx, float ty, float tz)
    \param surf2 second surface (geosurf) [unused]
    \param cpnum
  */
-void gsd_draw_cplane_fence(geosurf *surf1, geosurf *surf2 UNUSED, int cpnum)
+void gsd_draw_cplane_fence(geosurf *surf1, geosurf *surf2 G_UNUSED, int cpnum)
 {
     int was_on;
     float len, dir[3], bgn[2], end[2], px, py, fencenorm[3];

--- a/lib/ogsf/gsd_objs.c
+++ b/lib/ogsf/gsd_objs.c
@@ -1279,8 +1279,8 @@ int gsd_scalebar(float *pos2, float len, GLuint fontbase, unsigned long bar_clr,
  *                 Integer representing the color to use for the text.
  * @return 1
  */
-int gsd_scalebar_v2(float *pos, float len, GLuint fontbase UNUSED,
-                    unsigned long bar_clr, unsigned long text_clr UNUSED)
+int gsd_scalebar_v2(float *pos, float len, GLuint fontbase G_UNUSED,
+                    unsigned long bar_clr, unsigned long text_clr G_UNUSED)
 {
     float base[6][3];
     float Ntop[] = {0.0, 0.0, 1.0};

--- a/lib/ogsf/gsd_prim.c
+++ b/lib/ogsf/gsd_prim.c
@@ -670,7 +670,7 @@ void gsd_litvert_func(float *norm, unsigned long col, float *pt)
    \param col [unused]
    \param pt
  */
-void gsd_litvert_func2(float *norm, unsigned long col UNUSED, float *pt)
+void gsd_litvert_func2(float *norm, unsigned long col G_UNUSED, float *pt)
 {
     glNormal3fv(norm);
     glVertex3fv(pt);
@@ -1150,7 +1150,7 @@ void gsd_endlist(void)
    \param listno
    \param range [unused]
  */
-void gsd_deletelist(GLuint listno, int range UNUSED)
+void gsd_deletelist(GLuint listno, int range G_UNUSED)
 {
     unsigned int i;
 
@@ -1182,7 +1182,7 @@ void gsd_calllist(int listno)
 
    \param listno [unused]
  */
-void gsd_calllists(int listno UNUSED)
+void gsd_calllists(int listno G_UNUSED)
 {
     int i;
 

--- a/lib/ogsf/gsd_surf.c
+++ b/lib/ogsf/gsd_surf.c
@@ -1087,7 +1087,7 @@ int gsd_surf_const(geosurf *surf, float k)
 
    \return 1
  */
-int gsd_surf_func(geosurf *gs UNUSED, int (*user_func)(void) UNUSED)
+int gsd_surf_func(geosurf *gs G_UNUSED, int (*user_func)(void) G_UNUSED)
 {
 
     return (1);

--- a/lib/ogsf/gsd_wire.c
+++ b/lib/ogsf/gsd_wire.c
@@ -439,7 +439,7 @@ int gsd_wire_surf_const(geosurf *surf, float k)
 
    \return 1
  */
-int gsd_wire_surf_func(geosurf *gs UNUSED, int (*user_func)(void) UNUSED)
+int gsd_wire_surf_func(geosurf *gs G_UNUSED, int (*user_func)(void) G_UNUSED)
 {
     return (1);
 }

--- a/lib/ogsf/gsdrape.c
+++ b/lib/ogsf/gsdrape.c
@@ -1070,7 +1070,8 @@ int get_horz_intersects(geosurf *gs, float *bgn, float *end, float *dir)
 
    \return number of intersects
  */
-int get_diag_intersects(geosurf *gs, float *bgn, float *end, float *dir UNUSED)
+int get_diag_intersects(geosurf *gs, float *bgn, float *end,
+                        float *dir G_UNUSED)
 {
     int fdig, ldig, incr, hits, num, offset;
     int vrow, vcol, drow1, drow2, dcol1, dcol2;

--- a/lib/ogsf/gvld.c
+++ b/lib/ogsf/gvld.c
@@ -420,7 +420,7 @@ cleanup_exit:
 
    \return 0
  */
-int gvld_wire_isosurf(geovol *gvl UNUSED)
+int gvld_wire_isosurf(geovol *gvl G_UNUSED)
 {
     return (0);
 }

--- a/lib/pngdriver/raster.c
+++ b/lib/pngdriver/raster.c
@@ -108,7 +108,7 @@ void PNG_begin_raster(int mask, int s[2][2], double fd[2][2])
 
    \return next row
  */
-int PNG_raster(UNUSED int n, int row, const unsigned char *red,
+int PNG_raster(G_UNUSED int n, int row, const unsigned char *red,
                const unsigned char *grn, const unsigned char *blu,
                const unsigned char *nul)
 {

--- a/lib/raster/get_row.c
+++ b/lib/raster/get_row.c
@@ -254,8 +254,8 @@ static void read_data(int fd, int row, unsigned char *data_buf, int *nbytes)
 }
 
 /* copy cell file data to user buffer translated by window column mapping */
-static void cell_values_int(int fd UNUSED, const unsigned char *data UNUSED,
-                            const COLUMN_MAPPING *cmap, int nbytes UNUSED,
+static void cell_values_int(int fd G_UNUSED, const unsigned char *data G_UNUSED,
+                            const COLUMN_MAPPING *cmap, int nbytes G_UNUSED,
                             void *cell, int n)
 {
     CELL *c = cell;
@@ -299,8 +299,8 @@ static void cell_values_int(int fd UNUSED, const unsigned char *data UNUSED,
     }
 }
 
-static void cell_values_float(int fd, const unsigned char *data UNUSED,
-                              const COLUMN_MAPPING *cmap, int nbytes UNUSED,
+static void cell_values_float(int fd, const unsigned char *data G_UNUSED,
+                              const COLUMN_MAPPING *cmap, int nbytes G_UNUSED,
                               void *cell, int n)
 {
     struct fileinfo *fcb = &R__.fileinfo[fd];
@@ -318,8 +318,8 @@ static void cell_values_float(int fd, const unsigned char *data UNUSED,
     }
 }
 
-static void cell_values_double(int fd, const unsigned char *data UNUSED,
-                               const COLUMN_MAPPING *cmap, int nbytes UNUSED,
+static void cell_values_double(int fd, const unsigned char *data G_UNUSED,
+                               const COLUMN_MAPPING *cmap, int nbytes G_UNUSED,
                                void *cell, int n)
 {
     struct fileinfo *fcb = &R__.fileinfo[fd];
@@ -389,8 +389,8 @@ static void gdal_values_int(int fd, const unsigned char *data,
     }
 }
 
-static void gdal_values_float(int fd UNUSED, const unsigned char *data,
-                              const COLUMN_MAPPING *cmap, int nbytes UNUSED,
+static void gdal_values_float(int fd G_UNUSED, const unsigned char *data,
+                              const COLUMN_MAPPING *cmap, int nbytes G_UNUSED,
                               void *cell, int n)
 {
     COLUMN_MAPPING cmapold = 0;
@@ -415,8 +415,8 @@ static void gdal_values_float(int fd UNUSED, const unsigned char *data,
     }
 }
 
-static void gdal_values_double(int fd UNUSED, const unsigned char *data,
-                               const COLUMN_MAPPING *cmap, int nbytes UNUSED,
+static void gdal_values_double(int fd G_UNUSED, const unsigned char *data,
+                               const COLUMN_MAPPING *cmap, int nbytes G_UNUSED,
                                void *cell, int n)
 {
     COLUMN_MAPPING cmapold = 0;

--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -66,7 +66,7 @@ void Rast__init(void)
     G_initialize_done(&initialized);
 }
 
-void Rast__error_handler(void *p UNUSED)
+void Rast__error_handler(void *p G_UNUSED)
 {
     Rast__unopen_all();
 }

--- a/lib/raster3d/cache1.c
+++ b/lib/raster3d/cache1.c
@@ -52,8 +52,8 @@ void Rast3d_cache_reset(RASTER3D_cache *c)
 
 /*---------------------------------------------------------------------------*/
 
-static int cache_dummy_fun(int tileIndex UNUSED, const void *tileBuf UNUSED,
-                           void *map UNUSED)
+static int cache_dummy_fun(int tileIndex G_UNUSED, const void *tileBuf G_UNUSED,
+                           void *map G_UNUSED)
 {
     return 1;
 }
@@ -600,7 +600,8 @@ static void cache_test_print(RASTER3D_cache *c)
 
 /*---------------------------------------------------------------------------*/
 
-static int cache_test_flush_fun(int name, const void *eltPtr, void *data UNUSED)
+static int cache_test_flush_fun(int name, const void *eltPtr,
+                                void *data G_UNUSED)
 {
     printf("flushing name %d value %d\n", name, ((const int *)eltPtr)[17]);
     return 0;

--- a/lib/raster3d/error.c
+++ b/lib/raster3d/error.c
@@ -16,7 +16,7 @@
  *  \param msg
  *  \return void
  */
-void Rast3d_skip_error(const char *msg UNUSED)
+void Rast3d_skip_error(const char *msg G_UNUSED)
 {
 }
 

--- a/lib/raster3d/range.c
+++ b/lib/raster3d/range.c
@@ -14,7 +14,8 @@
 void Rast3d_range_update_from_tile(RASTER3D_Map *map, const void *tile,
                                    int rows, int cols, int depths,
                                    int xRedundant, int yRedundant,
-                                   int zRedundant UNUSED, int nofNum, int type)
+                                   int zRedundant G_UNUSED, int nofNum,
+                                   int type)
 {
     int y, z, cellType;
     struct FPRange *range;

--- a/lib/raster3d/tilewrite.c
+++ b/lib/raster3d/tilewrite.c
@@ -15,7 +15,7 @@
 
 static int Rast3d_tile2xdrTile(RASTER3D_Map *map, const void *tile, int rows,
                                int cols, int depths, int xRedundant,
-                               int yRedundant, int zRedundant UNUSED,
+                               int yRedundant, int zRedundant G_UNUSED,
                                int nofNum, int type)
 {
     int y, z;

--- a/lib/rst/interp_float/interp2d.c
+++ b/lib/rst/interp_float/interp2d.c
@@ -66,7 +66,7 @@ int IL_grid_calc_2d(
     double *gmin, double *gmax,     /*!< min and max interp. slope val. */
     double *c1min, double *c1max,   /*!< min and max interp. curv. val. */
     double *c2min, double *c2max,   /*!< min and max interp. curv. val. */
-    double *ertot UNUSED,           /*!< total interpolating func. error */
+    double *ertot G_UNUSED,         /*!< total interpolating func. error */
     double *b,                      /*!< solutions of linear equations */
     off_t offset1,                  /*!< offset for temp file writing */
     double dnorm)

--- a/lib/rst/interp_float/output2d.c
+++ b/lib/rst/interp_float/output2d.c
@@ -59,8 +59,8 @@ int IL_output_2d(struct interp_params *params,
                  double zmin, double zmax, /*!< min,max input z-values */
                  double zminac, double zmaxac, double c1min,
                  double c1max, /*!< min,max interpolated values */
-                 double c2min, double c2max, double gmin UNUSED,
-                 double gmax UNUSED,
+                 double c2min, double c2max, double gmin G_UNUSED,
+                 double gmax G_UNUSED,
                  double ertot, /*!< total interpolating func. error */
                  char *input,  /*!< input file name */
                  double dnorm, /*!< normalization factor */

--- a/lib/rst/interp_float/resout2d.c
+++ b/lib/rst/interp_float/resout2d.c
@@ -46,8 +46,9 @@ int IL_resample_output_2d(
     struct interp_params *params, double zmin,
     double zmax,                  /* min,max input z-values */
     double zminac, double zmaxac, /* min,max interpolated values */
-    double c1min, double c1max, double c2min, double c2max, double gmin UNUSED,
-    double gmax UNUSED, double ertot,       /* total interplating func. error */
+    double c1min, double c1max, double c2min, double c2max,
+    double gmin G_UNUSED, double gmax G_UNUSED,
+    double ertot,                           /* total interplating func. error */
     char *input,                            /* input file name */
     double *dnorm, struct Cell_head *outhd, /* Region with desired resolution */
     struct Cell_head *winhd,                /* Current region */

--- a/lib/stats/c_ave.c
+++ b/lib/stats/c_ave.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_ave(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_ave(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL sum;
     int count;
@@ -24,7 +24,8 @@ void c_ave(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
         *result = sum / count;
 }
 
-void w_ave(DCELL *result, DCELL (*values)[2], int n, const void *closure UNUSED)
+void w_ave(DCELL *result, DCELL (*values)[2], int n,
+           const void *closure G_UNUSED)
 {
     DCELL sum;
     DCELL count;

--- a/lib/stats/c_count.c
+++ b/lib/stats/c_count.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_count(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_count(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     int count;
     int i;
@@ -16,7 +16,7 @@ void c_count(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
 }
 
 void w_count(DCELL *result, DCELL (*values)[2], int n,
-             const void *closure UNUSED)
+             const void *closure G_UNUSED)
 {
     DCELL count;
     int i;

--- a/lib/stats/c_divr.c
+++ b/lib/stats/c_divr.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/stats.h>
 
-void c_divr(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_divr(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     int count;
     DCELL prev;

--- a/lib/stats/c_intr.c
+++ b/lib/stats/c_intr.c
@@ -2,7 +2,7 @@
 #include <grass/raster.h>
 #include <grass/stats.h>
 
-void c_intr(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_intr(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL center;
     int count;

--- a/lib/stats/c_kurt.c
+++ b/lib/stats/c_kurt.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_kurt(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_kurt(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq, sumqt, var;
     int count;
@@ -45,7 +45,7 @@ void c_kurt(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
 }
 
 void w_kurt(DCELL *result, DCELL (*values)[2], int n,
-            const void *closure UNUSED)
+            const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq, sumqt, var;
     DCELL count;

--- a/lib/stats/c_max.c
+++ b/lib/stats/c_max.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_max(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_max(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL max;
     int i;
@@ -22,7 +22,8 @@ void c_max(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
         *result = max;
 }
 
-void w_max(DCELL *result, DCELL (*values)[2], int n, const void *closure UNUSED)
+void w_max(DCELL *result, DCELL (*values)[2], int n,
+           const void *closure G_UNUSED)
 {
     DCELL max;
     int i;

--- a/lib/stats/c_maxx.c
+++ b/lib/stats/c_maxx.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_maxx(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_maxx(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL max, maxx;
     int i;

--- a/lib/stats/c_median.c
+++ b/lib/stats/c_median.c
@@ -2,7 +2,7 @@
 #include <grass/raster.h>
 #include <grass/stats.h>
 
-void c_median(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_median(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     n = sort_cell(values, n);
 
@@ -13,7 +13,7 @@ void c_median(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
 }
 
 void w_median(DCELL *result, DCELL (*values)[2], int n,
-              const void *closure UNUSED)
+              const void *closure G_UNUSED)
 {
     DCELL total;
     int i;

--- a/lib/stats/c_min.c
+++ b/lib/stats/c_min.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_min(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_min(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL min;
     int i;
@@ -22,7 +22,8 @@ void c_min(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
         *result = min;
 }
 
-void w_min(DCELL *result, DCELL (*values)[2], int n, const void *closure UNUSED)
+void w_min(DCELL *result, DCELL (*values)[2], int n,
+           const void *closure G_UNUSED)
 {
     DCELL min;
     int i;

--- a/lib/stats/c_minx.c
+++ b/lib/stats/c_minx.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_minx(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_minx(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL min, minx;
     int i;

--- a/lib/stats/c_mode.c
+++ b/lib/stats/c_mode.c
@@ -2,7 +2,7 @@
 #include <grass/raster.h>
 #include <grass/stats.h>
 
-void c_mode(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_mode(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL mode;
     int max;
@@ -36,7 +36,7 @@ void c_mode(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
 }
 
 void w_mode(DCELL *result, DCELL (*values)[2], int n,
-            const void *closure UNUSED)
+            const void *closure G_UNUSED)
 {
     DCELL mode;
     DCELL max;

--- a/lib/stats/c_percentile.c
+++ b/lib/stats/c_percentile.c
@@ -26,21 +26,21 @@ void c_quant(DCELL *result, DCELL *values, int n, const void *closure)
         (i0 == i1) ? values[i0] : values[i0] * (i1 - k) + values[i1] * (k - i0);
 }
 
-void c_quart1(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_quart1(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     static const double q = 0.25;
 
     c_quant(result, values, n, &q);
 }
 
-void c_quart3(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_quart3(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     static const double q = 0.75;
 
     c_quant(result, values, n, &q);
 }
 
-void c_perc90(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_perc90(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     static const double q = 0.90;
 
@@ -76,7 +76,7 @@ void w_quant(DCELL *result, DCELL (*values)[2], int n, const void *closure)
 }
 
 void w_quart1(DCELL *result, DCELL (*values)[2], int n,
-              const void *closure UNUSED)
+              const void *closure G_UNUSED)
 {
     static const double q = 0.25;
 
@@ -84,7 +84,7 @@ void w_quart1(DCELL *result, DCELL (*values)[2], int n,
 }
 
 void w_quart3(DCELL *result, DCELL (*values)[2], int n,
-              const void *closure UNUSED)
+              const void *closure G_UNUSED)
 {
     static const double q = 0.75;
 
@@ -92,7 +92,7 @@ void w_quart3(DCELL *result, DCELL (*values)[2], int n,
 }
 
 void w_perc90(DCELL *result, DCELL (*values)[2], int n,
-              const void *closure UNUSED)
+              const void *closure G_UNUSED)
 {
     static const double q = 0.90;
 

--- a/lib/stats/c_range.c
+++ b/lib/stats/c_range.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_range(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_range(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL min, max;
     int i;

--- a/lib/stats/c_reg.c
+++ b/lib/stats/c_reg.c
@@ -85,22 +85,22 @@ static void regression(DCELL *result, DCELL *values, int n, int which)
         Rast_set_d_null_value(result, 1);
 }
 
-void c_reg_m(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_reg_m(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     regression(result, values, n, REGRESSION_SLOPE);
 }
 
-void c_reg_c(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_reg_c(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     regression(result, values, n, REGRESSION_OFFSET);
 }
 
-void c_reg_r2(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_reg_r2(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     regression(result, values, n, REGRESSION_COEFF_DET);
 }
 
-void c_reg_t(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_reg_t(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     regression(result, values, n, REGRESSION_T);
 }
@@ -180,25 +180,25 @@ static void regression_w(DCELL *result, DCELL (*values)[2], int n, int which)
 }
 
 void w_reg_m(DCELL *result, DCELL (*values)[2], int n,
-             const void *closure UNUSED)
+             const void *closure G_UNUSED)
 {
     regression_w(result, values, n, REGRESSION_SLOPE);
 }
 
 void w_reg_c(DCELL *result, DCELL (*values)[2], int n,
-             const void *closure UNUSED)
+             const void *closure G_UNUSED)
 {
     regression_w(result, values, n, REGRESSION_OFFSET);
 }
 
 void w_reg_r2(DCELL *result, DCELL (*values)[2], int n,
-              const void *closure UNUSED)
+              const void *closure G_UNUSED)
 {
     regression_w(result, values, n, REGRESSION_COEFF_DET);
 }
 
 void w_reg_t(DCELL *result, DCELL (*values)[2], int n,
-             const void *closure UNUSED)
+             const void *closure G_UNUSED)
 {
     regression_w(result, values, n, REGRESSION_T);
 }

--- a/lib/stats/c_skew.c
+++ b/lib/stats/c_skew.c
@@ -3,7 +3,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_skew(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_skew(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq, sumcb, sdev;
     int count;
@@ -47,7 +47,7 @@ void c_skew(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
 }
 
 void w_skew(DCELL *result, DCELL (*values)[2], int n,
-            const void *closure UNUSED)
+            const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq, sumcb, sdev;
     DCELL count;

--- a/lib/stats/c_sum.c
+++ b/lib/stats/c_sum.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_sum(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_sum(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL sum;
     int count;
@@ -24,7 +24,8 @@ void c_sum(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
         *result = sum;
 }
 
-void w_sum(DCELL *result, DCELL (*values)[2], int n, const void *closure UNUSED)
+void w_sum(DCELL *result, DCELL (*values)[2], int n,
+           const void *closure G_UNUSED)
 {
     DCELL sum;
     DCELL count;

--- a/lib/stats/c_var.c
+++ b/lib/stats/c_var.c
@@ -1,7 +1,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 
-void c_var(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
+void c_var(DCELL *result, DCELL *values, int n, const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq;
     int count;
@@ -40,7 +40,8 @@ void c_var(DCELL *result, DCELL *values, int n, const void *closure UNUSED)
     *result = sumsq / count;
 }
 
-void w_var(DCELL *result, DCELL (*values)[2], int n, const void *closure UNUSED)
+void w_var(DCELL *result, DCELL (*values)[2], int n,
+           const void *closure G_UNUSED)
 {
     DCELL sum, ave, sumsq;
     DCELL count;

--- a/lib/vector/Vlib/break_polygons.c
+++ b/lib/vector/Vlib/break_polygons.c
@@ -71,7 +71,8 @@ typedef struct {
 static int fpoint;
 
 /* Function called from RTreeSearch for point found */
-static int srch(int id, const struct RTree_Rect *rect UNUSED, void *arg UNUSED)
+static int srch(int id, const struct RTree_Rect *rect G_UNUSED,
+                void *arg G_UNUSED)
 {
     fpoint = id;
 

--- a/lib/vector/Vlib/build.c
+++ b/lib/vector/Vlib/build.c
@@ -32,7 +32,7 @@
 #define SEP "-----------------------------------\n"
 
 #if !defined HAVE_POSTGRES
-static int format(struct Map_info *Map UNUSED, int build UNUSED)
+static int format(struct Map_info *Map G_UNUSED, int build G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/build_pg.c
+++ b/lib/vector/Vlib/build_pg.c
@@ -41,7 +41,7 @@ static void build_stmt_id(const void *, int, int, const struct Plus_head *,
 static int create_simple_feature_from_topo(struct Map_info *);
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!

--- a/lib/vector/Vlib/close.c
+++ b/lib/vector/Vlib/close.c
@@ -27,13 +27,13 @@
 
 #include "local_proto.h"
 
-static int clo_dummy(struct Map_info *map UNUSED)
+static int clo_dummy(struct Map_info *map G_UNUSED)
 {
     return -1;
 }
 
 #if !defined HAVE_POSTGRES
-static int format(struct Map_info *map UNUSED)
+static int format(struct Map_info *map G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/close_pg.c
+++ b/lib/vector/Vlib/close_pg.c
@@ -25,7 +25,7 @@
 #include "pg_local_proto.h"
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!

--- a/lib/vector/Vlib/copy.c
+++ b/lib/vector/Vlib/copy.c
@@ -37,7 +37,7 @@
 #include "pg_local_proto.h"
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 static int copy_lines_1(struct Map_info *, int, struct Map_info *);

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -35,7 +35,7 @@
 #ifdef HAVE_POSTGRES
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!

--- a/lib/vector/Vlib/graph.c
+++ b/lib/vector/Vlib/graph.c
@@ -25,7 +25,7 @@ static int
     From_node; /* from node set in SP and used by clipper for first arc */
 
 static int clipper(dglGraph_s *pgraph, dglSPClipInput_s *pargIn,
-                   dglSPClipOutput_s *pargOut, void *pvarg UNUSED)
+                   dglSPClipOutput_s *pargOut, void *pvarg G_UNUSED)
 { /* caller's pointer */
     dglInt32_t cost;
     dglInt32_t from;

--- a/lib/vector/Vlib/handler.c
+++ b/lib/vector/Vlib/handler.c
@@ -23,7 +23,7 @@ struct handler_data_io {
 
 static struct handler_data_io *handler_io;
 
-static void error_handler_io(void *p UNUSED)
+static void error_handler_io(void *p G_UNUSED)
 {
     char *name;
     struct Map_info *In, *Out;

--- a/lib/vector/Vlib/header.c
+++ b/lib/vector/Vlib/header.c
@@ -485,7 +485,7 @@ int Vect_set_zone(struct Map_info *Map, int zone)
 
    \return projection zone
  */
-int Vect_get_zone(struct Map_info *Map UNUSED)
+int Vect_get_zone(struct Map_info *Map G_UNUSED)
 {
     /* return Map->head.plani_zone; */
 

--- a/lib/vector/Vlib/intersect.c
+++ b/lib/vector/Vlib/intersect.c
@@ -601,7 +601,7 @@ static int ident(double x1, double y1, double x2, double y2, double thresh)
 static struct line_pnts *APnts, *BPnts;
 
 /* break segments (called by rtree search) */
-static int cross_seg(int id, const struct RTree_Rect *rect UNUSED, void *arg)
+static int cross_seg(int id, const struct RTree_Rect *rect G_UNUSED, void *arg)
 {
     double x1, y1, z1, x2, y2, z2;
     int i, j, ret;
@@ -663,7 +663,7 @@ int Vect_line_intersection(struct line_pnts *APoints, struct line_pnts *BPoints,
                            struct bound_box *ABox, struct bound_box *BBox,
                            struct line_pnts ***ALines,
                            struct line_pnts ***BLines, int *nalines,
-                           int *nblines, int with_z UNUSED)
+                           int *nblines, int with_z G_UNUSED)
 {
     int i, j, k, l, last_seg, seg, last;
     int n_alive_cross;
@@ -1234,7 +1234,7 @@ static int cross_found; /* set by find_cross() */
 static int report_all;  /* should all crossings be reported or just first one */
 
 /* break segments (called by rtree search) */
-static int find_cross(int id, const struct RTree_Rect *rect UNUSED, void *arg)
+static int find_cross(int id, const struct RTree_Rect *rect G_UNUSED, void *arg)
 {
     double x1, y1, z1, x2, y2, z2;
     int i, j, ret;

--- a/lib/vector/Vlib/net_analyze.c
+++ b/lib/vector/Vlib/net_analyze.c
@@ -22,7 +22,7 @@ static int
     From_node; /* from node set in SP and used by clipper for first arc */
 
 static int clipper(dglGraph_s *pgraph, dglSPClipInput_s *pargIn,
-                   dglSPClipOutput_s *pargOut, void *pvarg UNUSED)
+                   dglSPClipOutput_s *pargOut, void *pvarg G_UNUSED)
 { /* caller's pointer */
     dglInt32_t cost;
     dglInt32_t from;

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -48,7 +48,7 @@
 int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                              int nfield, int tfield, int tucfield,
                              const char *afcol, const char *abcol,
-                             const char *ncol, int geo, int algorithm UNUSED)
+                             const char *ncol, int geo, int algorithm G_UNUSED)
 {
     /* TODO very long function, split into smaller ones */
     int i, j, from, to, line, nlines, nnodes, ret, type, cat, skipped, cfound;

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -44,26 +44,26 @@
  */
 #define MAX_OPEN_LEVEL 2
 
-static int open_old_dummy(struct Map_info *Map UNUSED, int update UNUSED)
+static int open_old_dummy(struct Map_info *Map G_UNUSED, int update G_UNUSED)
 {
     return 0;
 }
 
-static int open_new_dummy(struct Map_info *Map UNUSED, const char *name UNUSED,
-                          int with_z UNUSED)
+static int open_new_dummy(struct Map_info *Map G_UNUSED,
+                          const char *name G_UNUSED, int with_z G_UNUSED)
 {
     return 0;
 }
 
 #if !defined HAVE_POSTGRES
-static int format_old(struct Map_info *Map UNUSED, int update UNUSED)
+static int format_old(struct Map_info *Map G_UNUSED, int update G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;
 }
 
-static int format_new(struct Map_info *Map UNUSED, const char *name UNUSED,
-                      int with_z UNUSED)
+static int format_new(struct Map_info *Map G_UNUSED, const char *name G_UNUSED,
+                      int with_z G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/open_pg.c
+++ b/lib/vector/Vlib/open_pg.c
@@ -57,7 +57,7 @@ static int remap_line(const struct Plus_head *, off_t, int);
 
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!
@@ -1759,7 +1759,7 @@ int Vect__load_map_lines_pg(struct Map_info *Map)
 
    Print out NOTICE message only on verbose level
  */
-void notice_processor(void *arg UNUSED, const char *message)
+void notice_processor(void *arg G_UNUSED, const char *message)
 {
     if (G_verbose() > G_verbose_std()) {
         fprintf(stderr, "%s", message);

--- a/lib/vector/Vlib/overlay.c
+++ b/lib/vector/Vlib/overlay.c
@@ -99,10 +99,10 @@ int Vect_overlay(struct Map_info *AMap, int atype, struct ilist *AList,
    \return 0 on error
  */
 int Vect_overlay_and(struct Map_info *AMap, int atype,
-                     struct ilist *AList UNUSED, struct ilist *AAList UNUSED,
-                     struct Map_info *BMap, int btype,
-                     struct ilist *BList UNUSED, struct ilist *BAList UNUSED,
-                     struct Map_info *OMap)
+                     struct ilist *AList G_UNUSED,
+                     struct ilist *AAList G_UNUSED, struct Map_info *BMap,
+                     int btype, struct ilist *BList G_UNUSED,
+                     struct ilist *BAList G_UNUSED, struct Map_info *OMap)
 {
     int i, j, k, line, altype, bltype, oltype, area, centr;
     struct line_pnts *Points;

--- a/lib/vector/Vlib/read.c
+++ b/lib/vector/Vlib/read.c
@@ -19,24 +19,26 @@
 #include <grass/vector.h>
 #include <grass/glocale.h>
 
-static int read_dummy(struct Map_info *Map UNUSED,
-                      struct line_pnts *line_p UNUSED,
-                      struct line_cats *line_c UNUSED)
+static int read_dummy(struct Map_info *Map G_UNUSED,
+                      struct line_pnts *line_p G_UNUSED,
+                      struct line_cats *line_c G_UNUSED)
 {
     G_warning("Vect_read_line() %s", _("for this format/level not supported"));
     return -1;
 }
 
 #if !defined HAVE_POSTGRES
-static int format(struct Map_info *Map UNUSED, struct line_pnts *line_p UNUSED,
-                  struct line_cats *line_c UNUSED)
+static int format(struct Map_info *Map G_UNUSED,
+                  struct line_pnts *line_p G_UNUSED,
+                  struct line_cats *line_c G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;
 }
 
-static int format2(struct Map_info *Map UNUSED, struct line_pnts *line_p UNUSED,
-                   struct line_cats *line_c UNUSED, int line UNUSED)
+static int format2(struct Map_info *Map G_UNUSED,
+                   struct line_pnts *line_p G_UNUSED,
+                   struct line_cats *line_c G_UNUSED, int line G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/read_pg.c
+++ b/lib/vector/Vlib/read_pg.c
@@ -61,7 +61,7 @@ static void error_tuples(struct Format_info_pg *);
 
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!

--- a/lib/vector/Vlib/rewind.c
+++ b/lib/vector/Vlib/rewind.c
@@ -18,13 +18,13 @@
 #include <grass/vector.h>
 #include <grass/glocale.h>
 
-static int rew_dummy(struct Map_info *Map UNUSED)
+static int rew_dummy(struct Map_info *Map G_UNUSED)
 {
     return -1;
 }
 
 #if !defined HAVE_POSTGRES
-static int format(struct Map_info *Map UNUSED)
+static int format(struct Map_info *Map G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/rtree_search.c
+++ b/lib/vector/Vlib/rtree_search.c
@@ -19,7 +19,7 @@
 /* Function to add the ids of overlapping rectangles to an ilist
  * This function is a callback function used in RTreeSearch2()
  * */
-static int add_id_to_list(int id, const struct RTree_Rect *rect UNUSED,
+static int add_id_to_list(int id, const struct RTree_Rect *rect G_UNUSED,
                           void *list)
 {
     struct ilist *l = (struct ilist *)list;

--- a/lib/vector/Vlib/select.c
+++ b/lib/vector/Vlib/select.c
@@ -118,7 +118,7 @@ void Vect_spatial_index_del_item(struct spatial_index *si, int id,
 
 /************************* SELECT BY BOX *********************************/
 /* This function is called by  RTreeSearch() to add selected item to the list */
-static int _add_item(int id, const struct RTree_Rect *rect UNUSED,
+static int _add_item(int id, const struct RTree_Rect *rect G_UNUSED,
                      struct ilist *list)
 {
     G_ilist_add(list, id);

--- a/lib/vector/Vlib/simple_features.c
+++ b/lib/vector/Vlib/simple_features.c
@@ -242,8 +242,8 @@ int Vect_sfa_line_astext(const struct line_pnts *Points, int type, int with_z,
    \return -1 feature type not supported (GV_POINT, GV_CENTROID, ...)
    \note Implementation is pending, now always returns 0
  */
-int Vect_sfa_is_line_simple(const struct line_pnts *Points UNUSED,
-                            int type UNUSED, int with_z UNUSED)
+int Vect_sfa_is_line_simple(const struct line_pnts *Points G_UNUSED,
+                            int type G_UNUSED, int with_z G_UNUSED)
 {
     /* TODO:
        SF_FeatureType sftype;

--- a/lib/vector/Vlib/snap.c
+++ b/lib/vector/Vlib/snap.c
@@ -76,7 +76,7 @@ static int sort_new2(const void *pa, const void *pb)
 }
 
 /* This function is called by RTreeSearch() to find a vertex */
-static int find_item(int id, const struct RTree_Rect *rect UNUSED, void *list)
+static int find_item(int id, const struct RTree_Rect *rect G_UNUSED, void *list)
 {
     G_ilist_add((struct ilist *)list, id);
     return 0;
@@ -84,7 +84,7 @@ static int find_item(int id, const struct RTree_Rect *rect UNUSED, void *list)
 
 /* This function is called by RTreeSearch() to add selected node/line/area/isle
  * to the list */
-static int add_item(int id, const struct RTree_Rect *rect UNUSED, void *list)
+static int add_item(int id, const struct RTree_Rect *rect G_UNUSED, void *list)
 {
     G_ilist_add((struct ilist *)list, id);
     return 1;

--- a/lib/vector/Vlib/tin.c
+++ b/lib/vector/Vlib/tin.c
@@ -29,7 +29,7 @@
    \return -1 area has not 4 points or has island
  */
 int Vect_tin_get_z(struct Map_info *Map, double tx, double ty, double *tz,
-                   double *angle UNUSED, double *slope UNUSED)
+                   double *angle G_UNUSED, double *slope G_UNUSED)
 {
     int i, area, n_points;
     struct Plus_head *Plus;

--- a/lib/vector/Vlib/write.c
+++ b/lib/vector/Vlib/write.c
@@ -26,33 +26,33 @@
 #include <grass/glocale.h>
 #include <grass/vector.h>
 
-static off_t write_dummy(struct Map_info *Map UNUSED, int type UNUSED,
-                         const struct line_pnts *points UNUSED,
-                         const struct line_cats *cats UNUSED)
+static off_t write_dummy(struct Map_info *Map G_UNUSED, int type G_UNUSED,
+                         const struct line_pnts *points G_UNUSED,
+                         const struct line_cats *cats G_UNUSED)
 {
     G_warning("Vect_write_line() %s", _("for this format/level not supported"));
     return -1;
 }
 
-static off_t rewrite_dummy(struct Map_info *Map UNUSED, off_t line UNUSED,
-                           int type UNUSED,
-                           const struct line_pnts *points UNUSED,
-                           const struct line_cats *cats UNUSED)
+static off_t rewrite_dummy(struct Map_info *Map G_UNUSED, off_t line G_UNUSED,
+                           int type G_UNUSED,
+                           const struct line_pnts *points G_UNUSED,
+                           const struct line_cats *cats G_UNUSED)
 {
     G_warning("Vect_rewrite_line() %s",
               _("for this format/level not supported"));
     return -1;
 }
 
-static int delete_dummy(struct Map_info *Map UNUSED, off_t line UNUSED)
+static int delete_dummy(struct Map_info *Map G_UNUSED, off_t line G_UNUSED)
 {
     G_warning("Vect_delete_line() %s",
               _("for this format/level not supported"));
     return -1;
 }
 
-static int restore_dummy(struct Map_info *Map UNUSED, off_t offset UNUSED,
-                         off_t line UNUSED)
+static int restore_dummy(struct Map_info *Map G_UNUSED, off_t offset G_UNUSED,
+                         off_t line G_UNUSED)
 {
     G_warning("Vect_restore_line() %s",
               _("for this format/level not supported"));
@@ -60,30 +60,31 @@ static int restore_dummy(struct Map_info *Map UNUSED, off_t offset UNUSED,
 }
 
 #if !defined HAVE_POSTGRES
-static int format(struct Map_info *Map UNUSED, off_t line UNUSED)
+static int format(struct Map_info *Map G_UNUSED, off_t line G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;
 }
 
-static int format2(struct Map_info *Map UNUSED, off_t offset UNUSED,
-                   off_t line UNUSED)
+static int format2(struct Map_info *Map G_UNUSED, off_t offset G_UNUSED,
+                   off_t line G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;
 }
 
-static off_t format_l(struct Map_info *Map UNUSED, int type UNUSED,
-                      const struct line_pnts *points UNUSED,
-                      const struct line_cats *cats UNUSED)
+static off_t format_l(struct Map_info *Map G_UNUSED, int type G_UNUSED,
+                      const struct line_pnts *points G_UNUSED,
+                      const struct line_cats *cats G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;
 }
 
-static off_t format_l2(struct Map_info *Map UNUSED, off_t line UNUSED,
-                       int type UNUSED, const struct line_pnts *points UNUSED,
-                       const struct line_cats *cats UNUSED)
+static off_t format_l2(struct Map_info *Map G_UNUSED, off_t line G_UNUSED,
+                       int type G_UNUSED,
+                       const struct line_pnts *points G_UNUSED,
+                       const struct line_cats *cats G_UNUSED)
 {
     G_fatal_error(_("Requested format is not compiled in this version"));
     return 0;

--- a/lib/vector/Vlib/write_pg.c
+++ b/lib/vector/Vlib/write_pg.c
@@ -82,7 +82,7 @@ static struct line_pnts *Points;
 
 #define NOPG_UNUSED
 #else
-#define NOPG_UNUSED UNUSED
+#define NOPG_UNUSED G_UNUSED
 #endif
 
 /*!
@@ -228,7 +228,7 @@ off_t V1_rewrite_line_pg(struct Map_info *Map NOPG_UNUSED, off_t offset,
  */
 off_t V2_rewrite_line_pg(struct Map_info *Map NOPG_UNUSED, off_t line, int type,
                          const struct line_pnts *points NOPG_UNUSED,
-                         const struct line_cats *cats UNUSED)
+                         const struct line_cats *cats G_UNUSED)
 {
     G_debug(3, "V2_rewrite_line_pg(): line=%d type=%d", (int)line, type);
 #ifdef HAVE_POSTGRES

--- a/lib/vector/dglib/edgemgmt-template.c
+++ b/lib/vector/dglib/edgemgmt-template.c
@@ -279,7 +279,7 @@ int DGL_ADD_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nHead, dglInt32_t nTail,
     return 0;
 }
 
-int DGL_DEL_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nEdge UNUSED)
+int DGL_DEL_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nEdge G_UNUSED)
 {
 #if defined(_DGL_V1)
     pgraph->iErrno = DGL_ERR_NotSupported;
@@ -335,7 +335,7 @@ int DGL_DEL_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nEdge UNUSED)
 #endif
 }
 
-dglInt32_t *DGL_GET_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nEdge UNUSED)
+dglInt32_t *DGL_GET_EDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nEdge G_UNUSED)
 {
 #if defined(_DGL_V1)
     pgraph->iErrno = DGL_ERR_NotSupported;

--- a/lib/vector/dglib/graph.c
+++ b/lib/vector/dglib/graph.c
@@ -40,7 +40,7 @@
 #endif
 #include "helpers.h"
 
-void dglResetStats(dglGraph_s *pgraph UNUSED)
+void dglResetStats(dglGraph_s *pgraph G_UNUSED)
 {
 #ifdef DGL_STATS
     pgraph->clkAddEdge = 0;
@@ -1046,7 +1046,7 @@ int dglMinimumSpanning(dglGraph_s *pgraphInput, dglGraph_s *pgraphOutput,
     return nRet;
 }
 
-void dglFreeSPReport(dglGraph_s *pgraph UNUSED, dglSPReport_s *pSPReport)
+void dglFreeSPReport(dglGraph_s *pgraph G_UNUSED, dglSPReport_s *pSPReport)
 {
     int iArc;
 
@@ -1450,7 +1450,7 @@ int dglEdgeset_T_Initialize(dglEdgesetTraverser_s *pT, dglGraph_s *pGraph,
     return -pGraph->iErrno;
 }
 
-void dglEdgeset_T_Release(dglEdgesetTraverser_s *pT UNUSED)
+void dglEdgeset_T_Release(dglEdgesetTraverser_s *pT G_UNUSED)
 {
 }
 
@@ -1507,7 +1507,7 @@ int dglIOContextInitialize(dglGraph_s *pG, dglIOContext_s *pIO)
     return 0;
 }
 
-void dglIOContextRelease(dglIOContext_s *pIO UNUSED)
+void dglIOContextRelease(dglIOContext_s *pIO G_UNUSED)
 {
 }
 

--- a/lib/vector/dglib/misc-template.c
+++ b/lib/vector/dglib/misc-template.c
@@ -26,8 +26,8 @@
  * Edge Traversing
  */
 int DGL_EDGE_T_INITIALIZE_FUNC(dglGraph_s *pGraph,
-                               dglEdgeTraverser_s *pT UNUSED,
-                               dglEdgePrioritizer_s *pEP UNUSED)
+                               dglEdgeTraverser_s *pT G_UNUSED,
+                               dglEdgePrioritizer_s *pEP G_UNUSED)
 {
 #if defined(_DGL_V1)
     pGraph->iErrno = DGL_ERR_NotSupported;
@@ -277,7 +277,7 @@ int DGL_EDGESET_T_INITIALIZE_FUNC(dglGraph_s *pGraph, dglEdgesetTraverser_s *pT,
     return 0;
 }
 
-void DGL_EDGESET_T_RELEASE_FUNC(dglEdgesetTraverser_s *pT UNUSED)
+void DGL_EDGESET_T_RELEASE_FUNC(dglEdgesetTraverser_s *pT G_UNUSED)
 {
 }
 

--- a/lib/vector/dglib/nodemgmt-template.c
+++ b/lib/vector/dglib/nodemgmt-template.c
@@ -23,7 +23,7 @@
 #include <grass/gis.h>
 
 int DGL_ADD_NODE_FUNC(dglGraph_s *pgraph, dglInt32_t nId,
-                      void *pvNodeAttr UNUSED, dglInt32_t nFlags UNUSED)
+                      void *pvNodeAttr G_UNUSED, dglInt32_t nFlags G_UNUSED)
 {
     DGL_T_NODEITEM_TYPE *pNodeItem;
     dglInt32_t *pnode;
@@ -191,7 +191,7 @@ int DGL_DEL_NODE_INEDGE_FUNC(dglGraph_s *pgraph, dglInt32_t nNode,
 }
 #endif
 
-int DGL_DEL_NODE_FUNC(dglGraph_s *pgraph, dglInt32_t nNodeId UNUSED)
+int DGL_DEL_NODE_FUNC(dglGraph_s *pgraph, dglInt32_t nNodeId G_UNUSED)
 {
 #if defined(_DGL_V1)
     pgraph->iErrno = DGL_ERR_NotSupported;
@@ -396,7 +396,7 @@ dglInt32_t *DGL_GET_NODE_OUTEDGESET_FUNC(dglGraph_s *pgraph, dglInt32_t *pnode)
 }
 
 dglInt32_t *DGL_GET_NODE_INEDGESET_FUNC(dglGraph_s *pgraph,
-                                        dglInt32_t *pnode UNUSED)
+                                        dglInt32_t *pnode G_UNUSED)
 {
 #if defined(_DGL_V1)
     pgraph->iErrno = DGL_ERR_NotSupported;

--- a/lib/vector/dglib/sp-template.c
+++ b/lib/vector/dglib/sp-template.c
@@ -42,7 +42,7 @@
 
 #include <grass/gis.h>
 
-int DGL_SP_CACHE_INITIALIZE_FUNC(dglGraph_s *pgraph UNUSED,
+int DGL_SP_CACHE_INITIALIZE_FUNC(dglGraph_s *pgraph G_UNUSED,
                                  dglSPCache_s *pCache, dglInt32_t nStart)
 {
     pCache->nStartNode = nStart;
@@ -58,7 +58,8 @@ int DGL_SP_CACHE_INITIALIZE_FUNC(dglGraph_s *pgraph UNUSED,
     return 0;
 }
 
-void DGL_SP_CACHE_RELEASE_FUNC(dglGraph_s *pgraph UNUSED, dglSPCache_s *pCache)
+void DGL_SP_CACHE_RELEASE_FUNC(dglGraph_s *pgraph G_UNUSED,
+                               dglSPCache_s *pCache)
 {
     if (pCache->pvVisited)
         avl_destroy(pCache->pvVisited, dglTreeTouchI32Cancel);

--- a/lib/vector/dglib/span-template.c
+++ b/lib/vector/dglib/span-template.c
@@ -229,8 +229,8 @@ dfs_error:
  */
 int DGL_SPAN_MINIMUM_SPANNING_FUNC(dglGraph_s *pgraphIn, dglGraph_s *pgraphOut,
                                    dglInt32_t nVertex,
-                                   dglSpanClip_fn fnClip UNUSED,
-                                   void *pvClipArg UNUSED)
+                                   dglSpanClip_fn fnClip G_UNUSED,
+                                   void *pvClipArg G_UNUSED)
 {
     dglInt32_t *pHead, *pTail, *pEdgeset, *pEdge;
     dglHeap_s FrontEdgeHeap;

--- a/lib/vector/dglib/tree.c
+++ b/lib/vector/dglib/tree.c
@@ -42,7 +42,7 @@ dglTreeNode_s *dglTreeNodeAlloc(void)
     return pNode;
 }
 
-void dglTreeNodeCancel(void *pvNode, void *pvParam UNUSED)
+void dglTreeNodeCancel(void *pvNode, void *pvParam G_UNUSED)
 {
     if (((dglTreeNode_s *)pvNode)->pv)
         free(((dglTreeNode_s *)pvNode)->pv);
@@ -52,7 +52,7 @@ void dglTreeNodeCancel(void *pvNode, void *pvParam UNUSED)
 }
 
 int dglTreeNodeCompare(const void *pvNodeA, const void *pvNodeB,
-                       void *pvParam UNUSED)
+                       void *pvParam G_UNUSED)
 {
     if (((dglTreeNode_s *)pvNodeA)->nKey < ((dglTreeNode_s *)pvNodeB)->nKey)
         return -1;
@@ -94,7 +94,7 @@ dglTreeNode2_s *dglTreeNode2Alloc(void)
     return pNode2;
 }
 
-void dglTreeNode2Cancel(void *pvNode2, void *pvParam UNUSED)
+void dglTreeNode2Cancel(void *pvNode2, void *pvParam G_UNUSED)
 {
     if (((dglTreeNode2_s *)pvNode2)->pv)
         free(((dglTreeNode2_s *)pvNode2)->pv);
@@ -106,7 +106,7 @@ void dglTreeNode2Cancel(void *pvNode2, void *pvParam UNUSED)
 }
 
 int dglTreeNode2Compare(const void *pvNode2A, const void *pvNode2B,
-                        void *pvParam UNUSED)
+                        void *pvParam G_UNUSED)
 {
     if (((dglTreeNode2_s *)pvNode2A)->nKey < ((dglTreeNode2_s *)pvNode2B)->nKey)
         return -1;
@@ -149,7 +149,7 @@ dglTreeEdge_s *dglTreeEdgeAlloc(void)
     return pEdge;
 }
 
-void dglTreeEdgeCancel(void *pvEdge, void *pvParam UNUSED)
+void dglTreeEdgeCancel(void *pvEdge, void *pvParam G_UNUSED)
 {
     if (((dglTreeEdge_s *)pvEdge)->pv)
         free(((dglTreeEdge_s *)pvEdge)->pv);
@@ -157,7 +157,7 @@ void dglTreeEdgeCancel(void *pvEdge, void *pvParam UNUSED)
 }
 
 int dglTreeEdgeCompare(const void *pvEdgeA, const void *pvEdgeB,
-                       void *pvParam UNUSED)
+                       void *pvParam G_UNUSED)
 {
     if (((dglTreeEdge_s *)pvEdgeA)->nKey < ((dglTreeEdge_s *)pvEdgeB)->nKey)
         return -1;
@@ -199,13 +199,13 @@ dglTreeTouchI32_s *dglTreeTouchI32Alloc(void)
     return pTouchI32;
 }
 
-void dglTreeTouchI32Cancel(void *pvTouchI32, void *pvParam UNUSED)
+void dglTreeTouchI32Cancel(void *pvTouchI32, void *pvParam G_UNUSED)
 {
     free(pvTouchI32);
 }
 
 int dglTreeTouchI32Compare(const void *pvTouchI32A, const void *pvTouchI32B,
-                           void *pvParam UNUSED)
+                           void *pvParam G_UNUSED)
 {
     if (((dglTreeTouchI32_s *)pvTouchI32A)->nKey <
         ((dglTreeTouchI32_s *)pvTouchI32B)->nKey)
@@ -249,13 +249,13 @@ dglTreePredist_s *dglTreePredistAlloc(void)
     return pPredist;
 }
 
-void dglTreePredistCancel(void *pvPredist, void *pvParam UNUSED)
+void dglTreePredistCancel(void *pvPredist, void *pvParam G_UNUSED)
 {
     free(pvPredist);
 }
 
 int dglTreePredistCompare(const void *pvPredistA, const void *pvPredistB,
-                          void *pvParam UNUSED)
+                          void *pvParam G_UNUSED)
 {
     if (((dglTreePredist_s *)pvPredistA)->nKey <
         ((dglTreePredist_s *)pvPredistB)->nKey)
@@ -299,13 +299,13 @@ dglTreeNodePri32_s *dglTreeNodePri32Alloc(void)
     return pNodePri32;
 }
 
-void dglTreeNodePri32Cancel(void *pvNodePri32, void *pvParam UNUSED)
+void dglTreeNodePri32Cancel(void *pvNodePri32, void *pvParam G_UNUSED)
 {
     free(pvNodePri32);
 }
 
 int dglTreeNodePri32Compare(const void *pvNodePri32A, const void *pvNodePri32B,
-                            void *pvParam UNUSED)
+                            void *pvParam G_UNUSED)
 {
     if (((dglTreeNodePri32_s *)pvNodePri32A)->nKey <
         ((dglTreeNodePri32_s *)pvNodePri32B)->nKey)
@@ -349,7 +349,7 @@ dglTreeEdgePri32_s *dglTreeEdgePri32Alloc(void)
     return pEdgePri32;
 }
 
-void dglTreeEdgePri32Cancel(void *pvEdgePri32, void *pvParam UNUSED)
+void dglTreeEdgePri32Cancel(void *pvEdgePri32, void *pvParam G_UNUSED)
 {
     if (((dglTreeEdgePri32_s *)pvEdgePri32)->pnData) {
         free(((dglTreeEdgePri32_s *)pvEdgePri32)->pnData);
@@ -358,7 +358,7 @@ void dglTreeEdgePri32Cancel(void *pvEdgePri32, void *pvParam UNUSED)
 }
 
 int dglTreeEdgePri32Compare(const void *pvEdgePri32A, const void *pvEdgePri32B,
-                            void *pvParam UNUSED)
+                            void *pvParam G_UNUSED)
 {
     if (((dglTreeEdgePri32_s *)pvEdgePri32A)->nKey <
         ((dglTreeEdgePri32_s *)pvEdgePri32B)->nKey)
@@ -389,13 +389,13 @@ dglTreeEdgePri32_s *dglTreeEdgePri32Add(void *pavl, dglInt32_t nKey)
 /*
  * Our AVL allocator
  */
-static void *_tree_malloc(struct libavl_allocator *allocator UNUSED,
+static void *_tree_malloc(struct libavl_allocator *allocator G_UNUSED,
                           size_t libavl_size)
 {
     return malloc(libavl_size);
 }
 
-static void _tree_free(struct libavl_allocator *allocator UNUSED,
+static void _tree_free(struct libavl_allocator *allocator G_UNUSED,
                        void *libavl_block)
 {
     free(libavl_block);

--- a/lib/vector/diglib/frmt.c
+++ b/lib/vector/diglib/frmt.c
@@ -151,8 +151,9 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
  *  Returns: 0 OK
  *           -1 on error
  */
-int dig_write_frmt_ascii(FILE *dascii UNUSED, struct Format_info *finfo UNUSED,
-                         int format UNUSED)
+int dig_write_frmt_ascii(FILE *dascii G_UNUSED,
+                         struct Format_info *finfo G_UNUSED,
+                         int format G_UNUSED)
 {
     G_debug(3, "dig_write_frmt_ascii()");
 

--- a/lib/vector/diglib/spindex.c
+++ b/lib/vector/diglib/spindex.c
@@ -605,7 +605,7 @@ int dig_spidx_del_isle(struct Plus_head *Plus, int isle)
 
 /* This function is called by RTreeSearch() to add selected node/line/area/isle
  * to the list */
-static int _add_item(int id, const struct RTree_Rect *rect UNUSED,
+static int _add_item(int id, const struct RTree_Rect *rect G_UNUSED,
                      struct ilist *list)
 {
     G_ilist_add(list, id);
@@ -699,7 +699,7 @@ int dig_select_nodes(struct Plus_head *Plus, const struct bound_box *box,
 }
 
 /* This function is called by RTreeSearch() for nodes to find the node id */
-static int _add_node(int id, const struct RTree_Rect *rect UNUSED, int *node)
+static int _add_node(int id, const struct RTree_Rect *rect G_UNUSED, int *node)
 {
     *node = id;
     return 0;

--- a/lib/vector/neta/flow.c
+++ b/lib/vector/neta/flow.c
@@ -175,7 +175,7 @@ int NetA_flow(dglGraph_s *graph, struct ilist *source_list,
    \return -1 on failure
  */
 int NetA_min_cut(dglGraph_s *graph, struct ilist *source_list,
-                 struct ilist *sink_list UNUSED, int *flow, struct ilist *cut)
+                 struct ilist *sink_list G_UNUSED, int *flow, struct ilist *cut)
 {
     int nnodes, i;
     dglEdgesetTraverser_s et;

--- a/lib/vector/neta/timetables.c
+++ b/lib/vector/neta/timetables.c
@@ -351,7 +351,7 @@ static neta_heap_data *new_heap_data(int conns, int v)
    \param heap ?
  */
 void NetA_update_dijkstra(int old_conns, int new_conns, int to, int new_dst,
-                          int v, int route, int rows UNUSED, int update,
+                          int v, int route, int rows G_UNUSED, int update,
                           neta_timetable_result *result, dglHeap_s *heap)
 {
     if (result->dst[new_conns][to] == -1 ||

--- a/lib/vector/vedit/break.c
+++ b/lib/vector/vedit/break.c
@@ -225,7 +225,7 @@ int Vedit_connect_lines(struct Map_info *Map, struct ilist *List, double thresh)
 }
 
 int connect_lines(struct Map_info *Map, int first, int line_from, int line_to,
-                  double thresh, struct ilist *List UNUSED)
+                  double thresh, struct ilist *List G_UNUSED)
 {
     int line_new;
     int type_from, type_to;

--- a/lib/vector/vedit/extend.c
+++ b/lib/vector/vedit/extend.c
@@ -150,7 +150,7 @@ int Vedit_extend_lines(struct Map_info *Map, struct ilist *List, int nodes,
 }
 
 int extend_lines(struct Map_info *Map, int first, int line_from, int line_to,
-                 int parallel, double thresh, struct ilist *List UNUSED)
+                 int parallel, double thresh, struct ilist *List G_UNUSED)
 {
     /* TODO: If line_from extends to the i'th segment of line_to but the
      * line_from node is closest to the j'th segment of line_to, this function

--- a/lib/vector/vedit/select.c
+++ b/lib/vector/vedit/select.c
@@ -41,7 +41,7 @@ static int merge_lists(struct ilist *alist, struct ilist *blist);
 
    \return number of selected primitives
  */
-int Vedit_select_by_query(struct Map_info *Map, int type, int layer UNUSED,
+int Vedit_select_by_query(struct Map_info *Map, int type, int layer G_UNUSED,
                           double thresh, int query, struct ilist *List)
 {
     int num, line, i;

--- a/misc/m.nviz.image/volume.c
+++ b/misc/m.nviz.image/volume.c
@@ -76,7 +76,7 @@ int load_rasters3d(const struct GParams *params, nv_data *data)
 
    \return number of defined isosurfaces
  */
-int add_isosurfs(const struct GParams *params, nv_data *data UNUSED)
+int add_isosurfs(const struct GParams *params, nv_data *data G_UNUSED)
 {
     int i;
     float level;
@@ -247,7 +247,7 @@ int add_isosurfs(const struct GParams *params, nv_data *data UNUSED)
     return 1;
 }
 
-int add_slices(const struct GParams *params, nv_data *data UNUSED)
+int add_slices(const struct GParams *params, nv_data *data G_UNUSED)
 {
     int i;
     int num, nvols, *vol_list, id, nslices, axis;

--- a/misc/m.nviz.script/main.c
+++ b/misc/m.nviz.script/main.c
@@ -327,7 +327,7 @@ int main(int argc, char *argv[])
  * Calculate camera and eye coordinates
  **************************************/
 int do_profile(double e1, double e2, double n1, double n2,
-               const char *name UNUSED, int fd, int data_type)
+               const char *name G_UNUSED, int fd, int data_type)
 {
     float rows, cols, LEN;
     double Y, X, AZI;

--- a/ps/ps.map/scan_ref.c
+++ b/ps/ps.map/scan_ref.c
@@ -29,12 +29,12 @@ int scan_ref(char *buf, int *xref, int *yref)
         lowercase(word2);
         if (!(xmatch(word2, xref) || ymatch(word2, yref)))
             return 0;
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     case 1:
         lowercase(word1);
         if (xmatch(word1, xref) || ymatch(word1, yref))
             return 1;
-        FALLTHROUGH;
+        G_FALLTHROUGH;
     default:
         return 0;
     }

--- a/raster/r.buildvrt/link.c
+++ b/raster/r.buildvrt/link.c
@@ -82,7 +82,7 @@ void write_fp_quant(const char *output)
 
 void create_map(const struct input *inputs, int num_inputs, const char *output,
                 struct Cell_head *cellhd, int maptype, DCELL dmin, DCELL dmax,
-                int have_stats UNUSED, struct R_stats *ostats UNUSED,
+                int have_stats G_UNUSED, struct R_stats *ostats G_UNUSED,
                 const char *title)
 {
     struct History history;

--- a/raster/r.fill.dir/filldir.c
+++ b/raster/r.fill.dir/filldir.c
@@ -36,7 +36,7 @@ void check(CELL newdir, CELL *dir, void *center, void *edge, double cnst,
 }
 
 /* process one row, filling single-cell pits */
-int fill_row(int nl UNUSED, int ns, struct band3 *bnd)
+int fill_row(int nl G_UNUSED, int ns, struct band3 *bnd)
 {
     int j, offset, inc, rc;
     char *min;

--- a/raster/r.fill.dir/resolve.c
+++ b/raster/r.fill.dir/resolve.c
@@ -32,7 +32,7 @@ CELL select_dir(CELL i)
     return dir[i];
 }
 
-void flink(int i UNUSED, int j, int nl UNUSED, int ns UNUSED, CELL *p1,
+void flink(int i G_UNUSED, int j, int nl G_UNUSED, int ns G_UNUSED, CELL *p1,
            CELL *p2, CELL *p3, int *active, int *goagain)
 {
     CELL bitmask[8] = {1, 2, 4, 8, 16, 32, 64, 128};

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -233,8 +233,8 @@ void *get_input_row(unsigned long row_idx)
  * types of information to be collected.
  */
 
-void collect_values_unfiltered(double val1, double val2, double min UNUSED,
-                               double max UNUSED, stats_struct *stats)
+void collect_values_unfiltered(double val1, double val2, double min G_UNUSED,
+                               double max G_UNUSED, stats_struct *stats)
 {
     stats->values[stats->num_values] = val1;
     stats->certainty += val2;
@@ -250,7 +250,8 @@ void collect_values_filtered(double val1, double val2, double min, double max,
 }
 
 void collect_values_and_weights_unfiltered(double val1, double val2,
-                                           double min UNUSED, double max UNUSED,
+                                           double min G_UNUSED,
+                                           double max G_UNUSED,
                                            stats_struct *stats)
 {
     stats->values[stats->num_values] = val1;
@@ -268,8 +269,8 @@ void collect_values_and_weights_filtered(double val1, double val2, double min,
 }
 
 void collect_values_and_frequencies_unfiltered(double val1, double val2,
-                                               double min UNUSED,
-                                               double max UNUSED,
+                                               double min G_UNUSED,
+                                               double max G_UNUSED,
                                                stats_struct *stats)
 {
     unsigned long i;

--- a/raster/r.in.ascii/gethead.c
+++ b/raster/r.in.ascii/gethead.c
@@ -228,7 +228,7 @@ int gethead(FILE *fd, struct Cell_head *cellhd, RASTER_MAP_TYPE *d_type,
     return 1;
 }
 
-static int scan_int(const char *s, double *i, int proj UNUSED)
+static int scan_int(const char *s, double *i, int proj G_UNUSED)
 {
     char dummy[3];
     int *i_loc = (int *)i;

--- a/raster/r.li/r.li.cwed/cwed.c
+++ b/raster/r.li/r.li.cwed/cwed.c
@@ -709,7 +709,7 @@ free_exit:
 }
 
 int addCoppia(Coppie *cc, generic_cell ce1, generic_cell ce2, double pe,
-              long tc, long *siz UNUSED)
+              long tc, long *siz G_UNUSED)
 {
     generic_cell cs;
     long it = 0;

--- a/raster/r.li/r.li.daemon/daemon.c
+++ b/raster/r.li/r.li.daemon/daemon.c
@@ -710,7 +710,7 @@ int error_Output(int out, msg m)
     }
 }
 
-int raster_Output(int fd, int aid, struct g_area *g UNUSED, double res)
+int raster_Output(int fd, int aid, struct g_area *g G_UNUSED, double res)
 {
     double toPut = res;
     off_t offset = (off_t)aid * sizeof(double);

--- a/raster/r.li/r.li.dominance/dominance.c
+++ b/raster/r.li/r.li.dominance/dominance.c
@@ -65,7 +65,8 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int dominance(int fd, char **par UNUSED, struct area_entry *ad, double *result)
+int dominance(int fd, char **par G_UNUSED, struct area_entry *ad,
+              double *result)
 {
     int ris = RLI_OK;
     double indice = 0;

--- a/raster/r.li/r.li.mpa/mpa.c
+++ b/raster/r.li/r.li.mpa/mpa.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
                           raster->answer, output->answer);
 }
 
-int meanPixelAttribute(int fd, char **par UNUSED, struct area_entry *ad,
+int meanPixelAttribute(int fd, char **par G_UNUSED, struct area_entry *ad,
                        double *result)
 {
     int ris = 0;

--- a/raster/r.li/r.li.mps/mps.c
+++ b/raster/r.li/r.li.mps/mps.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int meanPatchSize(int fd, char **par UNUSED, struct area_entry *ad,
+int meanPatchSize(int fd, char **par G_UNUSED, struct area_entry *ad,
                   double *result)
 {
     int ris = RLI_OK;

--- a/raster/r.li/r.li.padcv/padcv.c
+++ b/raster/r.li/r.li.padcv/padcv.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                           raster->answer, output->answer);
 }
 
-int patchAreaDistributionCV(int fd, char **par UNUSED, struct area_entry *ad,
+int patchAreaDistributionCV(int fd, char **par G_UNUSED, struct area_entry *ad,
                             double *result)
 {
     double indice = 0;

--- a/raster/r.li/r.li.padrange/padrange.c
+++ b/raster/r.li/r.li.padrange/padrange.c
@@ -70,8 +70,8 @@ int main(int argc, char *argv[])
                           raster->answer, output->answer);
 }
 
-int patchAreaDistributionRANGE(int fd, char **par UNUSED, struct area_entry *ad,
-                               double *result)
+int patchAreaDistributionRANGE(int fd, char **par G_UNUSED,
+                               struct area_entry *ad, double *result)
 {
     double indice = 0;
     int ris = RLI_OK;

--- a/raster/r.li/r.li.padsd/padsd.c
+++ b/raster/r.li/r.li.padsd/padsd.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                           raster->answer, output->answer);
 }
 
-int patchAreaDistributionSD(int fd, char **par UNUSED, struct area_entry *ad,
+int patchAreaDistributionSD(int fd, char **par G_UNUSED, struct area_entry *ad,
                             double *result)
 {
     double indice = 0;

--- a/raster/r.li/r.li.patchdensity/main.c
+++ b/raster/r.li/r.li.patchdensity/main.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int patch_density(int fd, char **par UNUSED, struct area_entry *ad,
+int patch_density(int fd, char **par G_UNUSED, struct area_entry *ad,
                   double *result)
 {
     int ris = RLI_OK;

--- a/raster/r.li/r.li.patchnum/main.c
+++ b/raster/r.li/r.li.patchnum/main.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int patch_number(int fd, char **par UNUSED, struct area_entry *ad,
+int patch_number(int fd, char **par G_UNUSED, struct area_entry *ad,
                  double *result)
 {
     int ris = RLI_OK;

--- a/raster/r.li/r.li.pielou/pielou.c
+++ b/raster/r.li/r.li.pielou/pielou.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int pielou(int fd, char **par UNUSED, struct area_entry *ad, double *result)
+int pielou(int fd, char **par G_UNUSED, struct area_entry *ad, double *result)
 {
     int ris = RLI_OK;
     double indice = 0;

--- a/raster/r.li/r.li.richness/richness.c
+++ b/raster/r.li/r.li.richness/richness.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int richness(int fd, char **par UNUSED, struct area_entry *ad, double *result)
+int richness(int fd, char **par G_UNUSED, struct area_entry *ad, double *result)
 {
     int ris = RLI_OK;
     double indice = 0;

--- a/raster/r.li/r.li.shannon/shannon.c
+++ b/raster/r.li/r.li.shannon/shannon.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int shannon(int fd, char **par UNUSED, struct area_entry *ad, double *result)
+int shannon(int fd, char **par G_UNUSED, struct area_entry *ad, double *result)
 {
     int ris = RLI_OK;
     double indice = 0;

--- a/raster/r.li/r.li.shape/main.c
+++ b/raster/r.li/r.li.shape/main.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int shape_index(int fd, char **par UNUSED, struct area_entry *ad,
+int shape_index(int fd, char **par G_UNUSED, struct area_entry *ad,
                 double *result)
 {
     int ris = RLI_OK;

--- a/raster/r.li/r.li.simpson/simpson.c
+++ b/raster/r.li/r.li.simpson/simpson.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
                           output->answer);
 }
 
-int simpson(int fd, char **par UNUSED, struct area_entry *ad, double *result)
+int simpson(int fd, char **par G_UNUSED, struct area_entry *ad, double *result)
 {
     int ris = RLI_OK;
     double indice = 0;

--- a/raster/r.mapcalc/evaluate.c
+++ b/raster/r.mapcalc/evaluate.c
@@ -240,7 +240,7 @@ static void evaluate_constant(expression *e)
     }
 }
 
-static void evaluate_variable(expression *e UNUSED)
+static void evaluate_variable(expression *e G_UNUSED)
 {
     /* this is a no-op */
 }
@@ -357,7 +357,7 @@ static expr_list *exprs;
 
 /****************************************************************************/
 
-static void error_handler(void *p UNUSED)
+static void error_handler(void *p G_UNUSED)
 {
     expr_list *l;
 

--- a/raster/r.mapcalc/map.c
+++ b/raster/r.mapcalc/map.c
@@ -597,7 +597,7 @@ void setup_maps(void)
         setup_map(&maps[i]);
 }
 
-void get_map_row(int idx, int mod, int depth UNUSED, int row, int col,
+void get_map_row(int idx, int mod, int depth G_UNUSED, int row, int col,
                  void *buf, int res_type)
 {
     CELL *ibuf;

--- a/raster/r.mapcalc/map3.c
+++ b/raster/r.mapcalc/map3.c
@@ -323,7 +323,7 @@ static void translate_from_cats(map *m, CELL *cell, DCELL *xcell, int ncols)
     }
 }
 
-static void setup_map(map *m UNUSED)
+static void setup_map(map *m G_UNUSED)
 {
 }
 
@@ -428,7 +428,8 @@ int map_type(const char *name, int mod)
     }
 }
 
-int open_map(const char *name, int mod, int row, int col, int thread_num UNUSED)
+int open_map(const char *name, int mod, int row, int col,
+             int thread_num G_UNUSED)
 {
     int i;
     const char *mapset;
@@ -670,11 +671,11 @@ void copy_colors(const char *dst, int idx)
     Rast_free_colors(&colr);
 }
 
-void copy_history(const char *dst UNUSED, int idx UNUSED)
+void copy_history(const char *dst G_UNUSED, int idx G_UNUSED)
 {
 }
 
-void create_history(const char *dst UNUSED, expression *e UNUSED)
+void create_history(const char *dst G_UNUSED, expression *e G_UNUSED)
 {
 }
 

--- a/raster/r.mfilter/getrow.c
+++ b/raster/r.mfilter/getrow.c
@@ -10,7 +10,7 @@
 #include "glob.h"
 #include "local_proto.h"
 
-int getmaprow(int fd, void *buf, int row, int len UNUSED)
+int getmaprow(int fd, void *buf, int row, int len G_UNUSED)
 {
     Rast_get_d_row(fd, (DCELL *)buf, row);
     return 1;

--- a/raster/r.out.mpeg/write.c
+++ b/raster/r.out.mpeg/write.c
@@ -193,7 +193,8 @@ void write_ppm(char *tr, char *tg, char *tb, int nrows, int ncols, int *y_rows,
 
 /*******************************************************/
 void write_params(char *mpfilename, char *yfiles[], char *outfile, int frames,
-                  int quality, int y_rows UNUSED, int y_cols UNUSED, int fly)
+                  int quality, int y_rows G_UNUSED, int y_cols G_UNUSED,
+                  int fly)
 {
     FILE *fp;
     char dir[1000], *enddir;

--- a/raster/r.out.vrml/put_view.c
+++ b/raster/r.out.vrml/put_view.c
@@ -2,7 +2,7 @@
 
 /* Not yet implemented - just defaults */
 
-void vrml_put_view(FILE *vout, struct G_3dview *v3d UNUSED)
+void vrml_put_view(FILE *vout, struct G_3dview *v3d G_UNUSED)
 {
     char tbuf[512];
 

--- a/raster/r.out.vtk/writeascii.c
+++ b/raster/r.out.vtk/writeascii.c
@@ -150,7 +150,7 @@ void write_vtk_pointdata_header(FILE *fp, struct Cell_head region)
 /* ************************************************************************* */
 /* Write the VTK Structured Coordinates ************************************ */
 /* ************************************************************************* */
-void write_vtk_structured_coordinates(int fd, FILE *fp, char *varname UNUSED,
+void write_vtk_structured_coordinates(int fd, FILE *fp, char *varname G_UNUSED,
                                       struct Cell_head region, int out_type,
                                       char *null_value, double scale, int dp)
 {
@@ -202,7 +202,7 @@ void write_vtk_structured_coordinates(int fd, FILE *fp, char *varname UNUSED,
 /* ************************************************************************* */
 /* Write Polygonal Coordinates ********************************************* */
 /* ************************************************************************* */
-void write_vtk_polygonal_coordinates(int fd, FILE *fp, char *varname UNUSED,
+void write_vtk_polygonal_coordinates(int fd, FILE *fp, char *varname G_UNUSED,
                                      struct Cell_head region, int out_type,
                                      char *null_value, double scale,
                                      int polytype, int dp)

--- a/raster/r.param.scale/nrutil.c
+++ b/raster/r.param.scale/nrutil.c
@@ -140,8 +140,8 @@ int **imatrix(int nrl, int nrh, int ncl, int nch)
 }
 
 /* point a submatrix [newrl..][newcl..] to a[oldrl..oldrh][oldcl..oldch] */
-float **submatrix(float **a, int oldrl, int oldrh, int oldcl, int oldch UNUSED,
-                  int newrl, int newcl)
+float **submatrix(float **a, int oldrl, int oldrh, int oldcl,
+                  int oldch G_UNUSED, int newrl, int newcl)
 {
     int i, j, nrow = oldrh - oldrl + 1, ncol = oldcl - newcl;
     float **m;
@@ -219,73 +219,75 @@ float ***f3tensor(int nrl, int nrh, int ncl, int nch, int ndl, int ndh)
 }
 
 /* free a float vector allocated with vector() */
-void free_vector(float *v, int nl, int nh UNUSED)
+void free_vector(float *v, int nl, int nh G_UNUSED)
 {
     G_free((FREE_ARG)(v + nl - NR_END));
 }
 
 /* free an int vector allocated with ivector() */
-void free_ivector(int *v, int nl, int nh UNUSED)
+void free_ivector(int *v, int nl, int nh G_UNUSED)
 {
     G_free((FREE_ARG)(v + nl - NR_END));
 }
 
 /* free an unsigned char vector allocated with cvector() */
-void free_cvector(unsigned char *v, int nl, int nh UNUSED)
+void free_cvector(unsigned char *v, int nl, int nh G_UNUSED)
 {
     G_free((FREE_ARG)(v + nl - NR_END));
 }
 
 /* free an unsigned long vector allocated with lvector() */
-void free_lvector(unsigned long *v, int nl, int nh UNUSED)
+void free_lvector(unsigned long *v, int nl, int nh G_UNUSED)
 {
     G_free((FREE_ARG)(v + nl - NR_END));
 }
 
 /* free a double vector allocated with dvector() */
-void free_dvector(double *v, int nl, int nh UNUSED)
+void free_dvector(double *v, int nl, int nh G_UNUSED)
 {
     G_free((FREE_ARG)(v + nl - NR_END));
 }
 
 /* free a float matrix allocated by matrix() */
-void free_matrix(float **m, int nrl, int nrh UNUSED, int ncl, int nch UNUSED)
+void free_matrix(float **m, int nrl, int nrh G_UNUSED, int ncl,
+                 int nch G_UNUSED)
 {
     G_free((FREE_ARG)(m[nrl] + ncl - NR_END));
     G_free((FREE_ARG)(m + nrl - NR_END));
 }
 
 /* free a double matrix allocated by dmatrix() */
-void free_dmatrix(double **m, int nrl, int nrh UNUSED, int ncl, int nch UNUSED)
+void free_dmatrix(double **m, int nrl, int nrh G_UNUSED, int ncl,
+                  int nch G_UNUSED)
 {
     G_free((FREE_ARG)(m[nrl] + ncl - NR_END));
     G_free((FREE_ARG)(m + nrl - NR_END));
 }
 
 /* free an int matrix allocated by imatrix() */
-void free_imatrix(int **m, int nrl, int nrh UNUSED, int ncl, int nch UNUSED)
+void free_imatrix(int **m, int nrl, int nrh G_UNUSED, int ncl, int nch G_UNUSED)
 {
     G_free((FREE_ARG)(m[nrl] + ncl - NR_END));
     G_free((FREE_ARG)(m + nrl - NR_END));
 }
 
 /* free a submatrix allocated by submatrix() */
-void free_submatrix(float **b, int nrl, int nrh UNUSED, int ncl UNUSED,
-                    int nch UNUSED)
+void free_submatrix(float **b, int nrl, int nrh G_UNUSED, int ncl G_UNUSED,
+                    int nch G_UNUSED)
 {
     G_free((FREE_ARG)(b + nrl - NR_END));
 }
 
 /* free a matrix allocated by convert_matrix() */
-void free_convert_matrix(float **b, int nrl, int nrh UNUSED, int ncl UNUSED,
-                         int nch UNUSED)
+void free_convert_matrix(float **b, int nrl, int nrh G_UNUSED, int ncl G_UNUSED,
+                         int nch G_UNUSED)
 {
     G_free((FREE_ARG)(b + nrl - NR_END));
 }
 
 /* free a float f3tensor allocated by f3tensor() */
-void free_f3tensor(float ***t, int nrl, int nrh UNUSED, int ncl, int nch UNUSED,
-                   int ndl, int ndh UNUSED)
+void free_f3tensor(float ***t, int nrl, int nrh G_UNUSED, int ncl,
+                   int nch G_UNUSED, int ndl, int ndh G_UNUSED)
 {
     G_free((FREE_ARG)(t[nrl][ncl] + ndl - NR_END));
     G_free((FREE_ARG)(t[nrl] + ncl - NR_END));

--- a/raster/r.random.surface/makepp.c
+++ b/raster/r.random.surface/makepp.c
@@ -2,7 +2,7 @@
 #include "ransurf.h"
 #include "local_proto.h"
 
-double MakePP(int Row, int Col, int OutRows UNUSED, int OutCols UNUSED,
+double MakePP(int Row, int Col, int OutRows G_UNUSED, int OutCols G_UNUSED,
               double **Randoms, BIGF BigF)
 {
     int DRow, DCol;

--- a/raster/r.resamp.bspline/resamp.c
+++ b/raster/r.resamp.bspline/resamp.c
@@ -23,7 +23,7 @@
 
 struct Point *P_Read_Raster_Region_masked(SEGMENT *mask_seg,
                                           struct Cell_head *Original,
-                                          struct bound_box output_box UNUSED,
+                                          struct bound_box output_box G_UNUSED,
                                           struct bound_box General,
                                           int *num_points, int dim_vect,
                                           double mean)

--- a/raster/r.sim/simlib/output.c
+++ b/raster/r.sim/simlib/output.c
@@ -96,7 +96,7 @@ void output_walker_as_vector(int tt_minutes, int ndigit,
 
 /* Soeren 8. Mar 2011 TODO:
  * This function needs to be refractured and splittet into smaller parts */
-int output_data(int tt, double ft UNUSED, const Setup *setup,
+int output_data(int tt, double ft G_UNUSED, const Setup *setup,
                 const Geometry *geometry, const Settings *settings,
                 const Simulation *sim, const Inputs *inputs,
                 const Outputs *outputs, const Grids *grids)

--- a/raster/r.stream.extract/seg.c
+++ b/raster/r.stream.extract/seg.c
@@ -5,7 +5,7 @@
 
 int seg_open(SSEG *sseg, GW_LARGE_INT nrows, GW_LARGE_INT ncols, int row_in_seg,
              int col_in_seg, int nsegs_in_memory, int size_struct,
-             int fill UNUSED)
+             int fill G_UNUSED)
 {
     char *filename;
     int errflag;

--- a/raster/r.sun/rsunlib.c
+++ b/raster/r.sun/rsunlib.c
@@ -179,7 +179,7 @@ void com_par_const(double longitTime, struct SunGeometryConstDay *sungeom,
 void com_par(struct SunGeometryConstDay *sungeom,
              struct SunGeometryVarDay *sunVarGeom,
              struct GridGeometry *gridGeom, double latitude,
-             double longitude UNUSED)
+             double longitude G_UNUSED)
 {
     double pom, xpom, ypom;
     double costimeAngle;

--- a/raster/r.terraflow/fill.cpp
+++ b/raster/r.terraflow/fill.cpp
@@ -523,7 +523,7 @@ void assignFinalDirections(AMI_STREAM<plateauStats> *statstr,
 /* ********************************************************************** */
 class directionElevationMerger {
 public:
-    waterGridType operator()(elevation_type el, direction_type dir UNUSED,
+    waterGridType operator()(elevation_type el, direction_type dir G_UNUSED,
                              const waterType &p)
     {
         /* check that no (boundary) nodata values got in here */

--- a/raster/r.terraflow/filldepr.cpp
+++ b/raster/r.terraflow/filldepr.cpp
@@ -76,8 +76,8 @@ elevation_type *fill_depression(AMI_STREAM<boundaryType> *boundaryStr,
 
 /************************************************************/
 elevation_type *
-ext_fill_depression(AMI_STREAM<boundaryType> *boundaryStr UNUSED,
-                    cclabel_type maxWatersheds UNUSED)
+ext_fill_depression(AMI_STREAM<boundaryType> *boundaryStr G_UNUSED,
+                    cclabel_type maxWatersheds G_UNUSED)
 {
     G_fatal_error(
         _("Fill_depressions do not fit in memory. Not implemented yet"));

--- a/raster/r.terraflow/nodata.cpp
+++ b/raster/r.terraflow/nodata.cpp
@@ -119,8 +119,8 @@ detectEdgeNodata::~detectEdgeNodata()
    structs. */
 nodataType *detectEdgeNodata::getNodataForward(dimension_type i,
                                                dimension_type j,
-                                               dimension_type nr UNUSED,
-                                               dimension_type nc UNUSED)
+                                               dimension_type nr G_UNUSED,
+                                               dimension_type nc G_UNUSED)
 {
     bool ok;
     static nodataType ptarr[3]; /* return value */
@@ -163,7 +163,7 @@ nodataType *detectEdgeNodata::getNodataForward(dimension_type i,
 /* ********************************************************************** */
 
 void detectEdgeNodata::processWindow(dimension_type row, dimension_type col,
-                                     elevation_type &point UNUSED,
+                                     elevation_type &point G_UNUSED,
                                      elevation_type *a, elevation_type *b,
                                      elevation_type *c)
 {

--- a/raster/r.terraflow/plateau.cpp
+++ b/raster/r.terraflow/plateau.cpp
@@ -86,8 +86,8 @@ detectPlateaus::~detectPlateaus()
    structs. */
 plateauType *detectPlateaus::getPlateauForward(dimension_type i,
                                                dimension_type j,
-                                               dimension_type nr UNUSED,
-                                               dimension_type nc UNUSED)
+                                               dimension_type nr G_UNUSED,
+                                               dimension_type nc G_UNUSED)
 {
     bool ok;
     static plateauType ptarr[3]; /* return value */

--- a/raster/r.terraflow/water.cpp
+++ b/raster/r.terraflow/water.cpp
@@ -247,7 +247,7 @@ void createWaterWindows(AMI_STREAM<waterGridType> *mergedWaterStr,
 void generateWatersheds(AMI_STREAM<waterWindowType> **waterWindows,
                         const dimension_type nrows, const dimension_type ncols,
                         AMI_STREAM<labelElevType> *labeledWater,
-                        AMI_STREAM<boundaryType> *boundaryStr UNUSED)
+                        AMI_STREAM<boundaryType> *boundaryStr G_UNUSED)
 {
     AMI_err ae;
     waterWindowType *winp, prevWin;

--- a/raster/r.terraflow/weightWindow.cpp
+++ b/raster/r.terraflow/weightWindow.cpp
@@ -233,10 +233,11 @@ void weightWindow::compute(const dimension_type i, const dimension_type j,
 
 /* Find the dominant direction. Set corresponding weight to 1, and
    sets all other weights to 0. Set sumweight and sumcontour.*/
-void weightWindow::makeD8(const dimension_type i UNUSED,
-                          const dimension_type j UNUSED,
+void weightWindow::makeD8(const dimension_type i G_UNUSED,
+                          const dimension_type j G_UNUSED,
                           const genericWindow<elevation_type> &elevwin,
-                          const direction_type dir, const bool trustdir UNUSED)
+                          const direction_type dir,
+                          const bool trustdir G_UNUSED)
 {
 
     elevation_type elev_crt;

--- a/raster/r.to.vect/areas.c
+++ b/raster/r.to.vect/areas.c
@@ -668,7 +668,7 @@ static int add_to_list(int x, int y)
 /* assign_area - make current area number correspond to the passed */
 /* category number and allocate more space to store areas if necessary */
 
-static int assign_area(double cat, int kase UNUSED)
+static int assign_area(double cat, int kase G_UNUSED)
 {
     a_list_new->free = 0;
     a_list_new->cat = cat;

--- a/raster/r.to.vect/areas_io.c
+++ b/raster/r.to.vect/areas_io.c
@@ -128,8 +128,8 @@ int write_boundary(struct COOR *seed)
 /* writes binary and ASCII digit files and supplemental file */
 static int
 write_bnd(struct COOR *line_begin,
-          struct COOR *line_end UNUSED, /* start and end point of line */
-          int n                         /* number of points to write */
+          struct COOR *line_end G_UNUSED, /* start and end point of line */
+          int n                           /* number of points to write */
 )
 {
     static struct line_pnts *points = NULL;
@@ -173,10 +173,10 @@ write_bnd(struct COOR *line_begin,
 /* writes binary and ASCII digit files and supplemental file */
 #define SNAP_THRESH 0.00001
 
-static int
-write_smooth_bnd(struct COOR *line_begin,
-                 struct COOR *line_end UNUSED, /* start and end point of line */
-                 int n                         /* number of points to write */
+static int write_smooth_bnd(
+    struct COOR *line_begin,
+    struct COOR *line_end G_UNUSED, /* start and end point of line */
+    int n                           /* number of points to write */
 )
 {
     static struct line_pnts *points = NULL;

--- a/raster/r.to.vect/lines_io.c
+++ b/raster/r.to.vect/lines_io.c
@@ -143,7 +143,7 @@ int write_line(struct COOR *seed)
 /* writes binary and supplemental file */
 
 static int write_ln(struct COOR *begin,
-                    struct COOR *end UNUSED, /* start and end point of line */
+                    struct COOR *end G_UNUSED, /* start and end point of line */
                     int n)
 { /* number of points to write */
     static struct line_pnts *points = NULL;

--- a/raster/r.to.vect/points.c
+++ b/raster/r.to.vect/points.c
@@ -10,7 +10,7 @@
 #include <grass/vector.h>
 #include "global.h"
 
-int extract_points(int z_flag UNUSED)
+int extract_points(int z_flag G_UNUSED)
 {
     struct line_pnts *points = Vect_new_line_struct();
     CELL *cellbuf;

--- a/raster/r.viewshed/distribute.cpp
+++ b/raster/r.viewshed/distribute.cpp
@@ -502,8 +502,8 @@ void distribute_bnd_events(AMI_STREAM<AEvent> *bndEvents,
    solved by switching to radial sweep.  */
 unsigned long solve_in_memory(AMI_STREAM<AEvent> *eventList,
                               AMI_STREAM<AEvent> *enterBndEvents,
-                              double start_angle UNUSED,
-                              double end_angle UNUSED,
+                              double start_angle G_UNUSED,
+                              double end_angle G_UNUSED,
                               IOVisibilityGrid *visgrid, GridHeader *hd,
                               Viewpoint *vp, const ViewOptions &viewOptions)
 {

--- a/raster/r.viewshed/statusstructure.cpp
+++ b/raster/r.viewshed/statusstructure.cpp
@@ -59,7 +59,7 @@ extern "C" {
    If doCurv is set we need to consider the curvature of the
    earth */
 float get_vertical_angle(Viewpoint vp, StatusNode sn, surface_type elev,
-                         int doCurv UNUSED)
+                         int doCurv G_UNUSED)
 {
 
     /*determine the difference in elevation, based on the curvature */

--- a/raster/r.watershed/ram/over_cells.c
+++ b/raster/r.watershed/ram/over_cells.c
@@ -2,7 +2,7 @@
 #define BIGNEG -9999999
 
 int overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
-                             CELL *hih_ele UNUSED)
+                             CELL *hih_ele G_UNUSED)
 {
     int r, rr, c, cc;
     CELL new_ele, /* new_max_ele, */ value;
@@ -38,7 +38,7 @@ int overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
 
 /* non-recursive version */
 int overland_cells(int row, int col, CELL basin_num, CELL haf_num,
-                   CELL *hih_ele UNUSED)
+                   CELL *hih_ele G_UNUSED)
 {
     int r, c, rr, cc, next_r, next_c;
     int top = 0, idx;

--- a/raster/r.watershed/seg/over_cells.c
+++ b/raster/r.watershed/seg/over_cells.c
@@ -2,7 +2,7 @@
 #define BIGNEG -9999999
 
 int overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
-                             CELL *hih_ele UNUSED)
+                             CELL *hih_ele G_UNUSED)
 {
     int r, rr, c, cc;
     CELL new_ele /*, new_max_ele */;
@@ -41,7 +41,7 @@ int overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
 
 /* non-recursive version */
 int overland_cells(int row, int col, CELL basin_num, CELL haf_num,
-                   CELL *hih_ele UNUSED)
+                   CELL *hih_ele G_UNUSED)
 {
     int r, rr, c, cc, next_r, next_c;
     char aspect;

--- a/raster3d/r3.in.v5d/main.c
+++ b/raster3d/r3.in.v5d/main.c
@@ -83,7 +83,7 @@ static void getParams(char **input, char **output, int *convertNull,
 /*---------------------------------------------------------------------------*/
 
 void convert(char *openFile, RASTER3D_Region *region, int convertNull,
-             double nullValue UNUSED)
+             double nullValue G_UNUSED)
 {
     v5dstruct v5d;
     int time, var;

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -831,7 +831,7 @@ void v5dDecompressGrid(int nr, int nc, int nl, int compressmode, void *compdata,
  *         time, var - which timestep and variable
  * Return:  number of data points.
  */
-int v5dSizeofGrid(const v5dstruct *v, int time UNUSED, int var)
+int v5dSizeofGrid(const v5dstruct *v, int time G_UNUSED, int var)
 {
     return v->Nr * v->Nc * v->Nl[var] * v->CompressMode;
 }

--- a/raster3d/r3.mkdspf/iso_surface.c
+++ b/raster3d/r3.mkdspf/iso_surface.c
@@ -23,7 +23,7 @@ static void xings_grad(float *data[], int c_ndx, int x1, int y1, int z1,
 static void normalize(float n[3]);
 
 void viz_iso_surface(void *g3map, RASTER3D_Region *g3reg,
-                     cmndln_info *linefax UNUSED, int quiet)
+                     cmndln_info *linefax G_UNUSED, int quiet)
 {
     float *data[4]; /* will hold 4 slices of xy data */
     int zloop;

--- a/raster3d/r3.mkdspf/r3_data.c
+++ b/raster3d/r3.mkdspf/r3_data.c
@@ -3,8 +3,8 @@
 
 #define NO_RESAMPLE
 
-int r3read_level(void *g3map, RASTER3D_Region *g3reg UNUSED, file_info *Headfax,
-                 float *data, int n_lev)
+int r3read_level(void *g3map, RASTER3D_Region *g3reg G_UNUSED,
+                 file_info *Headfax, float *data, int n_lev)
 {
 #ifdef NO_RESAMPLE
     Rast3d_get_block(g3map, 0, 0, n_lev, Headfax->xdim, Headfax->ydim, 1,

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -85,7 +85,7 @@ void setParams(void)
 /*---------------------------------------------------------------------------*/
 /* Set up the input and output file names from the user's responses
  */
-void getParams(char **input, char **output, int *decim UNUSED)
+void getParams(char **input, char **output, int *decim G_UNUSED)
 {
     *input = param.input->answer;
     *output = param.output->answer;

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -833,7 +833,7 @@ void v5dDecompressGrid(int nr, int nc, int nl, int compressmode, void *compdata,
  *         time, var - which timestep and variable
  * Return:  number of data points.
  */
-int v5dSizeofGrid(const v5dstruct *v, int time UNUSED, int var)
+int v5dSizeofGrid(const v5dstruct *v, int time G_UNUSED, int var)
 {
     return v->Nr * v->Nc * v->Nl[var] * v->CompressMode;
 }

--- a/raster3d/r3.out.vtk/writeVTKHead.c
+++ b/raster3d/r3.out.vtk/writeVTKHead.c
@@ -30,7 +30,7 @@
 /* Writes the structured points Header ************************************* */
 
 /* ************************************************************************* */
-void write_vtk_structured_point_header(FILE *fp, char *vtkFile UNUSED,
+void write_vtk_structured_point_header(FILE *fp, char *vtkFile G_UNUSED,
                                        RASTER3D_Region region, int dp,
                                        double scale)
 {
@@ -94,7 +94,7 @@ void write_vtk_structured_point_header(FILE *fp, char *vtkFile UNUSED,
 /* Writes the strcutured grid header **************************************** */
 
 /* ************************************************************************* */
-void write_vtk_structured_grid_header(FILE *fp, char *vtkFile UNUSED,
+void write_vtk_structured_grid_header(FILE *fp, char *vtkFile G_UNUSED,
                                       RASTER3D_Region region)
 {
     G_debug(
@@ -117,7 +117,7 @@ void write_vtk_structured_grid_header(FILE *fp, char *vtkFile UNUSED,
 /* Writes the unstrcutured grid header ************************************* */
 
 /* ************************************************************************* */
-void write_vtk_unstructured_grid_header(FILE *fp, char *vtkFile UNUSED,
+void write_vtk_unstructured_grid_header(FILE *fp, char *vtkFile G_UNUSED,
                                         RASTER3D_Region region)
 {
     G_debug(3, "write_vtk_unstructured_grid_header: Writing "

--- a/vector/v.clean/split.c
+++ b/vector/v.clean/split.c
@@ -91,7 +91,7 @@ int split_lines(struct Map_info *Map, int otype, struct Map_info *Err)
 /* split a line using split_distance
  * returns number of split points */
 int split_line(struct Map_info *Map, int otype, struct line_pnts *Points,
-               struct line_cats *Cats, struct Map_info *Err UNUSED,
+               struct line_cats *Cats, struct Map_info *Err G_UNUSED,
                double split_distance)
 {
     int i, n_segs = 0;

--- a/vector/v.decimate/grid_decimation.c
+++ b/vector/v.decimate/grid_decimation.c
@@ -79,7 +79,7 @@ void grid_decimation_set_region(struct GridDecimation *grid_decimation,
 
 void grid_decimation_create_list_with_point(
     struct GridDecimation *grid_decimation, size_t index,
-    struct DecimationPoint *point, size_t npoints UNUSED)
+    struct DecimationPoint *point, size_t npoints G_UNUSED)
 {
     struct DecimationPoint **point_list =
         G_malloc(1 * sizeof(struct DecimationPoint *));

--- a/vector/v.decimate/main.c
+++ b/vector/v.decimate/main.c
@@ -30,7 +30,8 @@ struct DecimationContext {
     int unique_cats; /*!< TRUE or FALSE */
 };
 
-static int if_add_point(struct DecimationPoint *point, void *point_data UNUSED,
+static int if_add_point(struct DecimationPoint *point,
+                        void *point_data G_UNUSED,
                         struct DecimationPoint **point_list, size_t npoints,
                         void *context)
 {
@@ -56,8 +57,8 @@ struct WriteContext {
     int write_cats;
 };
 
-static void write_point(struct WriteContext *context, int cat UNUSED, double x,
-                        double y, double z, struct line_cats *cats)
+static void write_point(struct WriteContext *context, int cat G_UNUSED,
+                        double x, double y, double z, struct line_cats *cats)
 {
     if (Vect_append_point(context->line, x, y, z) != 1)
         G_fatal_error(

--- a/vector/v.delaunay/in_out.c
+++ b/vector/v.delaunay/in_out.c
@@ -74,7 +74,7 @@ int cmp(const void *a, const void *b)
     return 0;
 }
 
-void output_edges(unsigned int n, int mode3d UNUSED, int type,
+void output_edges(unsigned int n, int mode3d G_UNUSED, int type,
                   struct Map_info *Out)
 {
     struct edge *e_start, *e;
@@ -119,7 +119,7 @@ void output_edges(unsigned int n, int mode3d UNUSED, int type,
 
 /* Print the ring of triangles about each vertex. */
 
-void output_triangles(unsigned int n, int mode3d UNUSED, int type,
+void output_triangles(unsigned int n, int mode3d G_UNUSED, int type,
                       struct Map_info *Out)
 {
     struct edge *e_start, *e, *next;

--- a/vector/v.in.dxf/dxf_to_vect.c
+++ b/vector/v.in.dxf/dxf_to_vect.c
@@ -76,7 +76,7 @@ int dxf_to_vect(struct dxf_file *dxf, struct Map_info *Map)
                     case 30:
                         dxf_ext.B = atof(dxf_buf);
                         bounds++;
-                        FALLTHROUGH;
+                        G_FALLTHROUGH;
                     default:
                         break;
                     }

--- a/vector/v.in.dxf/make_arc.c
+++ b/vector/v.in.dxf/make_arc.c
@@ -73,7 +73,8 @@ int make_arc(int offset, /* offset into array of points */
     return arr_size - offset;
 }
 
-int make_arc_from_polyline(int arr_size, double bulge UNUSED, double prev_bulge)
+int make_arc_from_polyline(int arr_size, double bulge G_UNUSED,
+                           double prev_bulge)
 {
     int arc_arr_size;
     float ang1, ang2;

--- a/vector/v.in.dxf/write_vect.c
+++ b/vector/v.in.dxf/write_vect.c
@@ -86,7 +86,7 @@ void write_vect(struct Map_info *Map, char *layer, char *entity, char *handle,
     return;
 }
 
-int write_done(struct Map_info *Map UNUSED)
+int write_done(struct Map_info *Map G_UNUSED)
 {
     int i;
 

--- a/vector/v.kernel/main.c
+++ b/vector/v.kernel/main.c
@@ -635,7 +635,8 @@ int main(int argc, char **argv)
 }
 
 /* Read points to array return number of points */
-int read_points(struct Map_info *In, double ***coordinate, double dsize UNUSED)
+int read_points(struct Map_info *In, double ***coordinate,
+                double dsize G_UNUSED)
 {
     int line, nlines, npoints, ltype, i = 0;
     double **xySites;

--- a/vector/v.label.sa/annealing.c
+++ b/vector/v.label.sa/annealing.c
@@ -48,7 +48,8 @@ static unsigned int overlaps_removed = 0;
  @param n_labels The size of the labels array.
  @params The commandline parameters.
  */
-void simulate_annealing(label_t *labels, int n_labels, struct params *p UNUSED)
+void simulate_annealing(label_t *labels, int n_labels,
+                        struct params *p G_UNUSED)
 {
     /* The temperature of the system */
     double T;

--- a/vector/v.label.sa/labels.c
+++ b/vector/v.label.sa/labels.c
@@ -227,7 +227,7 @@ label_t *labels_init(struct params *p, int *n_labels)
  * @param The charset to use [unused]
  * @param The label to which we want to create a skyline
  */
-static int label_skyline(FT_Face face, const char *charset UNUSED,
+static int label_skyline(FT_Face face, const char *charset G_UNUSED,
                          label_t *label)
 {
     int i, len;

--- a/vector/v.lidar.correction/correction.c
+++ b/vector/v.lidar.correction/correction.c
@@ -23,7 +23,7 @@
 #include <math.h>
 #include "correction.h"
 
-void P_Sparse_Correction(struct Map_info *In UNUSED, struct Map_info *Out,
+void P_Sparse_Correction(struct Map_info *In G_UNUSED, struct Map_info *Out,
                          struct Map_info *Terrain,
                          struct Cell_head *Elaboration,
                          struct bound_box General, struct bound_box Overlap,

--- a/vector/v.lidar.growing/ConvexHull.c
+++ b/vector/v.lidar.growing/ConvexHull.c
@@ -188,8 +188,8 @@ int checkHull(int cR, int cC, double **oldHull, int lungOld)
 
 /*---------------------------------------------------------------------------*/
 double pianOriz(double **punti, int obsNum, double *minNS, double *minEW,
-                double *maxNS, double *maxEW, struct element_grow **mat UNUSED,
-                int CBordo UNUSED)
+                double *maxNS, double *maxEW,
+                struct element_grow **mat G_UNUSED, int CBordo G_UNUSED)
 {
     int c1;
     double minBordo, medioBordo; /*, minBordo1; */
@@ -301,14 +301,14 @@ struct element_grow **structMatrix(long nrl, long nrh, long ncl, long nch)
     return m;
 }
 
-void free_Pvector(double **v, long nl, long nh UNUSED)
+void free_Pvector(double **v, long nl, long nh G_UNUSED)
 {
 
     free((FREE_ARG)(v + nl - NR_END));
 }
 
-void free_structmatrix(struct element_grow **m, long nrl, long nrh UNUSED,
-                       long ncl, long nch UNUSED)
+void free_structmatrix(struct element_grow **m, long nrl, long nrh G_UNUSED,
+                       long ncl, long nch G_UNUSED)
 {
     free((FREE_ARG)(m[nrl] + ncl - NR_END));
     free((FREE_ARG)(m + nrl - NR_END));

--- a/vector/v.lidar.growing/growing.c
+++ b/vector/v.lidar.growing/growing.c
@@ -4,7 +4,7 @@
 #include "growing.h"
 
 void P_Aux_to_Coor(struct Map_info *In, struct Map_info *Out, dbDriver *driver,
-                   FILE *fsite UNUSED)
+                   FILE *fsite G_UNUSED)
 {
     int more, ltype, line_num, ID_type, Interp_type;
     double quotaZ;

--- a/vector/v.net.visibility/data_structures.c
+++ b/vector/v.net.visibility/data_structures.c
@@ -52,7 +52,7 @@ void init_stack(int size)
 
 /** compare the points along the x axis
  */
-int cmp_points(const void *v1, const void *v2, void *param UNUSED)
+int cmp_points(const void *v1, const void *v2, void *param G_UNUSED)
 {
     struct Point *p1 = (struct Point *)v1;
     struct Point *p2 = (struct Point *)v2;

--- a/vector/v.net.visibility/visibility.c
+++ b/vector/v.net.visibility/visibility.c
@@ -19,8 +19,8 @@
 
 /** for all points initiate their vis line to the one directly below
  */
-void init_vis(struct Point *points, int num_points, struct Line *lines UNUSED,
-              int num_lines UNUSED)
+void init_vis(struct Point *points, int num_points, struct Line *lines G_UNUSED,
+              int num_lines G_UNUSED)
 {
     int i;
     double d;

--- a/vector/v.out.vtk/writeVTK.c
+++ b/vector/v.out.vtk/writeVTK.c
@@ -452,7 +452,7 @@ int write_vtk_cells(FILE *ascii, struct Map_info *Map, VTKInfo *info,
 /* This function writes the categories as vtk cell data ******************** */
 /* ************************************************************************* */
 int write_vtk_cat_data(FILE *ascii, struct Map_info *Map, VTKInfo *info,
-                       int layer, int *types, int typenum, int dp UNUSED)
+                       int layer, int *types, int typenum, int dp G_UNUSED)
 {
     int type, cat, i, k, centroid;
     static struct line_pnts *Points;
@@ -556,7 +556,7 @@ int write_vtk_cat_data(FILE *ascii, struct Map_info *Map, VTKInfo *info,
    by the caller.
  */
 char *get_att(char *name, int cat, struct field_info *Fi, dbDriver *Driver,
-              int ncol UNUSED)
+              int ncol G_UNUSED)
 {
     char buf[2000];
     int more;
@@ -605,7 +605,7 @@ char *get_att(char *name, int cat, struct field_info *Fi, dbDriver *Driver,
 /* This function writes numerical attribute table fields as VTK scalars **** */
 /* ************************************************************************* */
 int write_vtk_db_data(FILE *ascii, struct Map_info *Map, VTKInfo *info,
-                      int layer, int *types, int typenum, int dp UNUSED)
+                      int layer, int *types, int typenum, int dp G_UNUSED)
 {
     int type, cat, i, k, centroid;
     struct line_cats *Cats;
@@ -856,7 +856,8 @@ int write_vtk_db_labels(FILE *ascii, struct Map_info *Map, VTKInfo *info,
 /* This function writes the point coordinates and the geometric feature **** */
 /* ************************************************************************* */
 int write_vtk(FILE *ascii, struct Map_info *Map, int layer, int *types,
-              int typenum, int dp, double scale, int numatts, int labels UNUSED)
+              int typenum, int dp, double scale, int numatts,
+              int labels G_UNUSED)
 {
     VTKInfo *info;
     VTKTypeInfo **typeinfo;

--- a/vector/v.reclass/reclass.c
+++ b/vector/v.reclass/reclass.c
@@ -23,7 +23,7 @@
 #include <grass/vector.h>
 
 int reclass(struct Map_info *In, struct Map_info *Out, int type, int field,
-            dbCatValArray *cvarr, int dissolve UNUSED)
+            dbCatValArray *cvarr, int dissolve G_UNUSED)
 {
     int i, nlines, line, ltype, old_cat, new_cat;
     int nocat = 0, rclelem = 0, negative = 0;

--- a/vector/v.rectify/cp.c
+++ b/vector/v.rectify/cp.c
@@ -14,7 +14,7 @@ struct Stats {
     double sum2, rms;
 };
 
-static void update_stats(struct Stats *st, int n UNUSED, double dx, double dy,
+static void update_stats(struct Stats *st, int n G_UNUSED, double dx, double dy,
                          double *dz, double dg, double d2)
 {
     st->x += dx;

--- a/vector/v.rectify/orthorot.c
+++ b/vector/v.rectify/orthorot.c
@@ -538,7 +538,7 @@ void copy_matrix(int n, int m, double **src_matrix, double **dest_matrix)
     }
 }
 
-double trace(int n, int m UNUSED, double **matrix)
+double trace(int n, int m G_UNUSED, double **matrix)
 {
     int i;
     double t = 0.0;

--- a/vector/v.surf.bspline/resamp.c
+++ b/vector/v.surf.bspline/resamp.c
@@ -25,7 +25,7 @@
 
 struct Point *P_Read_Raster_Region_masked(SEGMENT *mask_seg,
                                           struct Cell_head *Original,
-                                          struct bound_box output_box UNUSED,
+                                          struct bound_box output_box G_UNUSED,
                                           struct bound_box General,
                                           int *num_points, int dim_vect,
                                           double mean)

--- a/vector/v.vol.rst/user3.c
+++ b/vector/v.vol.rst/user3.c
@@ -51,7 +51,7 @@
 #undef hz
 #endif
 
-int secpar_loop(int ngstc UNUSED, int nszc UNUSED, int i)
+int secpar_loop(int ngstc G_UNUSED, int nszc G_UNUSED, int i)
 {
     double dnorm1, ro, dx2, dy2, dz2, grad1, grad2, slp, grad, oor1, oor2, curn,
         curm, curg, dxy2, dxz2, dyz2;

--- a/visualization/ximgview/main.c
+++ b/visualization/ximgview/main.c
@@ -132,7 +132,7 @@ static void redraw(void)
     last = (tv1.tv_sec - tv0.tv_sec) * 1000000L + (tv1.tv_usec - tv0.tv_usec);
 }
 
-static void dummy_handler(int sig UNUSED)
+static void dummy_handler(int sig G_UNUSED)
 {
 }
 


### PR DESCRIPTION
Prefix the preprocessing macros `UNUSED` and `FALLTHROUGH` with `G_` to avoid conflicts with third party software.

This is something I have long planned to do. For example, there was an issue for QGIS, which they solved in https://github.com/qgis/QGIS/pull/55018; one of the addons was also affected https://github.com/OSGeo/grass-addons/pull/1626.