### PR TITLE
docs: Replace GPL 2+ long text with SPDX License ID across core codebase

### DIFF
--- a/db/drivers/odbc/error.c
+++ b/db/drivers/odbc/error.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level driver error reporting function.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  *
  * \date 2000-2007

--- a/db/drivers/odbc/table.c
+++ b/db/drivers/odbc/table.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level drop table function.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author CERL
  * \author Radim Blazek
  *

--- a/db/drivers/ogr/cursor.c
+++ b/db/drivers/ogr/cursor.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/db.c
+++ b/db/drivers/ogr/db.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/driver.c
+++ b/db/drivers/ogr/driver.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/error.c
+++ b/db/drivers/ogr/error.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2011 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com> (2011/07)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com> (2011/07)
  */
 
 #include <stdlib.h>

--- a/db/drivers/ogr/fetch.c
+++ b/db/drivers/ogr/fetch.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/listtab.c
+++ b/db/drivers/ogr/listtab.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/ogr/select.c
+++ b/db/drivers/ogr/select.c
@@ -4,10 +4,8 @@
    \brief Low level OGR SQL driver
 
    (C) 2004-2009 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some updates by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/postgres/create_table.c
+++ b/db/drivers/postgres/create_table.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - create table
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <grass/dbmi.h>

--- a/db/drivers/postgres/cursor.c
+++ b/db/drivers/postgres/cursor.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - cursor manipulation
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 #include <stdio.h>
 #include <grass/gis.h>

--- a/db/drivers/postgres/db.c
+++ b/db/drivers/postgres/db.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - open/close database.
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Create/drop database by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/postgres/describe.c
+++ b/db/drivers/postgres/describe.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - describe table
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 #include <grass/dbmi.h>
 #include <grass/datetime.h>

--- a/db/drivers/postgres/error.c
+++ b/db/drivers/postgres/error.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - report errors
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdio.h>

--- a/db/drivers/postgres/fetch.c
+++ b/db/drivers/postgres/fetch.c
@@ -5,10 +5,8 @@
 
    \todo implement time zone handling
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/db/drivers/postgres/index.c
+++ b/db/drivers/postgres/index.c
@@ -5,10 +5,8 @@
 
    \todo implement time zone handling
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <grass/dbmi.h>

--- a/db/drivers/postgres/listdb.c
+++ b/db/drivers/postgres/listdb.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - list databases
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Updated for GRASS 7 by Martin Landa <landa.martin gmail.com>
  */
 

--- a/db/drivers/postgres/listtab.c
+++ b/db/drivers/postgres/listtab.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - list tables
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 #include <stdlib.h>
 #include <string.h>

--- a/db/drivers/postgres/parse.c
+++ b/db/drivers/postgres/parse.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - parse connection string
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/db/drivers/postgres/priv.c
+++ b/db/drivers/postgres/priv.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - privileges
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 #include <grass/dbmi.h>
 #include <grass/glocale.h>

--- a/db/drivers/postgres/select.c
+++ b/db/drivers/postgres/select.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level PostgreSQL database driver - select cursor
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/db/drivers/postgres/table.c
+++ b/db/drivers/postgres/table.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level drop table function.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Martin Landa <landa.martin gmail.com>
  *
  * \date 2015

--- a/db/drivers/sqlite/create_table.c
+++ b/db/drivers/sqlite/create_table.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite table creation.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -3,9 +3,8 @@
  *
  * \brief DBMI - Low Level SQLite database driver.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/describe.c
+++ b/db/drivers/sqlite/describe.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite database driver.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/fetch.c
+++ b/db/drivers/sqlite/fetch.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite database functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/index.c
+++ b/db/drivers/sqlite/index.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite database index functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/listdb.c
+++ b/db/drivers/sqlite/listdb.c
@@ -3,10 +3,8 @@
 
    \brief DBMI - Low Level SQLite database driver (list databases)
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author  Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author  Martin Landa <landa.martin gmail.com>
  */
 
 #include <dirent.h>

--- a/db/drivers/sqlite/listtab.c
+++ b/db/drivers/sqlite/listtab.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite table functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/select.c
+++ b/db/drivers/sqlite/select.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level SQLite database functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Support for multiple connections by Markus Metz
  *

--- a/db/drivers/sqlite/table.c
+++ b/db/drivers/sqlite/table.c
@@ -3,9 +3,8 @@
  *
  * \brief Low level drop table function.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Martin Landa <landa.martin gmail.com>
  *
  * \date 2015

--- a/imagery/i.segment/ngbrtree.c
+++ b/imagery/i.segment/ngbrtree.c
@@ -7,9 +7,8 @@
  *
  * (C) 2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author Julienne Walker 2003, 2008
  *         GRASS implementation Markus Metz, 2009
  */

--- a/imagery/i.segment/regtree.c
+++ b/imagery/i.segment/regtree.c
@@ -7,9 +7,8 @@
  *
  * (C) 2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author Julienne Walker 2003, 2008
  *         GRASS implementation Markus Metz, 2009
  */

--- a/lib/btree2/kdtree.c
+++ b/lib/btree2/kdtree.c
@@ -7,9 +7,8 @@
  *
  * (C) 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Markus Metz
  */
 

--- a/lib/btree2/kdtree.h
+++ b/lib/btree2/kdtree.h
@@ -10,9 +10,8 @@
  *
  * (C) 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Markus Metz
  *
  * \par References

--- a/lib/btree2/rbtree.c
+++ b/lib/btree2/rbtree.c
@@ -7,9 +7,8 @@
  *
  * (C) 2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author Julienne Walker 2003, 2008
  *         GRASS implementation Markus Metz, 2009
  */

--- a/lib/cairodriver/box.c
+++ b/lib/cairodriver/box.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/cairodriver.h
+++ b/lib/cairodriver/cairodriver.h
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/color.c
+++ b/lib/cairodriver/color.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/draw.c
+++ b/lib/cairodriver/draw.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen, Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/draw_bitmap.c
+++ b/lib/cairodriver/draw_bitmap.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/driver.c
+++ b/lib/cairodriver/driver.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/erase.c
+++ b/lib/cairodriver/erase.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008, 2011 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/line_width.c
+++ b/lib/cairodriver/line_width.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/raster.c
+++ b/lib/cairodriver/raster.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/read.c
+++ b/lib/cairodriver/read.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008, 2011 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/read_bmp.c
+++ b/lib/cairodriver/read_bmp.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/read_ppm.c
+++ b/lib/cairodriver/read_ppm.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008, 2011 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/set_window.c
+++ b/lib/cairodriver/set_window.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/text.c
+++ b/lib/cairodriver/text.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 #if defined(_MSC_VER)

--- a/lib/cairodriver/write.c
+++ b/lib/cairodriver/write.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/write_bmp.c
+++ b/lib/cairodriver/write_bmp.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cairodriver/write_ppm.c
+++ b/lib/cairodriver/write_ppm.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Lars Ahlzen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Lars Ahlzen <lars ahlzen.com> (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/cluster/c_assign.c
+++ b/lib/cluster/c_assign.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/cluster/c_begin.c
+++ b/lib/cluster/c_begin.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdlib.h>

--- a/lib/cluster/c_clear.c
+++ b/lib/cluster/c_clear.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_distinct.c
+++ b/lib/cluster/c_distinct.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_exec.c
+++ b/lib/cluster/c_exec.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_execmem.c
+++ b/lib/cluster/c_execmem.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_means.c
+++ b/lib/cluster/c_means.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/cluster/c_merge.c
+++ b/lib/cluster/c_merge.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_nclasses.c
+++ b/lib/cluster/c_nclasses.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_point.c
+++ b/lib/cluster/c_point.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/raster.h>

--- a/lib/cluster/c_reassign.c
+++ b/lib/cluster/c_reassign.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/cluster/c_reclass.c
+++ b/lib/cluster/c_reclass.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_sep.c
+++ b/lib/cluster/c_sep.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/cluster/c_sig.c
+++ b/lib/cluster/c_sig.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/cluster/c_sum2.c
+++ b/lib/cluster/c_sum2.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/cluster.h>

--- a/lib/db/dbmi_base/alloc.c
+++ b/lib/db/dbmi_base/alloc.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/case.c
+++ b/lib/db/dbmi_base/case.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/column.c
+++ b/lib/db/dbmi_base/column.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/columnfmt.c
+++ b/lib/db/dbmi_base/columnfmt.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/connect.c
+++ b/lib/db/dbmi_base/connect.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/datetime.c
+++ b/lib/db/dbmi_base/datetime.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/default_name.c
+++ b/lib/db/dbmi_base/default_name.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC)
    \author Upgraded to GRASS 5.7 by Radim Blazek
  */
 

