### PR TITLE
CI: Updated include path for OSGeo4W cairo 1.18

### DIFF
--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -40,7 +40,7 @@ CXXFLAGS="$CXXFLAGS -pipe" \
     --with-blas \
     --with-bzlib \
     --with-cairo \
-    --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
+    --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include/cairo \
     --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo" \
     --with-cairo-libs=${OSGEO4W_ROOT_MSYS}/lib \
     --with-cxx \

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -136,7 +136,7 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-blas \
 		--with-bzlib \
 		--with-cairo \
-		--with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
+		--with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include/cairo \
 		--with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo" \
 		--with-cairo-libs=${OSGEO4W_ROOT_MSYS}/lib \
 		--with-cxx \


### PR DESCRIPTION
Fixed Windows OSGeo4W build by updating `--with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include` to `--with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include/cairo`.

The change is from OSGeo4W migrating its cairo package to Meson and bumped it to 1.18.4 (jef-n/OSGeo4W@c3b8830).