### PR TITLE
v.patch: increase the buffer for column names

### DIFF
--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -622,10 +622,10 @@ int copy_records(dbDriver *driver_in, dbString *table_name_in,
     db_init_string(&sql);
 
     if (colnames && *colnames) {
-        if (strlen(colnames) + strlen("select  from ") >= DB_SQL_MAX) {
+        if (snprintf(tmpbuf, sizeof(tmpbuf), "select %s from ", colnames) >=
+            sizeof(tmpbuf)) {
             G_fatal_error(_("Too many columns to copy records"));
         }
-        snprintf(tmpbuf, sizeof(tmpbuf), "select %s from ", colnames);
     }
     else
         snprintf(tmpbuf, sizeof(tmpbuf), "select * from ");

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     int keycol = -1;
     int maxcat = 0;
     int out_is_3d = WITHOUT_Z;
-    char colnames[4096];
+    char colnames[DB_SQL_MAX];
     double snap = -1;
 
     G_gisinit(argv[0]);
@@ -239,7 +239,11 @@ int main(int argc, char *argv[])
 
                         snprintf(tmpbuf, sizeof(tmpbuf), ",%s",
                                  db_get_column_name(column_out));
-                        strcat(colnames, tmpbuf);
+                        if (strlen(colnames) + strlen(tmpbuf) >= DB_SQL_MAX) {
+                            G_fatal_error(
+                                _("Too many columns to copy the table"));
+                        }
+                        G_strlcat(colnames, tmpbuf, DB_SQL_MAX);
                     }
                 }
             }
@@ -612,13 +616,17 @@ int copy_records(dbDriver *driver_in, dbString *table_name_in,
     dbCursor cursor;
     dbString value_str, sql;
     dbTable *table_in;
-    char tmpbuf[4096];
+    char tmpbuf[DB_SQL_MAX];
 
     db_init_string(&value_str);
     db_init_string(&sql);
 
-    if (colnames && *colnames)
+    if (colnames && *colnames) {
+        if (strlen(colnames) + strlen("select  from ") >= DB_SQL_MAX) {
+            G_fatal_error(_("Too many columns to copy records"));
+        }
         snprintf(tmpbuf, sizeof(tmpbuf), "select %s from ", colnames);
+    }
     else
         snprintf(tmpbuf, sizeof(tmpbuf), "select * from ");
     db_set_string(&sql, tmpbuf);

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -623,7 +623,7 @@ int copy_records(dbDriver *driver_in, dbString *table_name_in,
 
     if (colnames && *colnames) {
         if (snprintf(tmpbuf, sizeof(tmpbuf), "select %s from ", colnames) >=
-            sizeof(tmpbuf)) {
+            (int)sizeof(tmpbuf)) {
             G_fatal_error(_("Too many columns to copy records"));
         }
     }

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -239,11 +239,11 @@ int main(int argc, char *argv[])
 
                         snprintf(tmpbuf, sizeof(tmpbuf), ",%s",
                                  db_get_column_name(column_out));
-                        if (strlen(colnames) + strlen(tmpbuf) >= DB_SQL_MAX) {
+                        if (G_strlcat(colnames, tmpbuf, sizeof(colnames)) >=
+                            sizeof(colnames)) {
                             G_fatal_error(
                                 _("Too many columns to copy the table"));
                         }
-                        G_strlcat(colnames, tmpbuf, DB_SQL_MAX);
                     }
                 }
             }


### PR DESCRIPTION
Currently, `v.patch -e` fails with an overflow error if the input tables contain many columns whose names are concatenated longer than 4096 characters. This PR increases the limit to DB_SQL_MAX = 65536 and adds tests to avoid buffer overflow.