--- a/lib/db/dbmi_base/dirent.c
+++ b/lib/db/dbmi_base/dirent.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC)
    \author Upgraded to GRASS 5.7 by Radim Blazek
  */
 

--- a/lib/db/dbmi_base/error.c
+++ b/lib/db/dbmi_base/error.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC)
    \author Upgraded to GRASS 5.7 by Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */

--- a/lib/db/dbmi_base/index.c
+++ b/lib/db/dbmi_base/index.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/interval.c
+++ b/lib/db/dbmi_base/interval.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/isdir.c
+++ b/lib/db/dbmi_base/isdir.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/legal_dbname.c
+++ b/lib/db/dbmi_base/legal_dbname.c
@@ -7,10 +7,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/ret_codes.c
+++ b/lib/db/dbmi_base/ret_codes.c
@@ -7,10 +7,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/sqlCtype.c
+++ b/lib/db/dbmi_base/sqlCtype.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/sqltype.c
+++ b/lib/db/dbmi_base/sqltype.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/string.c
+++ b/lib/db/dbmi_base/string.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC)
    \author Upgraded to GRASS 5.7 by Radim Blazek
  */
 

--- a/lib/db/dbmi_base/strip.c
+++ b/lib/db/dbmi_base/strip.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/table.c
+++ b/lib/db/dbmi_base/table.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/value.c
+++ b/lib/db/dbmi_base/value.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/valuefmt.c
+++ b/lib/db/dbmi_base/valuefmt.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/whoami.c
+++ b/lib/db/dbmi_base/whoami.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdr.c
+++ b/lib/db/dbmi_base/xdr.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrchar.c
+++ b/lib/db/dbmi_base/xdrchar.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrcolumn.c
+++ b/lib/db/dbmi_base/xdrcolumn.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrdatetime.c
+++ b/lib/db/dbmi_base/xdrdatetime.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrdouble.c
+++ b/lib/db/dbmi_base/xdrdouble.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrfloat.c
+++ b/lib/db/dbmi_base/xdrfloat.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrhandle.c
+++ b/lib/db/dbmi_base/xdrhandle.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrindex.c
+++ b/lib/db/dbmi_base/xdrindex.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrint.c
+++ b/lib/db/dbmi_base/xdrint.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrprocedure.c
+++ b/lib/db/dbmi_base/xdrprocedure.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrshort.c
+++ b/lib/db/dbmi_base/xdrshort.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrstring.c
+++ b/lib/db/dbmi_base/xdrstring.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrtable.c
+++ b/lib/db/dbmi_base/xdrtable.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrtoken.c
+++ b/lib/db/dbmi_base/xdrtoken.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/xdrvalue.c
+++ b/lib/db/dbmi_base/xdrvalue.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_base/zero.c
+++ b/lib/db/dbmi_base/zero.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Joel Jones (CERL/UIUC), Radim Blazek, Brad Douglas, Markus Neteler
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (2011)
  */
 

--- a/lib/db/dbmi_client/handler.c
+++ b/lib/db/dbmi_client/handler.c
@@ -5,10 +5,8 @@
 
    (C) 2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/gis.h>

--- a/lib/display/icon.c
+++ b/lib/display/icon.c
@@ -5,10 +5,8 @@
 
   (C) 2001-2008, 2012 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author USA-CERL
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author USA-CERL
 */
 
 #include <stdlib.h>

--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -5,10 +5,8 @@
 
   (C) 2001-2015 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author Original author CERL
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
   \author Monitors support by Martin Landa <landa.martin gmail.com>
 */
 

--- a/lib/display/raster.c
+++ b/lib/display/raster.c
@@ -5,10 +5,8 @@
 
   (C) 2006-2011 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author Glynn Clements <glynn gclements.plus.com> (original contributor)
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements <glynn gclements.plus.com> (original contributor)
   \author Huidae Cho <grass4u gmail.com>
 */
 

--- a/lib/display/setup.c
+++ b/lib/display/setup.c
@@ -5,10 +5,8 @@
 
   (C) 2006-2011 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author Glynn Clements <glynn gclements.plus.com> (original contributor)
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements <glynn gclements.plus.com> (original contributor)
   \author Huidae Cho <grass4u gmail.com>
 */
 

--- a/lib/driver/init.c
+++ b/lib/driver/init.c
@@ -5,10 +5,8 @@
 
   (C) 2006-2011 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author Glynn Clements <glynn gclements.plus.com> (original contributor)
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements <glynn gclements.plus.com> (original contributor)
   \author Huidae Cho <grass4u gmail.com>
 */
 

--- a/lib/driver/parse_ftcap.c
+++ b/lib/driver/parse_ftcap.c
@@ -5,10 +5,8 @@
 
   (C) 2006-2011 by the GRASS Development Team
 
-  This program is free software under the GNU General Public License
-  (>=v2). Read the file COPYING that comes with GRASS for details.
-
-  \author Glynn Clements <glynn gclements.plus.com> (original contributor)
+   SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements <glynn gclements.plus.com> (original contributor)
   \author Huidae Cho <grass4u gmail.com>
 */
 

--- a/lib/gis/adj_cellhd.c
+++ b/lib/gis/adj_cellhd.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/alloc.c
+++ b/lib/gis/alloc.c
@@ -5,9 +5,8 @@
  *
  * (C) 1999-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/aprintf.c
+++ b/lib/gis/aprintf.c
@@ -8,9 +8,8 @@
  *
  * (C) 2020 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Huidae Cho
  *
  * \date 2020

--- a/lib/gis/area.c
+++ b/lib/gis/area.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/area_ellipse.c
+++ b/lib/gis/area_ellipse.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/area_poly1.c
+++ b/lib/gis/area_poly1.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/area_poly2.c
+++ b/lib/gis/area_poly2.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/area_sphere.c
+++ b/lib/gis/area_sphere.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/ascii_chk.c
+++ b/lib/gis/ascii_chk.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/asprintf.c
+++ b/lib/gis/asprintf.c
@@ -11,9 +11,8 @@
  * (C) 2002-2014 by the GRASS Development Team
  * (C) 2010 by Glynn Clements
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- */
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 #define _GNU_SOURCE /* enable asprintf */
 #include <stdio.h>

--- a/lib/gis/basename.c
+++ b/lib/gis/basename.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  */
 

--- a/lib/gis/bres_line.c
+++ b/lib/gis/bres_line.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/commas.c
+++ b/lib/gis/commas.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/copy_dir.c
+++ b/lib/gis/copy_dir.c
@@ -7,9 +7,8 @@
  *
  * (C) 2008-2015 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Huidae Cho
  */
 

--- a/lib/gis/date.c
+++ b/lib/gis/date.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/debug.c
+++ b/lib/gis/debug.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2012 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  */
 

--- a/lib/gis/distance.c
+++ b/lib/gis/distance.c
@@ -9,10 +9,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/gis/done_msg.c
+++ b/lib/gis/done_msg.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/endian.c
+++ b/lib/gis/endian.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Markus Neteler
  */
 

--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2026 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Updated for GRASS7 by Glynn Clements
  */
 

--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/gis/find_rast3d.c
+++ b/lib/gis/find_rast3d.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   `  This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+   `   SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/find_vect.c
+++ b/lib/gis/find_vect.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/gis/geodist.c
+++ b/lib/gis/geodist.c
@@ -14,9 +14,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/get_ellipse.c
+++ b/lib/gis/get_ellipse.c
@@ -15,10 +15,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <unistd.h>

