### PR TITLE
tests: skip r.param.scale reference test pending libgmath race fix #7539

### DIFF
--- a/raster/r.param.scale/tests/r_param_scale_test.py
+++ b/raster/r.param.scale/tests/r_param_scale_test.py
@@ -168,6 +168,7 @@ def _combos():
             yield method, size
 
 
+@pytest.mark.skip(reason="Waiting for a fix to the libgmath race, see #7539")
 @pytest.mark.parametrize(("method", "size"), list(_combos()))
 def test_param_scale_matches_reference(param_scale_session, method, size):
     """r.param.scale stats must match the main reference values."""


### PR DESCRIPTION
The reference test added in #7534 turns out to be flaky on main, but the cause isn't the test itself. It's the libgmath race in #7539, which fires when the LU solution runs at the default thread count and occasionally corrupts the output. I'm adding this PR to skip it until the library fix lands, the same way r.mapcalc's nprocs test is currently skipped.