### PR TITLE
r.fillnulls: report the full list of unfilled holes

### DIFF
--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -669,14 +669,11 @@ def main():
     if len(failed_list) > 0:
         gs.warning(
             _(
-                "Following holes where not filled. Temporary maps with are left "
-                "in place to allow examination of unfilled holes"
+                "The following holes were not filled. Temporary maps are left "
+                "in place to allow examination of unfilled holes:"
             )
         )
-        outlist = failed_list[0]
-        for hole in failed_list[1:]:
-            outlist = ", " + outlist
-        gs.message(outlist)
+        gs.message(", ".join(failed_list))
 
     gs.message(_("Done."))
 


### PR DESCRIPTION
When `v.surf.rst` cannot fill some holes, r.fillnulls warns the user and is meant to list the unfilled holes so they can be examined. The list was built with a loop that never used the loop variable, so it only printed the first hole name with one leading comma per remaining hole.

For three unfilled holes the message printed `, , hole_3` instead of `hole_3, hole_7, hole_12`.

This replaces the loop with `", ".join(failed_list)` so every unfilled hole is reported, and fixes two typos in the adjacent warning (`where` to `were`, and a stray `with`).

```diff
-        outlist = failed_list[0]
-        for hole in failed_list[1:]:
-            outlist = ", " + outlist
-        gs.message(outlist)
+        gs.message(", ".join(failed_list))
```

The failure branch is only reached when `v.surf.rst` fails on specific holes, which is not deterministic to trigger, so this keeps the existing behavior otherwise and just fixes the reporting.
