### PR TITLE
grass.pygrass.vector: Fix for Wrong number of arguments in a call to update_odict

### DIFF
--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -218,7 +218,7 @@ class Columns:
 
     def __setitem__(self, name, new_type):
         self.cast(name, new_type)
-        self.update_odict(self)
+        self.update_odict()
 
     def __iter__(self):
         return self.odict.__iter__()


### PR DESCRIPTION
If you look at all the usages of the update_odict function, there is only one place where it is called with arguments. All other places are without arguments. Adding `self` here is wrong.

Removing the extra `self`.

---
The fix is to call `update_odict` with the correct arity, consistent with its other usage in the same class.

Best fix (no functional change): in `python/grass/pygrass/vector/table.py`, within `Columns.__setitem__`, replace:
- `self.update_odict(self)`
with:
- `self.update_odict()`

No new imports, helper methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._