### PR TITLE
gui(vnet): Fix for Wrong name for an argument in a call

### DIFF
--- a/gui/wxpython/vnet/vnet_core.py
+++ b/gui/wxpython/vnet/vnet_core.py
@@ -527,7 +527,8 @@ class VNETAnalyses:
                     GetNearestNodeCat(
                         e=coor[0],
                         n=coor[1],
-                        field=int(params["turn_cat_layer"], tresh=params["max_dist"]),
+                        layer=int(params["turn_cat_layer"]),
+                        tresh=params["max_dist"],
                         vectMap=params["input"],
                     )
                 )


### PR DESCRIPTION
My description: typo where the closing parentheses of int() spanned two arguments instead of only wrapping one.

Generated AI PR text in my fork was:

> The fix is to correct the keyword arguments in the `GetNearestNodeCat` call so they match that function’s expected parameter names, while preserving behavior.
> 
> Best fix in this snippet:
> - In `gui/wxpython/vnet/vnet_core.py`, inside `_runTurnsAn`, replace the malformed call:
>   - remove `field=...` (unsupported),
>   - remove `tresh=...` from inside `int(...)` (invalid),
>   - pass `layer=int(params["turn_cat_layer"])` and `tresh=params["max_dist"]` directly to `GetNearestNodeCat`.
> - Keep existing logic intact otherwise.
> 
> No new imports, methods, or dependencies are needed.
> 
> 
> _Suggested fixes powered by Copilot Autofix. Review carefully before merging._