### PR TITLE
lib/raster: read vrt tile only if needed

### DIFF
--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -205,8 +205,28 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 #pragma omp critical(raster_vrt_read)
     for (i = 0; i < vrt->tlist->n_values; i++) {
         struct tileinfo *p = &ti[vrt->tlist->value[i]];
+        double tile_west, tile_east;
 
-        if (p->cellhd.north > rows && p->cellhd.south <= rown) {
+        tile_west = p->cellhd.west;
+        tile_east = p->cellhd.east;
+
+        if (R__.rd_window.proj == PROJECTION_LL) {
+            /* longitude wrapping of the tile into the current
+             * reading window */
+            while (tile_west > rd_window->east) {
+                tile_west -= 360.0;
+                tile_east -= 360.0;
+            }
+            while (tile_east < rd_window->west) {
+                tile_west += 360.0;
+                tile_east += 360.0;
+            }
+        }
+
+        /* open the tile only if it overlaps with the current reading
+         * row and the current reading EW extents */
+        if (p->cellhd.north > rows && p->cellhd.south <= rown &&
+            tile_west < p->cellhd.east && tile_east > p->cellhd.west) {
             int tfd;
             void *p1, *p2;
 

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -223,8 +223,6 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
             Rast_get_row_nomask(tfd, tmpbuf, row, data_type);
             Rast_unopen(tfd);
 
-            p1 = buf;
-            p2 = tmpbuf;
             /* restrict to start and end col ? */
             for (j = 0; j < p->clist->n_values; j++) {
                 p1 = (unsigned char *)buf + size * p->clist->value[j];

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -225,7 +225,6 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 
             /* restrict to start and end col ? */
             for (j = 0; j < p->clist->n_values; j++) {
-                memcpy(p1, p2, size);
                 p1 = (unsigned char *)buf + size * p->clist->value[j];
                 p2 = (unsigned char *)tmpbuf + size * p->clist->value[j];
 

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -123,9 +123,9 @@ struct R_vrt *Rast_get_vrt(const char *vname, const char *vmapset)
 
                 if (rd_window->proj == PROJECTION_LL) {
                     while (east > p->cellhd.east)
-                        east -= 360;
+                        east -= 360.0;
                     while (east < p->cellhd.west)
-                        east += 360;
+                        east += 360.0;
                 }
                 if (east >= p->cellhd.west && east < p->cellhd.east)
                     G_ilist_add(p->clist, col);
@@ -205,28 +205,12 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 #pragma omp critical(raster_vrt_read)
     for (i = 0; i < vrt->tlist->n_values; i++) {
         struct tileinfo *p = &ti[vrt->tlist->value[i]];
-        double tile_west, tile_east;
-
-        tile_west = p->cellhd.west;
-        tile_east = p->cellhd.east;
-
-        if (R__.rd_window.proj == PROJECTION_LL) {
-            /* longitude wrapping of the tile into the current
-             * reading window */
-            while (tile_west > rd_window->east) {
-                tile_west -= 360.0;
-                tile_east -= 360.0;
-            }
-            while (tile_east < rd_window->west) {
-                tile_west += 360.0;
-                tile_east += 360.0;
-            }
-        }
 
         /* open the tile only if it overlaps with the current reading
          * row and the current reading EW extents */
         if (p->cellhd.north > rows && p->cellhd.south <= rown &&
-            tile_west < p->cellhd.east && tile_east > p->cellhd.west) {
+            p->cellhd.west < rd_window->east &&
+            p->cellhd.east > rd_window->west) {
             int tfd;
             void *p1, *p2;
 

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -18,7 +18,7 @@
 
 #include "R.h"
 
-int cmp_wnd(const void *a, const void *b)
+static int cmp_wnd(const void *a, const void *b)
 {
     struct Cell_head *cellhda = &((struct tileinfo *)a)->cellhd;
     struct Cell_head *cellhdb = &((struct tileinfo *)b)->cellhd;
@@ -225,24 +225,11 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 
             /* restrict to start and end col ? */
             for (j = 0; j < p->clist->n_values; j++) {
+                memcpy(p1, p2, size);
                 p1 = (unsigned char *)buf + size * p->clist->value[j];
                 p2 = (unsigned char *)tmpbuf + size * p->clist->value[j];
 
-                if (!Rast_is_null_value(p2, data_type)) {
-                    switch (data_type) {
-                    case CELL_TYPE:
-                        *(CELL *)p1 = *(CELL *)p2;
-                        break;
-                    case FCELL_TYPE:
-                        *(FCELL *)p1 = *(FCELL *)p2;
-                        break;
-                    case DCELL_TYPE:
-                        *(DCELL *)p1 = *(DCELL *)p2;
-                        break;
-                    default:
-                        break;
-                    }
-                }
+                memcpy(p1, p2, size);
             }
             have_tile = 1;
         }

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -228,7 +228,9 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
                 p1 = (unsigned char *)buf + size * p->clist->value[j];
                 p2 = (unsigned char *)tmpbuf + size * p->clist->value[j];
 
-                memcpy(p1, p2, size);
+                if (!Rast_is_null_value(p2, data_type)) {
+                    memcpy(p1, p2, size);
+                }
             }
             have_tile = 1;
         }


### PR DESCRIPTION
If there is a large GRASS vrt raster with many tiles and only a small region needs to be read, vrt tiles outside the current reading region should be ignored. This reduces disk IO and avoids unnecessary opening and closing of many files.