### PR TITLE
v.voronoi: fix skeleton creation

### DIFF
--- a/vector/v.voronoi/skeleton.c
+++ b/vector/v.voronoi/skeleton.c
@@ -513,8 +513,12 @@ int tie_up(void)
         /* find area for this node */
         area = Vect_find_area(&In, x, y);
 
-        if (area == 0)
-            G_fatal_error(_("Node is outside any input area"));
+        if (area == 0) {
+            /* the node can be exactly on a boundary which is fine,
+             * no tie-up needed */
+            G_debug(3, "Node is not completely inside any input area");
+            continue;
+        }
 
         /* get area outer ring */
         Vect_get_area_points(&In, area, Points);


### PR DESCRIPTION
With recent changes to vector libs, point-in-polygon calculations became more strict. A point exactly on a boundary can not be assigned to one specific area. For skeleton creation, points on boundaries are actually desired. This PR adjusts the test in `v.voronoi` when snapping skeleton nodes to an area's boundary. This affects also GRASS 8.5, thus backport is needed.