### PR TITLE
CI: Add automated SPDX SBOM generation workflow for releases

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,38 @@
+---
+name: Generate and Publish SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@v0
+        id: sbom
+        with:
+          path: .
+          format: spdx-json
+          output-file: grass-sbom.spdx.json
+
+      - name: Upload SBOM as Run Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: grass-release-sbom
+          path: grass-sbom.spdx.json
+          retention-days: 90
+
+      - name: Attach SBOM to GitHub Release Assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: grass-sbom.spdx.json


### PR DESCRIPTION
Closes #7215

### Proposed Changes
- Adds `./workflows/sbom.yml` to handle software asset inventory.
- Implements **Anchore `sbom-action`** to systematically package dependencies into an industry-standard **SPDX-JSON** file format.
- Automated generation triggers cleanly upon any new official tag/release being published.
- Attaches the resulting `grass-sbom.spdx.json` artifact directly into the release distribution assets for seamless user download alongside binaries.
- Includes `workflow_dispatch` access for dry-run validation profiles.

### Acceptance Criteria Addressed
- [x] Automated generation on release milestones
- [x] Conforms to SPDX ecosystem specifications 
- [x] Accessible alongside official delivery assets