### PR TITLE
cmake: check presence of FFTW for i.zc and r.surf.fractal

### DIFF
--- a/imagery/CMakeLists.txt
+++ b/imagery/CMakeLists.txt
@@ -34,8 +34,11 @@ set(imagery_modules_list
     i.smap
     i.target
     i.topo.corr
-    i.vi
-    i.zc)
+    i.vi)
+
+if(WITH_FFTW)
+  list(APPEND imagery_modules_list i.zc)
+endif()
 
 if(WITH_LIBSVM)
   build_program_in_subdir(
@@ -220,14 +223,18 @@ build_program_in_subdir(
 build_program_in_subdir(i.vi DEPENDS grass_imagery grass_raster grass_vector
                         grass_gis ${LIBM})
 
-build_program_in_subdir(
-  i.zc
-  DEPENDS
-  grass_imagery
-  grass_raster
-  grass_vector
-  grass_gis
-  grass_gmath)
+if(WITH_FFTW)
+  build_program_in_subdir(
+    i.zc
+    DEPENDS
+    grass_imagery
+    grass_raster
+    grass_vector
+    grass_gis
+    grass_gmath)
+else()
+  message(STATUS "i.zc disabled because FFTW is not available")
+endif()
 
 build_program_in_subdir(
   i.fft

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -105,7 +105,6 @@ set(raster_modules_list
     r.support.stats
     r.surf.area
     r.surf.contour
-    r.surf.fractal
     r.surf.gauss
     r.surf.idw
     r.surf.random
@@ -133,6 +132,10 @@ set(raster_modules_list
 
 if(WITH_LIBPNG)
   list(APPEND raster_modules_list r.in.png r.out.png)
+endif()
+
+if(WITH_FFTW)
+  list(APPEND raster_modules_list r.surf.fractal)
 endif()
 
 if(MSVC)
@@ -618,8 +621,12 @@ build_program_in_subdir(r.surf.area DEPENDS grass_gis grass_raster ${LIBM})
 
 build_program_in_subdir(r.surf.contour DEPENDS grass_gis grass_raster)
 
-build_program_in_subdir(r.surf.fractal DEPENDS grass_gis grass_raster
-                        grass_gmath ${LIBM})
+if(WITH_FFTW)
+  build_program_in_subdir(r.surf.fractal DEPENDS grass_gis grass_raster
+    grass_gmath ${LIBM})
+else()
+  message(STATUS "r.surf.fractal disabled because FFTW is not available")
+endif()
 
 build_program_in_subdir(r.surf.gauss DEPENDS grass_gis grass_raster grass_gmath)
 


### PR DESCRIPTION
Both `i.zc` and `r.surf.fractal` depend of GRASS' gmath library functions with FFTW dependency.

(If it were direct dependency, adding FFTW to PRIMARY_DEPENDS would have been enough, but cannot be used as it also would link to FFTW.)

Closes #7446 and #7447.