### PR TITLE
build: Add gui scripts to ALL_MODULES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,15 +284,16 @@ set(ALL_SUBDIRS
 foreach(d ${ALL_SUBDIRS})
   add_subdirectory(${d})
 endforeach()
+
+if(WITH_GUI)
+  add_subdirectory(gui)
+endif()
+
 add_custom_target(
   ALL_MODULES
   DEPENDS ${modules_list}
   COMMENT "Building all modules.")
 set_target_properties(ALL_MODULES PROPERTIES FOLDER Misc)
-
-if(WITH_GUI)
-  add_subdirectory(gui)
-endif()
 
 if(WITH_DOCS)
   add_subdirectory(doc)


### PR DESCRIPTION
This PR adds GUI scripts `d.rast3d` and `d.wms` to the `ALL_MODULES` target, so their batch files (even Python scripts for Linux, I think) can be generated.