### PR TITLE
style: Fix flake8 E501 in man/build_md.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,7 +22,6 @@ per-file-ignores =
     # F821 undefined name 'unicode'
     # E741 ambiguous variable name 'l'
     man/build_html.py: E501
-    man/build_md.py: E501
     doc/examples/python/m.distance.py: E501
     gui/scripts/d.wms.py: E501
     gui/wxpython/image2target/g.gui.image2target.py: E501

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -31,7 +31,7 @@ desc1_tmpl = string.Template(
 modclass_intro_tmpl = string.Template(
     r"""# ${modclass} tools
 
-To learn more about these tool in general, go to [${modclass} introduction](${modclass_lower}intro.md).
+To learn more, see the [${modclass} introduction](${modclass_lower}intro.md).
 """
 )
 


### PR DESCRIPTION
## Description

`man/build_md.py` had one long line (a string template) and a corresponding `man/build_md.py: E501` entry in `.flake8`. Reword the long line so it fits in 88 columns, then drop the per-file-ignore.

```diff
- To learn more about these tool in general, go to [${modclass} introduction](${modclass_lower}intro.md).
+ To learn more, see the [${modclass} introduction](${modclass_lower}intro.md).
```

The new text is semantically equivalent (and incidentally fixes the "these tool" -> singular grammar slip).

## Motivation and context

One of the cleanups invited by #1522.

## How has this been tested?

`python3 -m flake8 man/build_md.py` exits 0 with the per-file-ignore removed. The other `man/build_md.py: E501` candidates I looked at (`build_html.py`, `m.distance.py`, `r.semantic.label.py`, `python/grass/jupyter/__init__.py`) all hit either GRASS parser directive lines (`# % description:` that g.parser reads as a single line) or URLs inside ReST docstrings -- those cases are intentionally what `# noqa`-style ignores exist for, so I left their entries alone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

AI-assisted by Claude Code.