--- a/lib/gis/get_projinfo.c
+++ b/lib/gis/get_projinfo.c
@@ -5,9 +5,8 @@
 
    (C) 1999-2014 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
- */
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 #include <string.h>
 #include <errno.h>

--- a/lib/gis/get_window.c
+++ b/lib/gis/get_window.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdlib.h>

--- a/lib/gis/getl.c
+++ b/lib/gis/getl.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/gisinit.c
+++ b/lib/gis/gisinit.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author GRASS Development Team
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author GRASS Development Team
  */
 
 #include <stdio.h>

--- a/lib/gis/home.c
+++ b/lib/gis/home.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/is.c
+++ b/lib/gis/is.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2001-2014

--- a/lib/gis/key_value1.c
+++ b/lib/gis/key_value1.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <string.h>

--- a/lib/gis/key_value2.c
+++ b/lib/gis/key_value2.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/key_value3.c
+++ b/lib/gis/key_value3.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <errno.h>

--- a/lib/gis/legal_name.c
+++ b/lib/gis/legal_name.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009, 2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/list.c
+++ b/lib/gis/list.c
@@ -7,9 +7,8 @@
 
    (C) 2000, 2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
- */
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 #include <stdlib.h>
 #include <unistd.h>

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2004-2008

--- a/lib/gis/location.c
+++ b/lib/gis/location.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/gis/lrand48.c
+++ b/lib/gis/lrand48.c
@@ -5,9 +5,8 @@
  *
  * (C) 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  */
 

--- a/lib/gis/ls_filter.c
+++ b/lib/gis/ls_filter.c
@@ -5,9 +5,8 @@
  *
  * (C) 2010 by Glynn Clements and the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author Glynn Clements
  */
 

--- a/lib/gis/make_loc.c
+++ b/lib/gis/make_loc.c
@@ -8,9 +8,8 @@
  *
  * (C) 2000-2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Frank Warmerdam
  */
 

--- a/lib/gis/make_mapset.c
+++ b/lib/gis/make_mapset.c
@@ -6,9 +6,8 @@
  *
  * (C) 2006-2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Joel Pitt, joel.pitt@gmail.com
  */
 

--- a/lib/gis/mapset.c
+++ b/lib/gis/mapset.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -5,9 +5,8 @@
 
    (C) 1999-2014 The GRASS development team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
- */
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 #include <grass/config.h>
 #include <string.h>

--- a/lib/gis/mapset_nme.c
+++ b/lib/gis/mapset_nme.c
@@ -5,9 +5,8 @@
 
    (C) 1999-2014 The GRASS development team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
- */
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 #include <grass/config.h>
 #include <sys/types.h>

--- a/lib/gis/mkstemp.c
+++ b/lib/gis/mkstemp.c
@@ -5,9 +5,8 @@
  *
  * (C) 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  */
 

--- a/lib/gis/myname.c
+++ b/lib/gis/myname.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/nme_in_mps.c
+++ b/lib/gis/nme_in_mps.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/gis/overwrite.c
+++ b/lib/gis/overwrite.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2008, 2010 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team, Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -69,9 +69,8 @@
  *
  * (C) 2001-2015 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  * \author Soeren Gebbert added Dec. 2009 WPS process_description document
  */

--- a/lib/gis/parser_dependencies.c
+++ b/lib/gis/parser_dependencies.c
@@ -6,10 +6,8 @@
 
    (C) 2014-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements Jun. 2014
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements Jun. 2014
  */
 
 #include <stdarg.h>

--- a/lib/gis/parser_help.c
+++ b/lib/gis/parser_help.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Soeren Gebbert added Dec. 2009 WPS process_description document
  */
 

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2026 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/gis/parser_interface.c
+++ b/lib/gis/parser_interface.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  * \author Soeren Gebbert added Dec. 2009 WPS process_description document
  */

--- a/lib/gis/parser_json.c
+++ b/lib/gis/parser_json.c
@@ -6,10 +6,8 @@
 
    (C) 2018-2021 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Soeren Gebbert
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Soeren Gebbert
  */
 
 #include <stdio.h>

--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -5,10 +5,8 @@
 
    (C) 2012-2025 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa
    \author Vaclav Petras
  */
 #include <stdio.h>

--- a/lib/gis/parser_md_cli.c
+++ b/lib/gis/parser_md_cli.c
@@ -5,10 +5,8 @@
 
    (C) 2025 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Vaclav Petras
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Vaclav Petras
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/gis/parser_md_common.c
+++ b/lib/gis/parser_md_common.c
@@ -5,10 +5,8 @@
 
    (C) 2023-2025 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -5,10 +5,8 @@
 
    (C) 2025 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Vaclav Petras
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Vaclav Petras
  */
 #include <stdbool.h>
 #include <stdio.h>

--- a/lib/gis/parser_rest.c
+++ b/lib/gis/parser_rest.c
@@ -5,10 +5,8 @@
 
    (C) 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Luca Delucchi
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Luca Delucchi
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2019 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Soeren Gebbert added Dec. 2009 WPS process_description document
    \author Luca Delucchi added Aug 2011 G_OPT_M_DIR
  */

--- a/lib/gis/percent.c
+++ b/lib/gis/percent.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author GRASS Development Team
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author GRASS Development Team
  */
 
 #include <stdio.h>

--- a/lib/gis/plot.c
+++ b/lib/gis/plot.c
@@ -18,9 +18,8 @@
  *
  * (C) 2001-2008, 2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/pole_in_poly.c
+++ b/lib/gis/pole_in_poly.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/progrm_nme.c
+++ b/lib/gis/progrm_nme.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/proj1.c
+++ b/lib/gis/proj1.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/proj2.c
+++ b/lib/gis/proj2.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/proj3.c
+++ b/lib/gis/proj3.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2014 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 /* TODO: the G_database_*() functions should be renamed to G_location_*()

--- a/lib/gis/put_window.c
+++ b/lib/gis/put_window.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdlib.h>

--- a/lib/gis/putenv.c
+++ b/lib/gis/putenv.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Updated for GRASS7 by Glynn Clements
  */
 

--- a/lib/gis/radii.c
+++ b/lib/gis/radii.c
@@ -52,10 +52,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL
  */
 
 #include <math.h>

--- a/lib/gis/rd_cellhd.c
+++ b/lib/gis/rd_cellhd.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USACERL and others
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USACERL and others
  */
 
 #include <string.h>

--- a/lib/gis/remove.c
+++ b/lib/gis/remove.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/rename.c
+++ b/lib/gis/rename.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2015 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/rhumbline.c
+++ b/lib/gis/rhumbline.c
@@ -18,9 +18,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/seek.c
+++ b/lib/gis/seek.c
@@ -5,9 +5,8 @@
  *
  * (C) 2009-2010 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  */
 

--- a/lib/gis/set_window.c
+++ b/lib/gis/set_window.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/short_way.c
+++ b/lib/gis/short_way.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/snprintf.c
+++ b/lib/gis/snprintf.c
@@ -11,9 +11,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Markus Neteler
  *
  * \date 2006-2008

--- a/lib/gis/spawn.c
+++ b/lib/gis/spawn.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  *
  * \date 2004-2006

--- a/lib/gis/strings.c
+++ b/lib/gis/strings.c
@@ -7,10 +7,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Dave Gerdes (USACERL)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Dave Gerdes (USACERL)
    \author Michael Shapiro (USACERL)
    \author Amit Parghi (USACERL)
    \author Bernhard Reiter (Intevation GmbH, Germany) and many others

--- a/lib/gis/tempfile.c
+++ b/lib/gis/tempfile.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2015 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/timestamp.c
+++ b/lib/gis/timestamp.c
@@ -68,9 +68,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Michael Shapiro & Bill Brown, CERL
  * \author raster3d functions by Michael Pelizzari, LMCO
  * \author Soeren Gebbert, vector timestamp implementation update

--- a/lib/gis/token.c
+++ b/lib/gis/token.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2011-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USA CERL and others
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USA CERL and others
  */
 
 #include <stdlib.h>

