### PR TITLE
build: Remove grep warning about stray backslash before white space

### DIFF
--- a/cmake/modules/build_addon.cmake
+++ b/cmake/modules/build_addon.cmake
@@ -53,7 +53,7 @@ if(WIN32)
 else()
   set(null_device /dev/null)
   set(search_command grep -v)
-  set(html_search_str "\'</body>\|</html>\|</div> <!-- end container -->\'")
+  set(html_search_str "'</body>\|</html>\|</div>.<!--.end.container.-->'")
   set(sep ":")
 endif()
 

--- a/cmake/modules/generate_docs.cmake
+++ b/cmake/modules/generate_docs.cmake
@@ -106,7 +106,7 @@ function(generate_docs name)
     set(py "")
     set(null_device /dev/null)
     set(search_cmd grep -v)
-    set(html_search_str "\'</body>\|</html>\|</div> <!-- end container -->\'")
+    set(html_search_str "'</body>\|</html>\|</div>.<!--.end.container.-->'")
   endif()
 
   if(D_HTML_DESCR)


### PR DESCRIPTION
This PR removes `grep: warning: stray \ before white space` by replacing spaces with dots (hopefully, acceptable; also consistent with `findstr` expression). CMake breaks and merges string pieces in a **shell-safe** way, adding a backslash before a white space, causing these warnings.

The previous `grep` command became:
```bash
grep -v '</body>\|</html>\|</div>\ <!--\ end\ container\ -->'
```