### PR TITLE
v.proj: Seed region from default window to ignore region override

### DIFF
--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -289,8 +289,14 @@ int main(int argc, char *argv[])
             int first = 1, counter = 0;
             struct Cell_head inwindow;
 
-            G_unset_window();
-            G_get_window(&inwindow);
+            /* Initialize from the source projects's default region, not the
+             * current region: G_get_window() would honor WIND_OVERRIDE /
+             * GRASS_REGION, but those name a region in the target's mapset,
+             * not in the source project we just switched into, and would
+             * fail to open it. Every spatial field below is overwritten from
+             * the input vector's extent anyway, so the default window is a
+             * sufficient and side-effect-free seed. */
+            G_get_default_window(&inwindow);
 
             /* Cycle through all lines */
             Vect_rewind(&Map);

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -289,13 +289,12 @@ int main(int argc, char *argv[])
             int first = 1, counter = 0;
             struct Cell_head inwindow;
 
-            /* Initialize from the source projects's default region, not the
-             * current region: G_get_window() would honor WIND_OVERRIDE /
-             * GRASS_REGION, but those name a region in the target's mapset,
-             * not in the source project we just switched into, and would
-             * fail to open it. Every spatial field below is overwritten from
-             * the input vector's extent anyway, so the default window is a
-             * sufficient and side-effect-free seed. */
+            // Initialize from the source projects's default region, not the
+            // current region, because G_get_window() honors WIND_OVERRIDE /
+            // GRASS_REGION, but those refer to a region in the target's mapset,
+            // not in the source project we just switched into. Every spatial
+            // field below is overwritten from the input vector's extent anyway,
+            // so the default window is a sufficient and side-effect-free seed.
             G_get_default_window(&inwindow);
 
             /* Cycle through all lines */

--- a/vector/v.proj/tests/v_proj_wind_override_test.py
+++ b/vector/v.proj/tests/v_proj_wind_override_test.py
@@ -38,23 +38,22 @@ def test_vproj_succeeds_with_wind_override(source_and_target):
     source, target = source_and_target
     with gs.setup.init(target, env=os.environ.copy()) as session:
         # A named region that exists only in the target's current mapset.
-        gs.run_command(
-            "g.region",
+        tools = Tools(session=session)
+        tools.g_region(
             n=300000,
             s=200000,
             e=700000,
             w=600000,
             res=10,
             save="local_region",
-            env=session.env,
         )
         # Set the override after init so it is not stripped by runtime setup;
         # this mirrors a caller running under a temporary named region.
         session.env["WIND_OVERRIDE"] = "local_region"
-        Tools(session=session).v_proj(
+        tools.v_proj(
             project=source.name,
             mapset="PERMANENT",
             input="points",
             output="points",
         )
-        assert gs.find_file("points", element="vector", env=session.env)["name"]
+        assert tools.g_findfile(file="points", element="vector", format="json")["name"]

--- a/vector/v.proj/tests/v_proj_wind_override_test.py
+++ b/vector/v.proj/tests/v_proj_wind_override_test.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Regression test for v.proj run with a region override set.
+
+v.proj switches into the source project to read the input vector. It used to
+seed its working region with G_get_window(), which honors WIND_OVERRIDE and
+GRASS_REGION. Those name a region in the caller's mapset, not in the source
+project, so the read failed with "Unable to open element file <windows>".
+v.proj now seeds from the source project's default window instead, which does
+not consult the override.
+"""
+
+import os
+from io import StringIO
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
+
+
+@pytest.fixture
+def source_and_target(tmp_path):
+    """Two projects with different CRS.
+
+    The source (lon/lat) holds a vector map in PERMANENT; the target
+    (NC State Plane, meters) is where v.proj runs.
+    """
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    gs.create_project(source, epsg="4326")
+    gs.create_project(target, epsg="3358")
+    with gs.setup.init(source, env=os.environ.copy()) as session:
+        Tools(session=session).v_in_ascii(
+            input=StringIO("-78.6|35.7\n-78.5|35.8\n"),
+            output="points",
+            separator="|",
+            format="point",
+        )
+    return source, target
+
+
+def test_vproj_succeeds_with_wind_override(source_and_target):
+    """v.proj imports a map while WIND_OVERRIDE names a region only in the
+    target mapset."""
+    source, target = source_and_target
+    with gs.setup.init(target, env=os.environ.copy()) as session:
+        # A named region that exists only in the target's current mapset.
+        gs.run_command(
+            "g.region",
+            n=300000,
+            s=200000,
+            e=700000,
+            w=600000,
+            res=10,
+            save="local_region",
+            env=session.env,
+        )
+        # Set the override after init so it is not stripped by runtime setup;
+        # this mirrors a caller running under a temporary named region.
+        session.env["WIND_OVERRIDE"] = "local_region"
+        Tools(session=session).v_proj(
+            project=source.name,
+            mapset="PERMANENT",
+            input="points",
+            output="points",
+        )
+        assert gs.find_file("points", element="vector", env=session.env)["name"]

--- a/vector/v.proj/tests/v_proj_wind_override_test.py
+++ b/vector/v.proj/tests/v_proj_wind_override_test.py
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-"""Regression test for v.proj run with a region override set.
-
-v.proj switches into the source project to read the input vector. It used to
-seed its working region with G_get_window(), which honors WIND_OVERRIDE and
-GRASS_REGION. Those name a region in the caller's mapset, not in the source
-project, so the read failed with "Unable to open element file <windows>".
-v.proj now seeds from the source project's default window instead, which does
-not consult the override.
-"""
+"""Regression test for v.proj run with a region override set."""
 
 import os
 from io import StringIO


### PR DESCRIPTION
This came up when i was testing r.in.ssurgo addon in parallel within RegionManager which uses WIND_OVERRIDE. v.proj was throwing:
```
Unable to open element file <windows> for <local_region@PERMANENT>
```

Added test.

More info:
<details>
When v.proj switches into the source project to read the input vector,
  it seeded its working region with G_get_window(), which honors
  WIND_OVERRIDE and GRASS_REGION. Those name a region in the caller's
  mapset, not in the source project, so the read failed with "Unable to
  open element file <windows>" whenever v.proj ran under a named temporary
  region (e.g. inside RegionManager, use_temp_region(), or parallel
  pipelines).

  Read the source project's default window instead. The seed value is
  overwritten field by field from the input vector's extent immediately
  afterward, so seeding from the default window is sufficient and does not
  consult the override. G_unset_window() is dropped since it only existed
  to defeat G_get_window()'s cache.

  Add a regression test that runs v.proj with WIND_OVERRIDE naming a region
  present only in the target mapset
</details>

## Commit message

When v.proj switches into the source project to read the input vector, it seeded its working region with G_get_window(), which honors WIND_OVERRIDE and GRASS_REGION. WIND_OVERRIDE names a region in the caller's mapset, not in the source project, so the read failed with "Unable to open element file" whenever v.proj ran under a named temporary region (e.g. inside RegionManager, use_temp_region(), or parallel pipelines). Using GRASS_REGION would also be wrong.

Read the source project's default window instead. The seed value is overwritten field by field from the input vector's extent immediately afterward, so seeding from the default window is sufficient and does not consult the override. G_unset_window() is dropped since it only existed to defeat G_get_window()'s cache.

Adds a regression test that runs v.proj with WIND_OVERRIDE naming a region present only in the target mapset.