--- a/lib/gis/trim_dec.c
+++ b/lib/gis/trim_dec.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/units.c
+++ b/lib/gis/units.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Adopted for libgis by Martin Landa <landa.martin gmail.com> (2010)
    \author Temporal units and unit type check from Soeren gebbert <soerengebbert
    googlemail.com> (2012)

--- a/lib/gis/user_config.c
+++ b/lib/gis/user_config.c
@@ -16,9 +16,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Eric G Miller - egm2 at jps net
  *
  * \date 2007-04-14

--- a/lib/gis/verbose.c
+++ b/lib/gis/verbose.c
@@ -16,9 +16,8 @@
  *
  * (C) 2001-2008, 2012-2013 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Jachym Cepicky - jachym.cepicky at gmail.com
  */
 

--- a/lib/gis/view.c
+++ b/lib/gis/view.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Bill Brown - US Army CERL
  *
  * \date 1992-2008

--- a/lib/gis/whoami.c
+++ b/lib/gis/whoami.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 #include <unistd.h>

--- a/lib/gis/wind_2_box.c
+++ b/lib/gis/wind_2_box.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/wind_format.c
+++ b/lib/gis/wind_format.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/wind_in.c
+++ b/lib/gis/wind_in.c
@@ -3,9 +3,8 @@
  *
  * \brief Point in region functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Hamish Bowman. (c) Hamish Bowman, and the GRASS Development Team
  *
  * \date February 2007

--- a/lib/gis/wind_limits.c
+++ b/lib/gis/wind_limits.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/wind_overlap.c
+++ b/lib/gis/wind_overlap.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/wind_scan.c
+++ b/lib/gis/wind_scan.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/gis/window_map.c
+++ b/lib/gis/window_map.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/gis/worker.c
+++ b/lib/gis/worker.c
@@ -5,9 +5,8 @@
  *
  * (C) 2008-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  */
 

--- a/lib/gis/wr_cellhd.c
+++ b/lib/gis/wr_cellhd.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/writ_zeros.c
+++ b/lib/gis/writ_zeros.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 1999-2014

--- a/lib/gis/xdr.c
+++ b/lib/gis/xdr.c
@@ -5,9 +5,8 @@
  *
  * (C) 2012-2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements
  */
 

--- a/lib/gis/zero.c
+++ b/lib/gis/zero.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/gis/zone.c
+++ b/lib/gis/zone.c
@@ -3,9 +3,8 @@
  *
  * \brief GIS Library - Cartographic zone functions.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/imagery/iclass.c
+++ b/lib/imagery/iclass.c
@@ -8,10 +8,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iclass_bands.c
+++ b/lib/imagery/iclass_bands.c
@@ -10,10 +10,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iclass_local_proto.h
+++ b/lib/imagery/iclass_local_proto.h
@@ -8,10 +8,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iclass_perimeter.c
+++ b/lib/imagery/iclass_perimeter.c
@@ -11,10 +11,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iclass_signatures.c
+++ b/lib/imagery/iclass_signatures.c
@@ -10,10 +10,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iclass_statistics.c
+++ b/lib/imagery/iclass_statistics.c
@@ -11,10 +11,8 @@
 
    Copyright (C) 1999-2007, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author David Satnik, Central Washington University (original author)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author David Satnik, Central Washington University (original author)
    \author Markus Neteler <neteler itc.it> (i.class module)
    \author Bernhard Reiter <bernhard intevation.de> (i.class module)
    \author Brad Douglas <rez touchofmadness.com>(i.class module)

