### PR TITLE
doc: Move grass.tools to second tab for tools

### DIFF
--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -63,18 +63,18 @@ void G__usage_markdown(void)
     /* short version */
     fprintf(stdout, "\n=== \"Command line\"\n\n");
     G__md_print_cli_short_version(stdout, tab_indent);
-    fprintf(stdout, "\n=== \"Python (grass.script)\"\n\n");
-    G__md_print_python_short_version(stdout, tab_indent, false);
     fprintf(stdout, "\n=== \"Python (grass.tools)\"\n\n");
     G__md_print_python_short_version(stdout, tab_indent, true);
+    fprintf(stdout, "\n=== \"Python (grass.script)\"\n\n");
+    G__md_print_python_short_version(stdout, tab_indent, false);
 
     fprintf(stdout, "\n## %s\n", _("Parameters"));
 
     /* long version */
     fprintf(stdout, "\n=== \"Command line\"\n\n");
     G__md_print_cli_long_version(stdout, tab_indent);
-    fprintf(stdout, "\n=== \"Python (grass.script)\"\n\n");
-    G__md_print_python_long_version(stdout, tab_indent, false);
     fprintf(stdout, "\n=== \"Python (grass.tools)\"\n\n");
     G__md_print_python_long_version(stdout, tab_indent, true);
+    fprintf(stdout, "\n=== \"Python (grass.script)\"\n\n");
+    G__md_print_python_long_version(stdout, tab_indent, false);
 }


### PR DESCRIPTION
Move the grass.tools tab before the grass.script tab in the documentation of individual tools. This presents grass.tools as the primary and grass.script as the secondary API similarly to how the Python intro presents that.

Command line tab still stays first which, at this point, fits also with the page title (which is the dotted name, not the snake_case name).

<img width="900" height="746" alt="image" src="https://github.com/user-attachments/assets/6e6fa435-4bee-4b8e-ae51-d885c5e259b8" />
