### PR TITLE
gui: Add keyboard shortcuts to history browser tree

### DIFF
--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -185,6 +185,8 @@ class HistoryBrowserTree(CTreeView):
         self.itemActivated.connect(self.OnDoubleClick)
         self.contextMenu.connect(self.OnRightClick)
 
+        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
+
     def _resetSelectVariables(self):
         """Reset variables related to item selection."""
         self.selected_day = []
@@ -645,6 +647,34 @@ class HistoryBrowserTree(CTreeView):
             self._popupMenuCommand()
         else:
             self._popupMenuEmpty()
+
+    def OnKeyDown(self, event):
+        """Handle keyboard shortcuts for copying and deleting history entries."""
+        keycode = event.GetKeyCode()
+        control_down = event.ControlDown()
+
+        # Check if anything is selected
+        selected = self.GetSelected()
+        if not selected:
+            event.Skip()
+            return
+
+        # Check if a command node is selected (we don't want to allow copying/deleting day nodes)
+        node = selected[0]
+        if node.data.get("type") != COMMAND:
+            event.Skip()
+            return
+
+        # Ctrl+C -> Copy command to clipboard
+        if control_down and keycode == ord("C"):
+            self.OnCopyCmd(None)
+
+        # Ctrl+D or Delete key -> Remove command from history
+        elif (control_down and keycode == ord("D")) or keycode == wx.WXK_DELETE:
+            self.OnRemoveCmd(None)
+
+        else:
+            event.Skip()
 
     def OnDoubleClick(self, node):
         """Double click on item/node.

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -659,8 +659,14 @@ class HistoryBrowserTree(CTreeView):
             event.Skip()
             return
 
-        # Check if a command node is selected (we don't want to allow copying/deleting day nodes)
         node = selected[0]
+
+        # Map Enter / Return key to the same action as double-clicking the item
+        if keycode in {wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER}:
+            self.OnDoubleClick(node)
+            return
+
+        # Check if a command node is selected (we don't want to allow copying/deleting day nodes)
         if node.data.get("type") != COMMAND:
             event.Skip()
             return


### PR DESCRIPTION
## Description

This Pull Request implements the requested keyboard shortcuts for the history browser tree, improving accessibility and overall user experience. Users who prefer using the keyboard over context menus can now manage their command history much faster.

### Key Changes
* Added **Ctrl + C** shortcut to copy the selected command to the clipboard.
* Added **Ctrl + D** and the **Delete** key shortcuts to remove the selected command from the history log.
* Added **Enter** and **Return** key shortcuts (including the numpad) to mimic the double-click behavior.
* Added safety checks to ensure these shortcuts only trigger on command nodes (`COMMAND`), preventing accidental modification or deletion of day/time period header nodes (`TIME_PERIOD`).

## Related PRs / Issues

* Follow-up enhancement suggested in **#4927** (specifically addressing the request for accessible keyboard shortcuts like `Ctrl+C` and `Ctrl+D`).

## How to Test

1. Open the History tab in the GRASS GUI.
2. Select any successfully executed command.
3. Press `Ctrl + C` and try pasting it into a text editor to verify it was copied.
4. Press `Delete` or `Ctrl + D` on a command, confirm the dialog, and verify it was removed.
5. Try pressing these keys on a date header (e.g., "Today") and verify that nothing happens.