--- a/lib/imagery/iscatt_core.c
+++ b/lib/imagery/iscatt_core.c
@@ -6,10 +6,8 @@
 
    Copyright (C) 2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Stepan Turek <stepan.turek@seznam.cz> (GSoC 2013, Mentor: Martin
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Stepan Turek <stepan.turek@seznam.cz> (GSoC 2013, Mentor: Martin
    Landa)
  */
 

--- a/lib/imagery/iscatt_structs.c
+++ b/lib/imagery/iscatt_structs.c
@@ -6,10 +6,8 @@
 
    Copyright (C) 2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Stepan Turek <stepan.turek@seznam.cz> (GSoC 2013, Mentor: Martin
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Stepan Turek <stepan.turek@seznam.cz> (GSoC 2013, Mentor: Martin
    Landa)
  */
 

--- a/lib/imagery/list_gp.c
+++ b/lib/imagery/list_gp.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USA CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USA CERL
  */
 
 #include <string.h>

--- a/lib/imagery/list_subgp.c
+++ b/lib/imagery/list_subgp.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008,2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USA CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USA CERL
  */
 
 #include <string.h>

--- a/lib/imagery/manage_signatures.c
+++ b/lib/imagery/manage_signatures.c
@@ -5,10 +5,8 @@
 
    (C) 2021 by Maris Nartiss and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Maris Nartiss
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Maris Nartiss
  */
 
 #include <unistd.h>

--- a/lib/imagery/sigfile.c
+++ b/lib/imagery/sigfile.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2008, 2013, 2021 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USA CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USA CERL
  */
 
 #include <string.h>

--- a/lib/imagery/sigsetfile.c
+++ b/lib/imagery/sigsetfile.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011, 2013, 2021 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author USA CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author USA CERL
  */
 
 #include <string.h>

--- a/lib/manage/add_elem.c
+++ b/lib/manage/add_elem.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/manage/do_copy.c
+++ b/lib/manage/do_copy.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/manage/do_list.c
+++ b/lib/manage/do_list.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/manage/do_remove.c
+++ b/lib/manage/do_remove.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/manage/do_rename.c
+++ b/lib/manage/do_rename.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/manage/empty.c
+++ b/lib/manage/empty.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 /* look for at least one file in the element */

--- a/lib/manage/find.c
+++ b/lib/manage/find.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/manage/get_len.c
+++ b/lib/manage/get_len.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/manage/list.c
+++ b/lib/manage/list.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/manage/option.c
+++ b/lib/manage/option.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/manage/read_list.c
+++ b/lib/manage/read_list.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/manage/show_elem.c
+++ b/lib/manage/show_elem.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/manage/sighold.c
+++ b/lib/manage/sighold.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <signal.h>

--- a/lib/nviz/change_view.c
+++ b/lib/nviz/change_view.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/change_view.c
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/cplanes_obj.c
+++ b/lib/nviz/cplanes_obj.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/cutplanes_obj.c
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/draw.c
+++ b/lib/nviz/draw.c
@@ -7,10 +7,8 @@
    visualization/nviz/src/togl_flythrough.c
 
    (C) 2008, 2010-2011 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010) \author Textures by Anna Kratochvilova
  */
 

--- a/lib/nviz/exag.c
+++ b/lib/nviz/exag.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/exag.c
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/lights.c
+++ b/lib/nviz/lights.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/lights.c
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/nviz.c
+++ b/lib/nviz/nviz.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/position.c
+++ b/lib/nviz/position.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/position.c
 
    (C) 2008, 2010 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
  */
 

--- a/lib/nviz/render.c
+++ b/lib/nviz/render.c
@@ -6,10 +6,8 @@
    Based on visualization/nviz/src/togl.c
 
    (C) 2008, 2010, 2018 by the GRASS Development Team
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Updated/modified by Martin Landa <landa.martin gmail.com> (Google SoC
            2008/2010)
    \author Support for framebuffer objects by Huidae Cho <grass4u gmail.com>
            (July 2018)

--- a/lib/ogsf/gp.c
+++ b/lib/ogsf/gp.c
@@ -6,10 +6,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL, GMSL/University of Illinois (January 1994)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL, GMSL/University of Illinois (January 1994)
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (May 2008)
  */
 

--- a/lib/ogsf/gp2.c
+++ b/lib/ogsf/gp2.c
@@ -6,10 +6,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL (January 1994)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL (January 1994)
    \author Updated by Martin landa <landa.martin gmail.com>
    (doxygenized in May 2008, thematic mapping in June 2011)
  */

--- a/lib/ogsf/gp3.c
+++ b/lib/ogsf/gp3.c
@@ -7,10 +7,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL, GMSL/University of Illinois (January 1994)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL, GMSL/University of Illinois (January 1994)
    \author Updated by Martin Landa <landa.martin gmail.com>
    (doxygenized in May 2008, thematic mapping in June 2011)
  */

--- a/lib/ogsf/gpd.c
+++ b/lib/ogsf/gpd.c
@@ -5,10 +5,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL, GMSL/University of Illinois (December 1993)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL, GMSL/University of Illinois (December 1993)
    \author Doxygenized by Martin Landa <landa.martin gmail.com> (May 2008)
  */
 

--- a/lib/ogsf/gv.c
+++ b/lib/ogsf/gv.c
@@ -6,10 +6,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL (November 1993)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL (November 1993)
    \author Doxygenized by Martin Landa (June 2008)
  */
 

--- a/lib/ogsf/gv2.c
+++ b/lib/ogsf/gv2.c
@@ -6,10 +6,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL, GMSL/University of Illinois
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL, GMSL/University of Illinois
    \author Updated by Martin landa <landa.martin gmail.com>
    (doxygenized in May 2008, thematic mapping in June 2011)
  */

--- a/lib/ogsf/gv3.c
+++ b/lib/ogsf/gv3.c
@@ -7,10 +7,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL (December 1993)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL (December 1993)
    \author Updated by Martin Landa <landa.martin gmail.com>
    (doxygenized in May 2008, thematic mapping in August 2011)
  */

--- a/lib/ogsf/gvd.c
+++ b/lib/ogsf/gvd.c
@@ -6,10 +6,8 @@
 
    (C) 1999-2008, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Bill Brown USACERL (December 1993)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Bill Brown USACERL (December 1993)
    \author Doxygenized by Martin Landa (June 2008)
  */
 

--- a/lib/pngdriver/box.c
+++ b/lib/pngdriver/box.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/color.c
+++ b/lib/pngdriver/color.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/draw.c
+++ b/lib/pngdriver/draw.c
@@ -5,10 +5,8 @@
 
    (C) 2008 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <grass/gis.h>

--- a/lib/pngdriver/draw_bitmap.c
+++ b/lib/pngdriver/draw_bitmap.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/driver.c
+++ b/lib/pngdriver/driver.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include "pngdriver.h"

--- a/lib/pngdriver/erase.c
+++ b/lib/pngdriver/erase.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/graph_close.c
+++ b/lib/pngdriver/graph_close.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/graph_set.c
+++ b/lib/pngdriver/graph_set.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/line_width.c
+++ b/lib/pngdriver/line_width.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/pngdriver.h
+++ b/lib/pngdriver/pngdriver.h
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #ifndef __PNGDRIVER_H__

--- a/lib/pngdriver/point.c
+++ b/lib/pngdriver/point.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <grass/gis.h>

--- a/lib/pngdriver/polygon.c
+++ b/lib/pngdriver/polygon.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/raster.c
+++ b/lib/pngdriver/raster.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2014 by Per Henrik Johansen and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/read.c
+++ b/lib/pngdriver/read.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/read_bmp.c
+++ b/lib/pngdriver/read_bmp.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/read_png.c
+++ b/lib/pngdriver/read_png.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/read_ppm.c
+++ b/lib/pngdriver/read_ppm.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/set_window.c
+++ b/lib/pngdriver/set_window.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Per Henrik Johansen (original contributor)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Per Henrik Johansen (original contributor)
    \author Glynn Clements
  */
 

--- a/lib/pngdriver/write.c
+++ b/lib/pngdriver/write.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/write_bmp.c
+++ b/lib/pngdriver/write_bmp.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/write_png.c
+++ b/lib/pngdriver/write_png.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/pngdriver/write_ppm.c
+++ b/lib/pngdriver/write_ppm.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2014 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdio.h>

--- a/lib/proj/convert.c
+++ b/lib/proj/convert.c
@@ -6,10 +6,8 @@
 
    (C) 2003-2018 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Paul Kelly, Frank Warmerdam, Markus Metz
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Paul Kelly, Frank Warmerdam, Markus Metz
  */
 
 #include <grass/config.h>

--- a/lib/psdriver/draw.c
+++ b/lib/psdriver/draw.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by Glynn Clements and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include "psdriver.h"

--- a/lib/raster/align_window.c
+++ b/lib/raster/align_window.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/alloc_cell.c
+++ b/lib/raster/alloc_cell.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/auto_mask.c
+++ b/lib/raster/auto_mask.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2024 by Vaclav Petras and the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  * \author Vaclav Petras (environmental variable and refactoring)
  */

--- a/lib/raster/cats.c
+++ b/lib/raster/cats.c
@@ -62,9 +62,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/cell_stats.c
+++ b/lib/raster/cell_stats.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_compat.c
+++ b/lib/raster/color_compat.c
@@ -5,9 +5,8 @@
  *
  * (C) 2007-2009 Glynn Clements and the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements <glynn@gclements.plus.com>
  */
 

--- a/lib/raster/color_free.c
+++ b/lib/raster/color_free.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_get.c
+++ b/lib/raster/color_get.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_hist.c
+++ b/lib/raster/color_hist.c
@@ -5,9 +5,8 @@
  *
  * (C) 2007-2009 Glynn Clements and the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Glynn Clements <glynn@gclements.plus.com>
  */
 

--- a/lib/raster/color_init.c
+++ b/lib/raster/color_init.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/raster/color_invrt.c
+++ b/lib/raster/color_invrt.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/gis.h>

--- a/lib/raster/color_range.c
+++ b/lib/raster/color_range.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_remove.c
+++ b/lib/raster/color_remove.c
@@ -5,10 +5,8 @@
 
    (C) 2007 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <string.h>

--- a/lib/raster/color_rule_get.c
+++ b/lib/raster/color_rule_get.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_set.c
+++ b/lib/raster/color_set.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_shift.c
+++ b/lib/raster/color_shift.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/color_xform.c
+++ b/lib/raster/color_xform.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2021 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/gdal.c
+++ b/lib/raster/gdal.c
@@ -5,10 +5,8 @@
 
    (C) 2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Glynn Clements
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Glynn Clements
  */
 
 #include <stdlib.h>

--- a/lib/raster/get_cellhd.c
+++ b/lib/raster/get_cellhd.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2020 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <string.h>

--- a/lib/raster/get_row.c
+++ b/lib/raster/get_row.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdint.h>

--- a/lib/raster/history.c
+++ b/lib/raster/history.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2000-2008

--- a/lib/raster/interp.c
+++ b/lib/raster/interp.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009,2013 GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <math.h>

--- a/lib/raster/maskfd.c
+++ b/lib/raster/maskfd.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2024 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  * \author Vaclav Petras (documentation)
  */

--- a/lib/raster/null_val.c
+++ b/lib/raster/null_val.c
@@ -8,9 +8,8 @@
  *
  * (C) 2001-2009 GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author unknown - probably CERL
  * \author Justin Hickey - Thailand - jhickey@hpcc.nectec.or.th
  */

--- a/lib/raster/put_cellhd.c
+++ b/lib/raster/put_cellhd.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/put_row.c
+++ b/lib/raster/put_row.c
@@ -5,10 +5,8 @@
 
    (C) 2003-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 /**********************************************************************

--- a/lib/raster/quant.c
+++ b/lib/raster/quant.c
@@ -11,9 +11,8 @@
  *
  * (C) 1999-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author USACERL and many others
  */
 

--- a/lib/raster/quant_io.c
+++ b/lib/raster/quant_io.c
@@ -5,9 +5,8 @@
  *
  * (C) 1999-2010 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author USACERL and many others
  */
 

--- a/lib/raster/range.c
+++ b/lib/raster/range.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/raster.c
+++ b/lib/raster/raster.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -7,10 +7,8 @@
    (C) 2007-2009, 2021 by Hamish Bowman, Maris Nartiss,
    and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Hamish Bowman
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Hamish Bowman
  */
 
 #include <stdbool.h>

--- a/lib/raster/reclass.c
+++ b/lib/raster/reclass.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/sample.c
+++ b/lib/raster/sample.c
@@ -8,10 +8,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author James Darrell McCauley <darrell mccauley-usa.com>,
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author James Darrell McCauley <darrell mccauley-usa.com>,
    http://mccauley-usa.com/
  */
 

--- a/lib/raster/set_window.c
+++ b/lib/raster/set_window.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -5,10 +5,8 @@
 
    (C) 2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Markus Metz
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Markus Metz
  */
 
 #include <grass/gis.h>

--- a/lib/raster/window.c
+++ b/lib/raster/window.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/window_map.c
+++ b/lib/raster/window_map.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/raster/zero_cell.c
+++ b/lib/raster/zero_cell.c
@@ -5,9 +5,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL
  */
 

--- a/lib/rowio/fileno.c
+++ b/lib/rowio/fileno.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/rowio.h>

--- a/lib/rowio/forget.c
+++ b/lib/rowio/forget.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <grass/rowio.h>

--- a/lib/rowio/get.c
+++ b/lib/rowio/get.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/rowio/put.c
+++ b/lib/rowio/put.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/rowio/setup.c
+++ b/lib/rowio/setup.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
  */
 
 #include <stdio.h>

--- a/lib/segment/address.c
+++ b/lib/segment/address.c
@@ -3,9 +3,8 @@
  *
  * \brief Address routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/close.c
+++ b/lib/segment/close.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment closing routine.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2018

--- a/lib/segment/flush.c
+++ b/lib/segment/flush.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment flush routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/format.c
+++ b/lib/segment/format.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment formatting routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2018

--- a/lib/segment/get.c
+++ b/lib/segment/get.c
@@ -3,9 +3,8 @@
  *
  * \brief Get segment routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2018

--- a/lib/segment/get_row.c
+++ b/lib/segment/get_row.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment row retrieval routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2018

--- a/lib/segment/open.c
+++ b/lib/segment/open.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment creation routine.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2018

--- a/lib/segment/pagein.c
+++ b/lib/segment/pagein.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment page-in routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/pageout.c
+++ b/lib/segment/pageout.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment page-out routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/put.c
+++ b/lib/segment/put.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment write routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2018

--- a/lib/segment/put_row.c
+++ b/lib/segment/put_row.c
@@ -3,9 +3,8 @@
  *
  * \brief Write segment row routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2018

--- a/lib/segment/release.c
+++ b/lib/segment/release.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment release routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/seek.c
+++ b/lib/segment/seek.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment seek routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/segment/setup.c
+++ b/lib/segment/setup.c
@@ -3,9 +3,8 @@
  *
  * \brief Segment setup routines.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author GRASS Development Team
  *
  * \date 2005-2009

--- a/lib/temporal/lib/connect.c
+++ b/lib/temporal/lib/connect.c
@@ -5,10 +5,8 @@
 
    (C) 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Soeren Gebbert
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Soeren Gebbert
    Code is based on the dbmi library written by
    Joel Jones (CERL/UIUC) and Radim Blazek
  */

--- a/lib/temporal/lib/default_name.c
+++ b/lib/temporal/lib/default_name.c
@@ -5,10 +5,8 @@
 
    (C) 2012-2014 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Soeren Gebbert
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Soeren Gebbert
    Code is based on the dbmi library written by
    Joel Jones (CERL/UIUC) and Radim Blazek
  */

--- a/lib/vector/Vlib/area.c
+++ b/lib/vector/Vlib/area.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/area_pg.c
+++ b/lib/vector/Vlib/area_pg.c
@@ -7,10 +7,8 @@
 
    (C) 2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL
    \author Updated for GRASS 7 (SF support) by Martin Landa <landa.martin
    gmail.com>
  */

--- a/lib/vector/Vlib/break_polygons.c
+++ b/lib/vector/Vlib/break_polygons.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Update for GRASS 7 Markus Metz
  */
 

--- a/lib/vector/Vlib/build.c
+++ b/lib/vector/Vlib/build.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2010, 2012-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/build_nat.c
+++ b/lib/vector/Vlib/build_nat.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/build_ogr.c
+++ b/lib/vector/Vlib/build_ogr.c
@@ -10,10 +10,8 @@
 
    (C) 2001-2010, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek, Piero Cavalieri
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek, Piero Cavalieri
    \author Various updates for GRASS 7 by Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/Vlib/build_sfa.c
+++ b/lib/vector/Vlib/build_sfa.c
@@ -11,10 +11,8 @@
 
    (C) 2001-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Piero Cavalieri
    \author Various updates for GRASS 7 by Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/cats.c
+++ b/lib/vector/Vlib/cats.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001-2012 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Original author CERL, probably Dave Gerdes or Mike Higgins
  * \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  * \author Various updates by Martin Landa <landa.martin gmail.com>

--- a/lib/vector/Vlib/cindex.c
+++ b/lib/vector/Vlib/cindex.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Some contribution by Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/Vlib/clean_nodes.c
+++ b/lib/vector/Vlib/clean_nodes.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/close.c
+++ b/lib/vector/Vlib/close.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/close_nat.c
+++ b/lib/vector/Vlib/close_nat.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/close_ogr.c
+++ b/lib/vector/Vlib/close_ogr.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and Piero Cavalieri.
  */
 

--- a/lib/vector/Vlib/color_read.c
+++ b/lib/vector/Vlib/color_read.c
@@ -5,10 +5,8 @@
 
    (C) 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/color_remove.c
+++ b/lib/vector/Vlib/color_remove.c
@@ -5,10 +5,8 @@
 
    (C) 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/color_write.c
+++ b/lib/vector/Vlib/color_write.c
@@ -5,10 +5,8 @@
 
    (C) 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/constraint.c
+++ b/lib/vector/Vlib/constraint.c
@@ -20,10 +20,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/copy.c
+++ b/lib/vector/Vlib/copy.c
@@ -8,10 +8,8 @@
 
    (C) 2001-2009, 2012-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 by Martin Landa <landa.martin gmail.com>
    (OGR/PostGIS topology support)

--- a/lib/vector/Vlib/dangles.c
+++ b/lib/vector/Vlib/dangles.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/dbcolumns.c
+++ b/lib/vector/Vlib/dbcolumns.c
@@ -7,10 +7,8 @@
 
    (C) 2005-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Markus Neteler
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Markus Neteler
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/dgraph.c
+++ b/lib/vector/Vlib/dgraph.c
@@ -7,10 +7,8 @@
 
    (C) 2008-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Rewritten by Rosen Matev (Google Summer of Code 2008)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Rewritten by Rosen Matev (Google Summer of Code 2008)
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/e_intersect.c
+++ b/lib/vector/Vlib/e_intersect.c
@@ -7,10 +7,8 @@
 
    (C) 2008-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Rewritten by Rosen Matev (Google Summer of Code 2008)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Rewritten by Rosen Matev (Google Summer of Code 2008)
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -11,10 +11,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 by Radim Blazek and David D. Gray.
    \author Various updates by Martin Landa <landa.martin gmail.com>, 2009-2011
  */

--- a/lib/vector/Vlib/find.c
+++ b/lib/vector/Vlib/find.c
@@ -7,10 +7,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
-
- * \author Original author CERL, probably Dave Gerdes or Mike
+ * SPDX-License-Identifier: GPL-2.0-or-later
+* \author Original author CERL, probably Dave Gerdes or Mike
  * Higgins.
  * \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */

--- a/lib/vector/Vlib/geos.c
+++ b/lib/vector/Vlib/geos.c
@@ -7,10 +7,8 @@
 
    (C) 2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/geos_to_wktb.c
+++ b/lib/vector/Vlib/geos_to_wktb.c
@@ -7,10 +7,8 @@
 
    (C) 2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Soeren Gebbert <soerengebbert googlemail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Soeren Gebbert <soerengebbert googlemail.com>
  */
 
 #include <stdbool.h>

--- a/lib/vector/Vlib/graph.c
+++ b/lib/vector/Vlib/graph.c
@@ -9,10 +9,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/handler.c
+++ b/lib/vector/Vlib/handler.c
@@ -7,10 +7,8 @@
 
    (C) 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/gis.h>

--- a/lib/vector/Vlib/header.c
+++ b/lib/vector/Vlib/header.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 (OGR support) by Martin Landa <landa.martin
    gmail.com>

--- a/lib/vector/Vlib/header_finfo.c
+++ b/lib/vector/Vlib/header_finfo.c
@@ -8,10 +8,8 @@
 
    (C) 2001-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 (OGR/PostGIS support) by Martin Landa <landa.martin
    gmail.com>

--- a/lib/vector/Vlib/hist.c
+++ b/lib/vector/Vlib/hist.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/init_head.c
+++ b/lib/vector/Vlib/init_head.c
@@ -10,10 +10,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Various updates by Martin Landa <landa.martin gmail.com>, 2009
  */

--- a/lib/vector/Vlib/intersect.c
+++ b/lib/vector/Vlib/intersect.c
@@ -58,10 +58,8 @@
 
    (C) 2001-2009, 2022 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek.
  */
 

--- a/lib/vector/Vlib/intersect2.c
+++ b/lib/vector/Vlib/intersect2.c
@@ -58,10 +58,8 @@
 
    (C) 2001-2014, 2022 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek.
    \author Update to GRASS 7 Markus Metz.
  */

--- a/lib/vector/Vlib/legal_vname.c
+++ b/lib/vector/Vlib/legal_vname.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/level.c
+++ b/lib/vector/Vlib/level.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/level_two.c
+++ b/lib/vector/Vlib/level_two.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 by Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/line.c
+++ b/lib/vector/Vlib/line.c
@@ -5,10 +5,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Some updates for GRASS 7 by Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/map.c
+++ b/lib/vector/Vlib/map.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/net_analyze.c
+++ b/lib/vector/Vlib/net_analyze.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001-2009, 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Stepan Turek stepan.turek seznam.cz (turns support)
  */

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001-2009, 2014 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author Stepan Turek stepan.turek seznam.cz (turns support)
  */

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -8,10 +8,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 Martin Landa <landa.martin gmail.com> (better OGR
    support and native PostGIS access)

--- a/lib/vector/Vlib/open_nat.c
+++ b/lib/vector/Vlib/open_nat.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/open_ogr.c
+++ b/lib/vector/Vlib/open_ogr.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2010 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7.0 Martin Landa <landa.martin gmail.com> (2009)
  */

--- a/lib/vector/Vlib/open_pg.c
+++ b/lib/vector/Vlib/open_pg.c
@@ -7,10 +7,8 @@
 
    (C) 2011-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/overlap.c
+++ b/lib/vector/Vlib/overlap.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/overlay.c
+++ b/lib/vector/Vlib/overlay.c
@@ -10,10 +10,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <string.h>

--- a/lib/vector/Vlib/poly.c
+++ b/lib/vector/Vlib/poly.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/read.c
+++ b/lib/vector/Vlib/read.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Update to GRASS 7 Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/read_nat.c
+++ b/lib/vector/Vlib/read_nat.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 by Radim Blazek and David D. Gray.
    \author Update to GRASS 7 by Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/read_ogr.c
+++ b/lib/vector/Vlib/read_ogr.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek, Piero Cavalieri
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek, Piero Cavalieri
    \author Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/Vlib/read_sfa.c
+++ b/lib/vector/Vlib/read_sfa.c
@@ -10,10 +10,8 @@
 
    (C) 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/remove_areas.c
+++ b/lib/vector/Vlib/remove_areas.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek, Markus Metz
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek, Markus Metz
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/remove_duplicates.c
+++ b/lib/vector/Vlib/remove_duplicates.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/rewind.c
+++ b/lib/vector/Vlib/rewind.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author Level 3 by Martin Landa <landa.martin gmail.com>
  */

--- a/lib/vector/Vlib/rewind_nat.c
+++ b/lib/vector/Vlib/rewind_nat.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 

--- a/lib/vector/Vlib/rewind_ogr.c
+++ b/lib/vector/Vlib/rewind_ogr.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009, 2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek, Piero Cavalieri
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek, Piero Cavalieri
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/rewind_pg.c
+++ b/lib/vector/Vlib/rewind_pg.c
@@ -7,10 +7,8 @@
 
    (C) 2011-2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/rtree_search.c
+++ b/lib/vector/Vlib/rtree_search.c
@@ -7,10 +7,8 @@
 
    (C) 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Soeren Gebbert
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Soeren Gebbert
  */
 
 #include <assert.h>

--- a/lib/vector/Vlib/select.c
+++ b/lib/vector/Vlib/select.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/simple_features.c
+++ b/lib/vector/Vlib/simple_features.c
@@ -22,10 +22,8 @@
 
    (C) 2009, 2011-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <stdio.h>

--- a/lib/vector/Vlib/sindex.c
+++ b/lib/vector/Vlib/sindex.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek, Markus Metz
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek, Markus Metz
  */
 
 #include <stdlib.h>

--- a/lib/vector/Vlib/snap.c
+++ b/lib/vector/Vlib/snap.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2).  Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  * \author update to GRASS 7 Markus Metz
  */

