### PR TITLE
gui(vdigit): Fix for Wrong number of arguments in a call of stub class

### DIFF
--- a/gui/wxpython/vdigit/main.py
+++ b/gui/wxpython/vdigit/main.py
@@ -25,7 +25,7 @@ except (ImportError, NameError) as err:
     GV_LINES = -1
 
     class IVDigit:
-        def __init__(self):
+        def __init__(self, giface, mapwindow):
             pass
 
 


### PR DESCRIPTION
If we look at the stub class created as a fallback just above in that small file, we clearly see that calling `__init__` with more arguments than the stub won’t work. So add the extra arguments.

---
Generated PR text:
To fix this without changing behavior, make the fallback `IVDigit` constructor accept the same arguments as the primary implementation usage in `VDigit.__init__`.

Best single fix:
- **File:** `gui/wxpython/vdigit/main.py`
- **Region:** fallback class in the `except` block (lines 27–29 in snippet)
- Change:
  - from `def __init__(self):`
  - to `def __init__(self, giface, mapwindow):`
- Keep body as `pass` (stub behavior unchanged).
- No new imports or dependencies are needed.

This preserves existing functionality while removing the argument-count runtime hazard and satisfying the static analysis rule.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._