### PR TITLE
grass.script: Sanitize GRASS_MASK in mapset environment

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -2246,6 +2246,8 @@ def sanitize_mapset_environment(env):
         del env["WIND_OVERRIDE"]
     if "GRASS_REGION" in env:
         del env["GRASS_REGION"]
+    if "GRASS_MASK" in env:
+        del env["GRASS_MASK"]
     return env
 
 

--- a/python/grass/script/tests/grass_script_setup_test.py
+++ b/python/grass/script/tests/grass_script_setup_test.py
@@ -469,7 +469,7 @@ def test_grass_path_types_in_setup(tmp_path, path_type):
     assert "GISBASE" in env
 
 
-@pytest.mark.parametrize("variable", ["GRASS_REGION", "WIND_OVERRIDE"])
+@pytest.mark.parametrize("variable", ["GRASS_REGION", "WIND_OVERRIDE", "GRASS_MASK"])
 @pytest.mark.usefixtures("mock_no_session")
 def test_init_removes_mapset_variables(tmp_path, variable):
     """Check that init removes mapset-specific variables from the environment.


### PR DESCRIPTION
sanitize_mapset_environment() removes WIND_OVERRIDE and GRASS_REGION but not GRASS_MASK, which was added in 8.5 