--- a/lib/vector/Vlib/tin.c
+++ b/lib/vector/Vlib/tin.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/type.c
+++ b/lib/vector/Vlib/type.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 
 #include <grass/vector.h>

--- a/lib/vector/Vlib/window.c
+++ b/lib/vector/Vlib/window.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
  */
 #include <grass/vector.h>
 

--- a/lib/vector/Vlib/write.c
+++ b/lib/vector/Vlib/write.c
@@ -13,10 +13,8 @@
 
    (C) 2001-2010, 2012-2013 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Radim Blazek
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Radim Blazek
    \author Updated by Martin Landa <landa.martin gmail.com> (restore lines, OGR
    & PostGIS support)
  */

--- a/lib/vector/Vlib/write_nat.c
+++ b/lib/vector/Vlib/write_nat.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2015 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes or Mike Higgins.
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes or Mike Higgins.
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
    \author V*_restore_line() by Martin Landa <landa.martin gmail.com> (2008)
  */

--- a/lib/vector/Vlib/write_ogr.c
+++ b/lib/vector/Vlib/write_ogr.c
@@ -11,10 +11,8 @@
 
    (C) 2009-2013 by Martin Landa, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <inttypes.h>

--- a/lib/vector/Vlib/write_sfa.c
+++ b/lib/vector/Vlib/write_sfa.c
@@ -16,10 +16,8 @@
 
    (C) 2011-2012 by Martin Landa, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vector.h>

