### PR TITLE
build: Skip PROJ version check on cross-compilation

### DIFF
--- a/configure
+++ b/configure
@@ -9299,7 +9299,7 @@ proj_version="$proj_ver_major.$proj_ver_minor.$proj_ver_patch"
 if test "$(expr "$proj_ver_major" \>= 9)" = 1; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using PROJ version \"${proj_version}\"" >&5
 printf "%s\n" "using PROJ version \"${proj_version}\"" >&6; }
-else
+elif test "$cross_compiling" != "yes" ; then
   as_fn_error $? "*** PROJ version 9.0.0 or newer is required (found version \"${proj_version}\")" "$LINENO" 5
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -765,7 +765,7 @@ proj_version="$proj_ver_major.$proj_ver_minor.$proj_ver_patch"
 
 if test "$(expr "$proj_ver_major" \>= 9)" = 1; then
   AC_MSG_RESULT([using PROJ version "${proj_version}"])
-else
+elif test "$cross_compiling" != "yes" ; then
   AC_MSG_ERROR([*** PROJ version 9.0.0 or newer is required (found version "${proj_version}")])
 fi
 


### PR DESCRIPTION
This PR skips the PROJ version check when cross-compiling because we cannot run the test program.