### PR TITLE
r.param.scale: loosen curvature test tolerance across platforms

### DIFF
--- a/raster/r.param.scale/tests/r_param_scale_test.py
+++ b/raster/r.param.scale/tests/r_param_scale_test.py
@@ -191,7 +191,8 @@ def test_param_scale_matches_reference(param_scale_session, method, size):
     assert stats["n"] == reference["n"]
     assert stats["null_cells"] == reference["null_cells"]
 
-    # Value statistics: relative tolerance, with an absolute floor that
-    # covers near-zero values and a zero standard deviation.
+    # Value statistics: relative tolerance for the large-magnitude methods,
+    # with an absolute floor above cross-build floating-point noise for the
+    # near-zero curvature outputs (profc/planc/minic) and zero stddev.
     for field in ("min", "max", "mean", "stddev", "sum"):
-        assert stats[field] == pytest.approx(reference[field], rel=1e-6, abs=1e-9)
+        assert stats[field] == pytest.approx(reference[field], rel=1e-6, abs=5e-8)


### PR DESCRIPTION
My previous PR #7534 was merged into main but ended up having a "(ubuntu-24.04, 3.13) (push)" error once it was pushed, so this PR is to just fix that one little issue.

The curvature numbers were tiny, very close to zero. The last digits came out a little different depending on the compiler and CPUs, so the values match to about 7 figures but not exactly. My old tolerance of (1e-9) was too tight so planc at size 9 failed on the Linux runner by a very small amount. I'm raising the floor to be 5e-8 so it handles the platform rounding properly and it's still far below the size change a real bug would have caused if there was one.