--- a/lib/vector/diglib/file.c
+++ b/lib/vector/diglib/file.c
@@ -11,10 +11,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes
    \author Update to GRASS 5.7 Radim Blazek
  */
 

--- a/lib/vector/diglib/plus.c
+++ b/lib/vector/diglib/plus.c
@@ -5,9 +5,8 @@
  *
  * Lower level functions for reading/writing/manipulating vectors.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author CERL (probably Dave Gerdes), Radim Blazek
  *
  * \date 2001-2006

--- a/lib/vector/diglib/plus_area.c
+++ b/lib/vector/diglib/plus_area.c
@@ -5,9 +5,8 @@
  *
  * Lower level functions for reading/writing/manipulating vectors.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author CERL (probably Dave Gerdes), Radim Blazek
  *
  * \date 2001-2006

--- a/lib/vector/diglib/plus_line.c
+++ b/lib/vector/diglib/plus_line.c
@@ -5,9 +5,8 @@
  *
  * Lower level functions for reading/writing/manipulating vectors.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author CERL (probably Dave Gerdes), Radim Blazek
  *
  * \date 2001-2008

--- a/lib/vector/diglib/plus_node.c
+++ b/lib/vector/diglib/plus_node.c
@@ -5,9 +5,8 @@
  *
  * Lower level functions for reading/writing/manipulating vectors.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author CERL (probably Dave Gerdes), Radim Blazek
  *
  * \date 2001-2006

--- a/lib/vector/diglib/port_init.c
+++ b/lib/vector/diglib/port_init.c
@@ -69,10 +69,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes
    \author Update to GRASS 5.7 Radim Blazek
  */
 

--- a/lib/vector/diglib/portable.c
+++ b/lib/vector/diglib/portable.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes
    \author Update to GRASS 5.7 Radim Blazek
  */
 

