### PR TITLE
r.out.vtk: Replace dead WMS server in Spearfish RGB example

### DIFF
--- a/raster/r.out.vtk/r.out.vtk.html
+++ b/raster/r.out.vtk/r.out.vtk.html
@@ -97,7 +97,8 @@ paraview --data=/tmp/out.vtk
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
 # using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
+r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry \
+         mapserver=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi \
          output=wms_global_mosaic
 
 # export the data to VTK

--- a/raster/r.out.vtk/r.out.vtk.md
+++ b/raster/r.out.vtk/r.out.vtk.md
@@ -100,7 +100,8 @@ paraview --data=/tmp/out.vtk
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
 # using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
+r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry \
+         mapserver=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi \
          output=wms_global_mosaic
 
 # export the data to VTK


### PR DESCRIPTION
## What changed

`raster/r.out.vtk/r.out.vtk.md` and `raster/r.out.vtk/r.out.vtk.html` (kept in sync per the docs convention): updated the "Spearfish example with RGB data" so it doesn't point at a dead WMS server.

- Old: `r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi`
- New: `r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry mapserver=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi`

Closes #4844

## Why

The original example was added when JPL's WMS endpoint at `wms.jpl.nasa.gov` was online. That host stopped resolving some years back (`curl http://wms.jpl.nasa.gov/wms.cgi --max-time 10` now exits 6 / DNS failure), so anyone copy-pasting the example hits a hard error before they ever reach `r.out.vtk`.

NASA GIBS publishes a long-running WMS at `gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi` and recommends it for `r.in.wms`-style consumers. I pulled the layer name `BlueMarble_ShadedRelief_Bathymetry` straight from the live `GetCapabilities` response on that endpoint, which serves the same kind of global RGB satellite coverage the old `global_mosaic` layer did. That keeps the rest of the example (the `r.out.vtk rgbmaps=…` step and the Paraview notes) meaningful for a user who just walked through the Spearfish region setup.

The Spearfish region (`g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p`) is unchanged. `r.in.wms` reprojects from the WMS's EPSG:4326 service into the Spearfish UTM zone the same way it would have for the JPL endpoint.

## Verification

- `curl -s -o /dev/null -w '%{http_code}' "https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi"` -> `200`.
- `GetCapabilities` against the same endpoint includes `<Name>BlueMarble_ShadedRelief_Bathymetry</Name>` (alongside `BlueMarble_ShadedRelief` and `BlueMarble_NextGeneration`).
- Old endpoint: `curl http://wms.jpl.nasa.gov/wms.cgi --max-time 10` returns exit 6 / DNS failure.
- I do not have a built GRASS environment on this machine to run the full `r.in.wms` -> `r.out.vtk` pipeline end-to-end. The change is text-only inside the example block of an existing tool's docs, so the failure mode (URL still dead, layer name still wrong) is the previous state, not a regression. Happy to follow up with screenshots once the change is reviewed.
