### PR TITLE
utils: Don't set executable bit on mkdocs.py.

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -10,7 +10,7 @@ default: parsubdirs $(UTILSDIR)/mkdocs.py $(UTILSDIR)/mkhtml.py $(UTILSDIR)/mkma
 	$(UTILSDIR)/g.echo$(EXE)
 
 $(UTILSDIR)/mkdocs.py: mkdocs.py
-	$(INSTALL) $< $@
+	$(INSTALL_DATA) $< $@
 
 $(UTILSDIR)/mkhtml.py: mkhtml.py
 	$(INSTALL) $< $@


### PR DESCRIPTION
It's not an executable script.