### PR TITLE
CI: use parallel make whenever possible

### DIFF
--- a/.github/workflows/build_ubuntu-22.04.sh
+++ b/.github/workflows/build_ubuntu-22.04.sh
@@ -19,10 +19,10 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
+makecmd="make -j$(nproc)"
 if [[ "$#" -ge 2 ]]; then
     ARGS=("$@")
-    makecmd="make CFLAGS='$CFLAGS ${ARGS[@]:1}' CXXFLAGS='$CXXFLAGS ${ARGS[@]:1}'"
+    makecmd="make -j$(nproc) CFLAGS='$CFLAGS ${ARGS[@]:1}' CXXFLAGS='$CXXFLAGS ${ARGS[@]:1}'"
 fi
 
 # non-existent variables as an errors
@@ -53,4 +53,4 @@ export INSTALL_PREFIX=$1
     --with-zstd
 
 eval $makecmd
-make install
+make -j$(nproc) install

--- a/.github/workflows/build_ubuntu-22.04_without_x.sh
+++ b/.github/workflows/build_ubuntu-22.04_without_x.sh
@@ -19,9 +19,9 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
+makecmd="make -j$(nproc)"
 if [[ "$#" -eq 2 ]]; then
-    makecmd="make CFLAGS='$CFLAGS $2' CXXFLAGS='$CXXFLAGS $2'"
+    makecmd="make -j$(nproc) CFLAGS='$CFLAGS $2' CXXFLAGS='$CXXFLAGS $2'"
 fi
 
 # non-existent variables as an errors
@@ -51,4 +51,4 @@ export INSTALL_PREFIX=$1
     --without-pthread
 
 eval $makecmd
-make install
+make -j$(nproc) install

--- a/.github/workflows/build_ubuntu-24.04.sh
+++ b/.github/workflows/build_ubuntu-24.04.sh
@@ -19,10 +19,10 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
+makecmd="make -j$(nproc)"
 if [[ "$#" -ge 2 ]]; then
     ARGS=("$@")
-    makecmd="make CFLAGS='$CFLAGS ${ARGS[@]:1}' CXXFLAGS='$CXXFLAGS ${ARGS[@]:1}'"
+    makecmd="make -j$(nproc) CFLAGS='$CFLAGS ${ARGS[@]:1}' CXXFLAGS='$CXXFLAGS ${ARGS[@]:1}'"
 fi
 
 # non-existent variables as an errors
@@ -53,4 +53,4 @@ export INSTALL_PREFIX=$1
     --with-zstd
 
 eval $makecmd
-make install
+make -j$(nproc) install

--- a/.github/workflows/build_ubuntu-24.04_without_x.sh
+++ b/.github/workflows/build_ubuntu-24.04_without_x.sh
@@ -19,9 +19,9 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
+makecmd="make -j$(nproc)"
 if [[ "$#" -eq 2 ]]; then
-    makecmd="make CFLAGS='$CFLAGS $2' CXXFLAGS='$CXXFLAGS $2'"
+    makecmd="make -j$(nproc) CFLAGS='$CFLAGS $2' CXXFLAGS='$CXXFLAGS $2'"
 fi
 
 # non-existent variables as an errors
@@ -51,4 +51,4 @@ export INSTALL_PREFIX=$1
     --without-pthread
 
 eval $makecmd
-make install
+make -j$(nproc) install

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -140,8 +140,8 @@ jobs:
             --with-sqlite \
             --with-tiff \
             --with-zstd
-          make
-          make install
+          make -j"$(nproc)"
+          make -j"$(nproc)" install
 
       - name: Add the bin directory to PATH
         run: |
@@ -157,7 +157,7 @@ jobs:
       - name: Build Programmer's Manual with doxygen
         run: |
           cd grass
-          make htmldocs
+          make -j"$(nproc)" htmldocs
 
       - name: Make the doxygen results available (html)
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -237,7 +237,7 @@ jobs:
         run: |
           pip install -r "grass/python/grass/docs/requirements.txt"
           cd grass || exit
-          make sphinxdoclib
+          make -j"$(nproc)" sphinxdoclib
           ARCH="$(grass --config arch)"
           mv -v dist."${ARCH}/docs/html/libpython" "${MKDOCS_DIR}/site"
 

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -45,7 +45,7 @@ jobs:
           mkdir "${HOME}/install"
       - name: Ensure one core for compilation
         run: |
-          echo "MAKEFLAGS=-j1" >> "${GITHUB_ENV}"
+          echo "MAKEFLAGS=-j$(nproc)" >> "${GITHUB_ENV}"
       - name: Set LD_LIBRARY_PATH for compilation
         run: |
           echo "LD_LIBRARY_PATH=${HOME}/install/lib" >> "${GITHUB_ENV}"


### PR DESCRIPTION
This PR introduces where missing `make -j$(nproc)` to make use of the multi-core runners, see <https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories>

For ubuntu based runners, it is at present 4 Processor (CPU).

Hence, running CI time should be significantly cut.