### PR TITLE
gui: Display EPSG codes in tooltips for Data Catalog locations

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -197,6 +197,30 @@ class DataCatalogNode(DictFilterNode):
 
         return result
 
+    def _get_epsg_code(self):
+        """Attempt to extract EPSG code using g.proj -g"""
+        if not self.parent or "name" not in self.parent.data:
+            return None
+
+        db_path = self.parent.data["name"]
+        loc_name = self.data["name"]
+
+        # Create temporary GISRC to read projection information without affecting global state
+        tmp_gisrc, env = gs.create_environment(db_path, loc_name, "PERMANENT")
+        env["GRASS_SKIP_MAPSET_OWNER_CHECK"] = "1"
+
+        # Use g.proj -g to get projection information in a parseable format
+        proj_info = gs.read_command("g.proj", flags="g", env=env, quiet=True)
+        gs.try_remove(tmp_gisrc)
+
+        if proj_info:
+            # Look for EPSG code in the output using regex
+            match = re.search(r"srid=EPSG:(\d+)", proj_info, re.IGNORECASE)
+            if match:
+                return match.group(1)
+
+        return None
+
     @property
     def label(self):
         data = self.data
@@ -340,6 +364,7 @@ class DataCatalogTree(TreeView):
         self.startEdit.connect(self.OnStartEditLabel)
         self.endEdit.connect(self.OnEditLabel)
         self.EnableWatchingMapset()
+        self.Bind(wx.EVT_TREE_ITEM_GETTOOLTIP, self.OnItemToolTip)
 
     def _resetSelectVariables(self):
         """Reset variables related to item selection."""
@@ -1058,6 +1083,31 @@ class DataCatalogTree(TreeView):
             else:
                 font.SetWeight(wx.FONTWEIGHT_NORMAL)
         return font
+
+    def OnItemToolTip(self, event):
+        """Fetch and display EPSG code natively when requested by the OS."""
+        item = event.GetItem()
+        if not item.IsOk():
+            event.Skip()
+            return
+
+        # Extract row text directly to handle virtualization mapping safely
+        item_text = self.GetItemText(item)
+
+        # Query the tree model for the location node matching the row text
+        nodes = self._model.SearchNodes(name=item_text, type="location")
+        if nodes:
+            node = nodes[0]
+            # Fetch EPSG code on-demand and cache it to eliminate duplicate disk reads
+            if "epsg" not in node.data:
+                node.data["epsg"] = node._get_epsg_code()
+
+            if node.data["epsg"]:
+                tip_text = _("EPSG:{epsg}").format(epsg=node.data["epsg"])
+                event.SetToolTip(tip_text)
+                return
+
+        event.Skip()
 
     def ExpandCurrentMapset(self):
         """Expand current mapset"""


### PR DESCRIPTION
## Description

This PR enhances the Data Catalog tree view by providing immediate spatial context to users. It displays the EPSG code via a native tooltip when hovering over a georeferenced project (location).

### Technical Details

* **Native Extraction:** Uses `g.proj -g` inside a temporary isolated environment (`gs.create_environment`).
* **Lazy Caching:** The EPSG code is fetched once and cached in the node's internal data dictionary (`data["epsg"]`), ensuring that tree sorting and filtering remain instantaneous.
* **Fallback:** Safely returns `None` for unreferenced locations (like `XY`), rendering them without any extra markup.
* **On-Demand Execution:** The projection lookup is triggered exclusively by the `wx.EVT_TREE_ITEM_GETTOOLTIP` event. This ensures the heavy `g.proj` call only happens when the user actively hovers over a location, preventing any latency during application startup or tree initialization.

## How to Test

1. Open the Data Catalog panel in the GRASS main window.
2. ​Hover the mouse cursor over any georeferenced project (location) name.
3. ​Verify that a native tooltip appears after a short delay showing EPSG:XXXX.
4. ​Verify that the tree interface remains responsive and that no errors are triggered in the console during hover.

## Visuals
![IMG_20260526_215722_944.jpg](https://github.com/user-attachments/assets/9a177baf-5f2f-48bb-af64-0f7d3a5994bd)

