### PR TITLE
r.out.vtk: Replace dead WMS server in RGB example

### DIFF
--- a/raster/r.out.vtk/r.out.vtk.html
+++ b/raster/r.out.vtk/r.out.vtk.html
@@ -96,12 +96,13 @@ paraview --data=/tmp/out.vtk
 #set the region
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
-# using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
-         output=wms_global_mosaic
+# using r.in.wms to fetch RGB satellite imagery from NASA GIBS
+r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry \
+         url=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi \
+         output=wms_blue_marble
 
 # export the data to VTK
-r.out.vtk rgbmaps=wms_global_mosaic.red,wms_global_mosaic.green,wms_global_mosaic.blue \
+r.out.vtk rgbmaps=wms_blue_marble.red,wms_blue_marble.green,wms_blue_marble.blue \
           elevation=elevation.10m output=/tmp/out.vtk
 
 # visualize in Paraview or other VTK viewer:

--- a/raster/r.out.vtk/r.out.vtk.md
+++ b/raster/r.out.vtk/r.out.vtk.md
@@ -99,12 +99,13 @@ paraview --data=/tmp/out.vtk
 #set the region
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
-# using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
-         output=wms_global_mosaic
+# using r.in.wms to fetch RGB satellite imagery from NASA GIBS
+r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry \
+         url=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi \
+         output=wms_blue_marble
 
 # export the data to VTK
-r.out.vtk rgbmaps=wms_global_mosaic.red,wms_global_mosaic.green,wms_global_mosaic.blue \
+r.out.vtk rgbmaps=wms_blue_marble.red,wms_blue_marble.green,wms_blue_marble.blue \
           elevation=elevation.10m output=/tmp/out.vtk
 
 # visualize in Paraview or other VTK viewer:


### PR DESCRIPTION
## Description

The Spearfish RGB example in `r.out.vtk.{md,html}` points at `http://wms.jpl.nasa.gov/wms.cgi` with layer `global_mosaic`. That host stopped serving years ago, so the example no longer runs.

This PR swaps in the NASA GIBS WMS endpoint and a permanent layer, and updates the `r.in.wms` invocation from the old `mapserver=` parameter to the current `url=` parameter:

```diff
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
-         output=wms_global_mosaic
+r.in.wms layers=BlueMarble_ShadedRelief_Bathymetry \
+         url=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi \
+         output=wms_blue_marble
```

The downstream `r.out.vtk rgbmaps=...` line is updated to match the new output base name. Same change applied to both `r.out.vtk.md` and `r.out.vtk.html` (kept in sync per `AGENTS.md`).

## Motivation and context

Fixes #4844.

## How has this been tested?

- Confirmed the old URL is unreachable (`curl` timeout).
- Confirmed the new endpoint returns HTTP 200 and that `BlueMarble_ShadedRelief_Bathymetry` is present in the GIBS WMS `GetCapabilities` response.
- Confirmed `url=` is the current `r.in.wms` parameter name by reading `scripts/r.in.wms/r.in.wms.py`.
- **Did not** run the example end-to-end — would need an installed GRASS plus the Spearfish sample dataset, which I don't have set up locally. Happy to redo with a screenshot if a reviewer can spot-check.

## Screenshots (if appropriate)

None — see the testing caveat above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md) of this project.
- [x] My change requires a change to the documentation. _(this **is** a docs change)_
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. _(N/A — docs only)_

AI-assisted by Claude Code.