### PR TITLE
build: Skip GDAL version check on cross-compilation

### DIFF
--- a/configure
+++ b/configure
@@ -10345,7 +10345,7 @@ CPPFLAGS=$ac_save_cppflags
       test "$(expr "$gdal_version_minor" \>= 7)" = 1; then
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using GDAL version \"${gdal_version}\"" >&5
 printf "%s\n" "using GDAL version \"${gdal_version}\"" >&6; }
-  else
+  elif test "$cross_compiling" != "yes" ; then
       as_fn_error $? "*** GDAL version 3.7 or newer is required (found version \"${gdal_version}\")" "$LINENO" 5
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -963,7 +963,7 @@ else
   if test "$(expr "$gdal_version_major" \>= 3)" = 1 && \
       test "$(expr "$gdal_version_minor" \>= 7)" = 1; then
       AC_MSG_RESULT([using GDAL version "${gdal_version}"])
-  else
+  elif test "$cross_compiling" != "yes" ; then
       AC_MSG_ERROR([*** GDAL version 3.7 or newer is required (found version "${gdal_version}")])
   fi
 


### PR DESCRIPTION
This PR skips the GDAL version check when cross-compiling because we cannot run the test program.