### PR TITLE
docs: add doxygen 'since' tag for API added with 8.5

### DIFF
--- a/lib/external/parson/gjson.c
+++ b/lib/external/parson/gjson.c
@@ -1,3 +1,11 @@
+/*!
+  \file lib/external/parson/gjson.c
+
+  \brief GRASS JSON Library
+
+  \since 8.5
+*/
+
 /*****************************************************************************
  *
  * MODULE:       GRASS json output interface
@@ -18,39 +26,48 @@
 #include "gjson.h"
 #include "parson.h"
 
+/// \since version 8.5
 typedef struct json_object_t G_json_object_t;
+/// \since version 8.5
 typedef struct json_array_t G_json_array_t;
+/// \since version 8.5
 typedef struct json_value_t G_json_value_t;
 
 /* *************************************************************** */
 /* ***** WRAPPER FOR PARSON FUNCTIONS USED IN GRASS ************** */
 /* *************************************************************** */
 
+/// \since version 8.5
 G_JSON_Value *G_json_value_init_object(void)
 {
     return (G_JSON_Value *)json_value_init_object();
 }
 
+/// \since version 8.5
 G_JSON_Value *G_json_value_init_array(void)
 {
     return (G_JSON_Value *)json_value_init_array();
 }
 
+/// \since version 8.5
 G_JSON_Value_Type G_json_value_get_type(const G_JSON_Value *value)
 {
     return json_value_get_type((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 G_JSON_Object *G_json_value_get_object(const G_JSON_Value *value)
 {
     return (G_JSON_Object *)json_value_get_object((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 G_JSON_Object *G_json_object(const G_JSON_Value *value)
 {
     return (G_JSON_Object *)json_object((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 G_JSON_Object *G_json_object_get_object(const G_JSON_Object *object,
                                         const char *name)
 {
@@ -58,6 +75,7 @@ G_JSON_Object *G_json_object_get_object(const G_JSON_Object *object,
                                                    name);
 }
 
+/// \since version 8.5
 G_JSON_Array *G_json_object_get_array(const G_JSON_Object *object,
                                       const char *name)
 {
@@ -65,6 +83,7 @@ G_JSON_Array *G_json_object_get_array(const G_JSON_Object *object,
                                                  name);
 }
 
+/// \since version 8.5
 G_JSON_Value *G_json_object_get_value(const G_JSON_Object *object,
                                       const char *name)
 {
@@ -72,154 +91,187 @@ G_JSON_Value *G_json_object_get_value(const G_JSON_Object *object,
                                                  name);
 }
 
+/// \since version 8.5
 const char *G_json_object_get_string(const G_JSON_Object *object,
                                      const char *name)
 {
     return json_object_get_string((const JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 double G_json_object_get_number(const G_JSON_Object *object, const char *name)
 {
     return json_object_get_number((const JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 int G_json_object_get_boolean(const G_JSON_Object *object, const char *name)
 {
     return json_object_get_boolean((const JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 G_JSON_Value *G_json_object_get_wrapping_value(const G_JSON_Object *object)
 {
     return (G_JSON_Value *)json_object_get_wrapping_value(
         (const JSON_Object *)object);
 }
+
+/// \since version 8.5
 G_JSON_Status G_json_object_set_value(G_JSON_Object *object, const char *name,
                                       G_JSON_Value *value)
 {
     return json_object_set_value((JSON_Object *)object, name,
                                  (JSON_Value *)value);
 }
+
+/// \since version 8.5
 G_JSON_Status G_json_object_set_string(G_JSON_Object *object, const char *name,
                                        const char *string)
 {
     return json_object_set_string((JSON_Object *)object, name, string);
 }
+
+/// \since version 8.5
 G_JSON_Status G_json_object_set_number(G_JSON_Object *object, const char *name,
                                        double number)
 {
     return json_object_set_number((JSON_Object *)object, name, number);
 }
+
+/// \since version 8.5
 G_JSON_Status G_json_object_set_boolean(G_JSON_Object *object, const char *name,
                                         int boolean)
 {
     return json_object_set_boolean((JSON_Object *)object, name, boolean);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_object_set_null(G_JSON_Object *object, const char *name)
 {
     return json_object_set_null((JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_object_dotset_string(G_JSON_Object *object,
                                           const char *name, const char *string)
 {
     return json_object_dotset_string((JSON_Object *)object, name, string);
 }
 
+/// \since version 8.5
 const char *G_json_object_dotget_string(G_JSON_Object *object, const char *name)
 {
     return json_object_dotget_string((JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_object_dotset_number(G_JSON_Object *object,
                                           const char *name, double number)
 {
     return json_object_dotset_number((JSON_Object *)object, name, number);
 }
 
+/// \since version 8.5
 double G_json_object_dotget_number(G_JSON_Object *object, const char *name)
 {
     return json_object_dotget_number((JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_object_dotset_null(G_JSON_Object *object, const char *name)
 {
     return json_object_dotset_null((JSON_Object *)object, name);
 }
 
+/// \since version 8.5
 G_JSON_Array *G_json_array(const G_JSON_Value *value)
 {
     return (G_JSON_Array *)json_array((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 G_JSON_Value *G_json_array_get_value(const G_JSON_Array *array, size_t index)
 {
     return (G_JSON_Value *)json_array_get_value((const JSON_Array *)array,
                                                 index);
 }
 
+/// \since version 8.5
 const char *G_json_array_get_string(const G_JSON_Array *array, size_t index)
 {
     return json_array_get_string((const JSON_Array *)array, index);
 }
 
+/// \since version 8.5
 double G_json_array_get_number(const G_JSON_Array *array, size_t index)
 {
     return json_array_get_number((const JSON_Array *)array, index);
 }
 
+/// \since version 8.5
 int G_json_array_get_boolean(const G_JSON_Array *array, size_t index)
 {
     return json_array_get_boolean((const JSON_Array *)array, index);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_array_append_value(G_JSON_Array *array,
                                         G_JSON_Value *value)
 {
     return json_array_append_value((JSON_Array *)array, (JSON_Value *)value);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_array_append_string(G_JSON_Array *array,
                                          const char *string)
 {
     return json_array_append_string((JSON_Array *)array, string);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_array_append_number(G_JSON_Array *array, double number)
 {
     return json_array_append_number((JSON_Array *)array, number);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_array_append_boolean(G_JSON_Array *array, int boolean)
 {
     return json_array_append_boolean((JSON_Array *)array, boolean);
 }
 
+/// \since version 8.5
 G_JSON_Status G_json_array_append_null(G_JSON_Array *array)
 {
     return json_array_append_null((JSON_Array *)array);
 }
 
+/// \since version 8.5
 void G_json_set_float_serialization_format(const char *format)
 {
     json_set_float_serialization_format(format);
 }
 
+/// \since version 8.5
 char *G_json_serialize_to_string_pretty(const G_JSON_Value *value)
 {
     return json_serialize_to_string_pretty((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 char *G_json_serialize_to_string(const G_JSON_Value *value)
 {
     return json_serialize_to_string((const JSON_Value *)value);
 }
 
+/// \since version 8.5
 void G_json_free_serialized_string(char *string)
 {
     json_free_serialized_string(string);
 }
 
+/// \since version 8.5
 void G_json_value_free(G_JSON_Value *value)
 {
     json_value_free((JSON_Value *)value);

--- a/lib/gis/color_str.c
+++ b/lib/gis/color_str.c
@@ -164,6 +164,8 @@ int G_str_to_color(const char *str, int *red, int *grn, int *blu)
    \param[out] h pointer to store the calculated hue
    \param[out] s pointer to store the calculated saturation
    \param[out] v pointer to store the calculated value
+
+   \since version 8.5
  */
 void G_rgb_to_hsv(int r, int g, int b, float *h, float *s, float *v)
 {
@@ -206,6 +208,8 @@ void G_rgb_to_hsv(int r, int g, int b, float *h, float *s, float *v)
    \param b blue component of RGB color
    \param clr_frmt color format to be used (RGB, HEX, HSV, TRIPLET).
    \param[out] str color string
+
+   \since version 8.5
  */
 void G_color_to_str(int r, int g, int b, ColorFormat clr_frmt, char *str)
 {
@@ -250,6 +254,8 @@ void G_color_to_str(int r, int g, int b, ColorFormat clr_frmt, char *str)
    \param option pointer to color format option
 
    \return allocated ColorFormat
+
+   \since version 8.5
  */
 ColorFormat G_option_to_color_format(const struct Option *option)
 {

--- a/lib/gis/omp_threads.c
+++ b/lib/gis/omp_threads.c
@@ -20,6 +20,8 @@
 
     \param opt A nprocs Option struct to specify the number of threads
     \return the number of threads set up for OpenMP parallel computing
+
+    \since version 8.5
 */
 int G_set_omp_num_threads(struct Option *opt)
 {

--- a/lib/gis/strlcat.c
+++ b/lib/gis/strlcat.c
@@ -53,6 +53,8 @@ static size_t G__strlcat(char *restrict dst, const char *restrict src,
  *         created (the initial length of dst plus the length of src, not
  *         including the terminating NUL character). If the return value
  *         is >= dsize, truncation occurred.
+ *
+ * \since version 8.5
  */
 size_t G_strlcat(char *dst, const char *src, size_t dsize)
 {

--- a/lib/gis/strlcpy.c
+++ b/lib/gis/strlcpy.c
@@ -48,6 +48,8 @@ static size_t G__strlcpy(char *restrict dst, const char *restrict src,
  *
  * \warning The src string must be a valid NUL-terminated C string. Passing an
  *          unterminated string may result in buffer overrun.
+ *
+ * \since version 8.5
  */
 size_t G_strlcpy(char *dst, const char *src, size_t dsize)
 {

--- a/lib/raster/json_color_out.c
+++ b/lib/raster/json_color_out.c
@@ -93,6 +93,8 @@ static void write_json_rule(DCELL *val, DCELL *min, DCELL *max, int r, int g,
    \param fp file where to print color table rules
    \param perc TRUE for percentage output
    \param clr_frmt color format to be used (RBG, HEX, HSV, TRIPLET).
+
+   \since version 8.5
  */
 void Rast_print_json_colors(struct Colors *colors, DCELL min, DCELL max,
                             FILE *fp, int perc, ColorFormat clr_frmt)

--- a/lib/raster/mask_info.c
+++ b/lib/raster/mask_info.c
@@ -73,6 +73,8 @@ char *Rast_mask_info(void)
  * G_free() when it is no longer needed.
  *
  * @returns A dynamically allocated string containing the mask name.
+ *
+ * @since version 8.5
  */
 char *Rast_mask_name(void)
 {
@@ -134,6 +136,8 @@ static bool Rast__get_present_mask(char *name, char *mapset)
  * @param[out] reclass_mapset Name of the mapset the reclassified raster is in
  *
  * @return true if mask is present, false otherwise
+ *
+ * @since version 8.5
  */
 bool Rast_mask_status(char *name, char *mapset, bool *is_mask_reclass,
                       char reclass_name[GNAME_MAX],
@@ -194,6 +198,8 @@ int Rast__mask_info(char *name, char *mapset)
  * @brief Check presence of 2D raster mask
  *
  * @return true if mask is present, false otherwise
+ *
+ * @since version 8.5
  */
 bool Rast_mask_is_present(void)
 {
@@ -210,6 +216,8 @@ bool Rast_mask_is_present(void)
  *
  * \param nprocs number of threads to use
  * \return number of threads in use
+ *
+ * \since version 8.5
  */
 int Rast_disable_omp_on_mask(int nprocs)
 {


### PR DESCRIPTION
Add doxygen `\since` tag for API added with 8.5.
This helps, in particular, by addon development and backporting of new code.


New API:

- Rast_disable_omp_on_mask (#5731)
- Rast_mask_is_present (#4402)
- Rast_mask_name (#4531)
- Rast_mask_status (#2390)
- Rast_print_json_colors (#4665)
- G_color_to_str (#5822)
- G_json_{*} (#4801)
- G_option_to_color_format (#5822)
- G_rgb_to_hsv (#5011)
- G_set_omp_num_threads (#3929)
- G_strlcat (#4304)
- G_strlcpy (#4101)

