### PR TITLE
init: Windows does not have HOME environment variable; restrict old_mac_dir to MACOS

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -394,7 +394,9 @@ def create_grass_config_dir() -> str:
                 )
         # TODO: remove with next major or minor release after GRASS 8.5 (8.6 or 9.0)
         if MACOS:
-            old_mac_dir = os.path.join(os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}")
+            old_mac_dir = os.path.join(
+                os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}"
+            )
             if Path(old_mac_dir).is_dir():
                 try:
                     shutil.copy(os.path.join(old_mac_dir, "rc"), directory)

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -393,14 +393,15 @@ def create_grass_config_dir() -> str:
                     ).format(directory, e.strerror)
                 )
         # TODO: remove with next major or minor release after GRASS 8.5 (8.6 or 9.0)
-        old_mac_dir = os.path.join(os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}")
-        if MACOS and Path(old_mac_dir).is_dir():
-            try:
-                shutil.copy(os.path.join(old_mac_dir, "rc"), directory)
-                shutil.copy(os.path.join(old_mac_dir, "wx.json"), directory)
-                shutil.copytree(os.path.join(old_mac_dir, "toolboxes"), directory)
-            except Exception:
-                pass
+        if MACOS:
+            old_mac_dir = os.path.join(os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}")
+            if Path(old_mac_dir).is_dir():
+                try:
+                    shutil.copy(os.path.join(old_mac_dir, "rc"), directory)
+                    shutil.copy(os.path.join(old_mac_dir, "wx.json"), directory)
+                    shutil.copytree(os.path.join(old_mac_dir, "toolboxes"), directory)
+                except Exception:
+                    pass
 
     return directory
 


### PR DESCRIPTION
This PR fixes the following error on a fresh startup in Windows:
```
(grass) C:\Users\hcho>grass --version
-C:\Users\hcho\AppData\Roaming\GRASS8--
Traceback (most recent call last):
  File "C:\Users\hcho\opt\micromamba\envs\grass\Library\bin\\..\lib\grass85\etc\grass_main.py", line 2535, in <module>
    main()
    ~~~~^^
  File "C:\Users\hcho\opt\micromamba\envs\grass\Library\bin\\..\lib\grass85\etc\grass_main.py", line 2205, in main
    grass_config_dir = create_grass_config_dir()
  File "C:\Users\hcho\opt\micromamba\envs\grass\Library\bin\\..\lib\grass85\etc\grass_main.py", line 397, in create_grass_config_dir
    old_mac_dir = os.path.join(os.getenv("HOME"), f".grass{GRASS_VERSION_MAJOR}")
  File "<frozen ntpath>", line 100, in join
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
Windows does not have `HOME` and `old_mac_dir` should only be evaluated for `MACOS`.