### PR TITLE
grass.script: Sanitize mapset region variables in runtime setup

### DIFF
--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -221,10 +221,14 @@ def setup_runtime_env(gisbase=None, *, env=None):
         RuntimePaths,
     )
 
+    from grass.script.core import sanitize_mapset_environment
+
     # If environment is not provided, use the global one.
     if not env:
         env = os.environ
-
+    # Remove mapset-specific variables that should not leak into the
+    # runtime environment being set up.
+    sanitize_mapset_environment(env)
     runtime_paths = RuntimePaths(env=env, prefix=gisbase)
     gisbase = runtime_paths.gisbase
     if not Path(gisbase).is_dir():

--- a/python/grass/script/tests/grass_script_setup_test.py
+++ b/python/grass/script/tests/grass_script_setup_test.py
@@ -467,3 +467,19 @@ def test_grass_path_types_in_setup(tmp_path, path_type):
     gs.setup.setup_runtime_env(grass_path, env=env)
     # At least before FHS, GISBASE is the way to detect an active runtime.
     assert "GISBASE" in env
+
+
+@pytest.mark.parametrize("variable", ["GRASS_REGION", "WIND_OVERRIDE"])
+@pytest.mark.usefixtures("mock_no_session")
+def test_init_removes_mapset_variables(tmp_path, variable):
+    """Check that init removes mapset-specific variables from the environment.
+
+    Variables tied to a specific mapset (such as region overrides) must not
+    leak from the provided environment into the initialized session.
+    """
+    project = tmp_path / "test"
+    gs.create_project(project)
+    env = os.environ.copy()
+    env[variable] = "value"
+    with gs.setup.init(project, env=env) as session:
+        assert variable not in session.env


### PR DESCRIPTION
Remove mapset-specific variables (WIND_OVERRIDE, GRASS_REGION) when  setting up the runtime environment in setup_runtime_env(), so they do  not leak from the parent environment into a freshly initialized session.  This reuses the existing sanitize_mapset_environment() function.
Add a parametrized pytest covering both variables through init().