### PR TITLE
configure: update PDAL compilation test

### DIFF
--- a/configure
+++ b/configure
@@ -710,7 +710,6 @@ NETCDF_CFLAGS
 NETCDF_LIBS
 NETCDF_CONFIG
 USE_PDAL
-PDAL_INC
 PDAL_CPPFLAGS
 PDAL_LIBS
 USE_LIBLAS
@@ -10578,15 +10577,15 @@ printf "%s\n" "yes" >&6; }
     as_fn_error $? "*** Unable to locate PDAL package." "$LINENO" 5
   fi
 
-  PDAL_LIBS=`${PKG_CONFIG} --libs "${pdal}"`
-  PDAL_INC=`${PKG_CONFIG} --cflags "${pdal}"`
+  PDAL_LIBS=`pdal-config --libs`
+  PDAL_CPPFLAGS=`pdal-config --cxxflags`
   USE_PDAL=1
 
   PDAL=
   ac_save_libs="$LIBS"
   ac_save_cflags="$CFLAGS"
   LIBS="$LIBS $PDAL_LIBS"
-  CFLAGS="$CFLAGS $PDAL_CFLAGS"
+  CPPFLAGS="$CPPFLAGS $PDAL_CPPFLAGS"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -10620,7 +10619,6 @@ printf "%s\n" "#define HAVE_PDAL 1" >>confdefs.h
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
 fi
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1060,15 +1060,15 @@ else
     AC_MSG_ERROR([*** Unable to locate PDAL package.])
   fi
 
-  PDAL_LIBS=`${PKG_CONFIG} --libs "${pdal}"`
-  PDAL_INC=`${PKG_CONFIG} --cflags "${pdal}"`
+  PDAL_LIBS=`pdal-config --libs`
+  PDAL_CPPFLAGS=`pdal-config --cxxflags`
   USE_PDAL=1
 
   PDAL=
   ac_save_libs="$LIBS"
   ac_save_cflags="$CFLAGS"
   LIBS="$LIBS $PDAL_LIBS"
-  CFLAGS="$CFLAGS $PDAL_CFLAGS"
+  CPPFLAGS="$CPPFLAGS $PDAL_CPPFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
   #include <pdal/Streamable.hpp>
   class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],
@@ -1084,7 +1084,6 @@ fi
 
 AC_SUBST(PDAL_LIBS)
 AC_SUBST(PDAL_CPPFLAGS)
-AC_SUBST(PDAL_INC)
 AC_SUBST(USE_PDAL)
 
 AC_LANG_POP(C++)


### PR DESCRIPTION
WIP

With Fedora 45 the autoconf based PDAL test fails (both in G85 and `main`).

Fedora 45 ships:
- PDAL-libs-2.10.1-2.fc45.x86_64
- PDAL-devel-2.10.1-2.fc45.x86_64

This PR correctly retrieves the PDAL-related CPP flags and uses them for the configure test.

Note that there are still undeclared definitions, see:

```sh
configure:10554: checking whether to use PDAL
configure:10573: result: yes
configure:10603: g++ -std=gnu++11 -o conftest -g -Wall  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wl,--no-undefined -Wl,-z,now -Wl,--export-dynamic conftest.cpp  -L/usr/lib -lpdalcpp >&5
In file included from /usr/include/pdal/pdal_types.hpp:49,
                 from /usr/include/pdal/pdal_internal.hpp:42,
                 from /usr/include/pdal/SpatialReference.hpp:37,
                 from /usr/include/pdal/PointTable.hpp:41,
                 from conftest.cpp:59:
/usr/include/pdal/util/Utils.hpp:979:31: error: 'std::enable_if_t' has not been declared
  979 |     template<typename T, std::enable_if_t<!std::is_integral<T>::value>* = nullptr>
      |                               ^~~~~~~~~~~
/usr/include/pdal/util/Utils.hpp:979:31: note: 'std::enable_if_t' is only available from C++14 onwards
/usr/include/pdal/util/Utils.hpp:979:42: error: expected '>' before '<' token
  979 |     template<typename T, std::enable_if_t<!std::is_integral<T>::value>* = nullptr>

[...]
```

Might the reason be `-std=gnu++11`?

Edits of this PR are welcome.