### PR TITLE
cmake: build MySQL driver with server variant

### DIFF
--- a/db/drivers/CMakeLists.txt
+++ b/db/drivers/CMakeLists.txt
@@ -18,7 +18,7 @@ set(dbf_SRCS
 set(mysql_SRCS
     mysql/create_table.c
     mysql/cursor.c
-    mysql/dbe.c
+    mysql/db.c
     mysql/describe.c
     mysql/driver.c
     mysql/error.c


### PR DESCRIPTION
Build MySQL driver with CMake against standard MySQL/MariaDB server (not an embedded version).

This should be sufficient to fix the build as reported with #7450.

For the future, we should consider to remove the [MySQL Embedded Driver](https://github.com/OSGeo/grass/blob/main/db/drivers/mysql/grass-mesql.md), as @echoix [correctly noted](https://github.com/OSGeo/grass/issues/7450#issuecomment-4587589254) embedded MySQL is deprecated for a long time.


Closes #7450