### PR TITLE
doc: change documentation site name to include only major and minor version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -228,7 +228,7 @@ jobs:
           cd grass || exit
           eval "$(./utils/update_version.py status --bash)"
           cd ..
-          export SITE_NAME="GRASS $VERSION Documentation"
+          export SITE_NAME="GRASS ${MAJOR}.${MINOR} Documentation"
           export COPYRIGHT="&copy; 2003-$YEAR GRASS Development Team, GRASS $VERSION Documentation"
           cd "${MKDOCS_DIR}" || exit
           mkdocs build


### PR DESCRIPTION
Since documentation is built from the branch and not tag, we end up with "8.5.1dev" in the title for stable:
<img width="1201" height="304" alt="image" src="https://github.com/user-attachments/assets/80fa739d-d74b-49fb-9905-12fa6225e380" />

Only showing major.minor will look less confusing:
<img width="1201" height="304" alt="image" src="https://github.com/user-attachments/assets/1c8add8f-b51b-4a67-b57e-61476830573e" />