--- a/lib/vector/diglib/spindex.c
+++ b/lib/vector/diglib/spindex.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes
    \author Update to GRASS 5.7 Radim Blazek
    \author Update to GRASS 7 Markus Metz
  */

--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -7,10 +7,8 @@
 
    (C) 2001-2009 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Original author CERL, probably Dave Gerdes
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Original author CERL, probably Dave Gerdes
    \author Update to GRASS 5.7 Radim Blazek
    \author Update to GRASS 7 Markus Metz
  */

--- a/lib/vector/diglib/struct_alloc.c
+++ b/lib/vector/diglib/struct_alloc.c
@@ -10,10 +10,8 @@
    will be zero. The next memory location asked for could have been
    previously used and not zeroed. (e.g. compress()).
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author CERL (probably Dave Gerdes)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author CERL (probably Dave Gerdes)
    \author Radim Blazek
  */
 

--- a/lib/vector/diglib/type.c
+++ b/lib/vector/diglib/type.c
@@ -5,9 +5,8 @@
  *
  * Lower level functions for reading/writing/manipulating vectors.
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  *
  * \date 2001

--- a/lib/vector/diglib/update.c
+++ b/lib/vector/diglib/update.c
@@ -7,9 +7,8 @@
  *
  * (C) 2001 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  * \author Radim Blazek
  */
 

--- a/lib/vector/neta/articulation_point.c
+++ b/lib/vector/neta/articulation_point.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/bridge.c
+++ b/lib/vector/neta/bridge.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/centrality.c
+++ b/lib/vector/neta/centrality.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/components.c
+++ b/lib/vector/neta/components.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
    \author Markus Metz
  */
 

--- a/lib/vector/neta/flow.c
+++ b/lib/vector/neta/flow.c
@@ -8,10 +8,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/path.c
+++ b/lib/vector/neta/path.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
    \author Markus Metz
  */
 

--- a/lib/vector/neta/spanningtree.c
+++ b/lib/vector/neta/spanningtree.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/timetables.c
+++ b/lib/vector/neta/timetables.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/neta/utils.c
+++ b/lib/vector/neta/utils.c
@@ -7,10 +7,8 @@
 
    (C) 2009-2010 by Daniel Bundala, and the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Daniel Bundala (Google Summer of Code 2009)
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Daniel Bundala (Google Summer of Code 2009)
  */
 
 #include <stdio.h>

--- a/lib/vector/vedit/break.c
+++ b/lib/vector/vedit/break.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <math.h>

--- a/lib/vector/vedit/cats.c
+++ b/lib/vector/vedit/cats.c
@@ -5,10 +5,8 @@
 
    (C) 2006-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Jachym Cepicky <jachym.cepicky gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Jachym Cepicky <jachym.cepicky gmail.com>
    \author Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/vedit/chtype.c
+++ b/lib/vector/vedit/chtype.c
@@ -5,10 +5,8 @@
 
    (C) 2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vedit.h>

--- a/lib/vector/vedit/copy.c
+++ b/lib/vector/vedit/copy.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Jachym Cepicky <jachym.cepicky gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Jachym Cepicky <jachym.cepicky gmail.com>
    \author Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/vedit/delete.c
+++ b/lib/vector/vedit/delete.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008, 2012 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <stdlib.h>

--- a/lib/vector/vedit/distance.c
+++ b/lib/vector/vedit/distance.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vedit.h>

--- a/lib/vector/vedit/extend.c
+++ b/lib/vector/vedit/extend.c
@@ -5,10 +5,8 @@
 
    (C) 2017 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Huidae Cho <grass4u gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Huidae Cho <grass4u gmail.com>
  */
 
 #include <math.h>

--- a/lib/vector/vedit/flip.c
+++ b/lib/vector/vedit/flip.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vedit.h>

--- a/lib/vector/vedit/merge.c
+++ b/lib/vector/vedit/merge.c
@@ -5,10 +5,8 @@
 
    (C) 2006-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Jachym Cepicky <jachym.cepicky gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Jachym Cepicky <jachym.cepicky gmail.com>
    \author Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/vedit/move.c
+++ b/lib/vector/vedit/move.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
    \author Jachym Cepicky <jachym.cepicky gmail.com>
  */
 

--- a/lib/vector/vedit/render.c
+++ b/lib/vector/vedit/render.c
@@ -5,10 +5,8 @@
 
    (C) 2010-2011 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <math.h>

--- a/lib/vector/vedit/select.c
+++ b/lib/vector/vedit/select.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <math.h>

--- a/lib/vector/vedit/snap.c
+++ b/lib/vector/vedit/snap.c
@@ -5,10 +5,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/vedit.h>

--- a/lib/vector/vedit/vertex.c
+++ b/lib/vector/vedit/vertex.c
@@ -5,10 +5,8 @@
 
    (C) 2006-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Jachym Cepicky <jachym.cepicky gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Jachym Cepicky <jachym.cepicky gmail.com>
    \author Martin Landa <landa.martin gmail.com>
  */
 

--- a/lib/vector/vedit/zbulk.c
+++ b/lib/vector/vedit/zbulk.c
@@ -6,10 +6,8 @@
 
    (C) 2007-2008 by the GRASS Development Team
 
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
-
-   \author Martin Landa <landa.martin gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+\author Martin Landa <landa.martin gmail.com>
  */
 
 #include <grass/dbmi.h>

--- a/raster/r.viewshed/distribute.cpp
+++ b/raster/r.viewshed/distribute.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <assert.h>

--- a/raster/r.viewshed/distribute.h
+++ b/raster/r.viewshed/distribute.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef __DISTRIBUTE_H

--- a/raster/r.viewshed/eventlist.cpp
+++ b/raster/r.viewshed/eventlist.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <math.h>

--- a/raster/r.viewshed/eventlist.h
+++ b/raster/r.viewshed/eventlist.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 - 2011 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef _EVENTLIST_H

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/raster/r.viewshed/grass.h
+++ b/raster/r.viewshed/grass.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef _GRASS_H

--- a/raster/r.viewshed/grid.cpp
+++ b/raster/r.viewshed/grid.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <stdio.h>

--- a/raster/r.viewshed/grid.h
+++ b/raster/r.viewshed/grid.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 /*

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008-2011 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/raster/r.viewshed/rbbst.cpp
+++ b/raster/r.viewshed/rbbst.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 /*

--- a/raster/r.viewshed/rbbst.h
+++ b/raster/r.viewshed/rbbst.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef __RB_BINARY_SEARCH_TREE__

--- a/raster/r.viewshed/statusstructure.cpp
+++ b/raster/r.viewshed/statusstructure.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #include <math.h>

--- a/raster/r.viewshed/statusstructure.h
+++ b/raster/r.viewshed/statusstructure.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef _YZ__STATUSSTRUCTURE_H

--- a/raster/r.viewshed/viewshed.cpp
+++ b/raster/r.viewshed/viewshed.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  ****************************************************************************/
 
 #include <assert.h>

--- a/raster/r.viewshed/viewshed.h
+++ b/raster/r.viewshed/viewshed.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef _KREVELD_H

--- a/raster/r.viewshed/visibility.cpp
+++ b/raster/r.viewshed/visibility.cpp
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 #include <stdio.h>
 

--- a/raster/r.viewshed/visibility.h
+++ b/raster/r.viewshed/visibility.h
@@ -29,9 +29,8 @@
  *
  * COPYRIGHT: (C) 2008 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
- *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+*
  *****************************************************************************/
 
 #ifndef visibility_h


### PR DESCRIPTION
Closes #4190. Implements an automated search-and-replace migration pattern across the codebase to cleanly substitute legacy multi-line GPL-2.0-or-later statements with inline 'SPDX-License-Identifier: GPL-2.0-or-later' declarations in-place.

Following the advice from @nilason and @echoix:
- Changes are executed in-place within the original license commentary positioning blocks.
- Complex multi-licensed or non-standard project files have been systematically skipped for manual isolation during phase two.
- Commits are structurally segmented by root architectural components (/lib, /db, /imagery) to maximize review efficiency.