### PR TITLE
lib/datetime: Fix reliability issues and replace non-reentrant time functions

### DIFF
--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -81,6 +81,7 @@ int datetime_get_local_timezone(int *minutes)
 void datetime_get_local_time(DateTime *dt)
 {
     time_t clock;
+    struct tm local_tm;
     struct tm *local;
 
     /* first set dt to absolute full date */
@@ -88,7 +89,7 @@ void datetime_get_local_time(DateTime *dt)
 
     /* get the current date/time */
     time(&clock);
-    local = localtime(&clock);
+    local = localtime_r(&clock, &local_tm);
 
     /* now put current {year,month,day,hour,minute,second} into dt */
     datetime_set_year(dt, (int)local->tm_year + 1900);

--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -27,13 +27,14 @@
  */
 int datetime_get_local_timezone(int *minutes)
 {
+    struct tm local_tm, gm_tm;
     struct tm *local, *gm;
     time_t clock;
     DateTime dtl, dtg, dtdiff;
 
     time(&clock);
 
-    local = localtime(&clock);
+    local = localtime_r(&clock, &local_tm);
 
     datetime_set_type(&dtl, DATETIME_ABSOLUTE, DATETIME_YEAR, DATETIME_SECOND,
                       0);

--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -47,7 +47,7 @@ int datetime_get_local_timezone(int *minutes)
     datetime_set_minute(&dtl, (int)local->tm_min);
     datetime_set_second(&dtl, (double)local->tm_sec);
 
-    gm = gmtime(&clock);
+    gm = gmtime_r(&clock, &gm_tm);
 
     datetime_set_type(&dtg, DATETIME_ABSOLUTE, DATETIME_YEAR, DATETIME_SECOND,
                       0);

--- a/lib/datetime/same.c
+++ b/lib/datetime/same.c
@@ -20,6 +20,14 @@
  */
 int datetime_is_same(const DateTime *src, const DateTime *dst)
 {
-    /* WARNING: doesn't allow for padding */
-    return memcmp(src, dst, sizeof(DateTime)) == 0;
+    /* Compare field-by-field (DateTime may contain padding) */
+    return src->year == dst->year &&
+        src->month == dst->month &&
+        src->day == dst->day &&
+        src->hour == dst->hour &&
+        src->minute == dst->minute &&
+        src->second == dst->second &&
+        src->usec == dst->usec &&
+        src->timezone == dst->timezone;
+
 }


### PR DESCRIPTION
## Description

Fix a reliability bug and replace two non-reentrant time functions in
`lib/datetime`.

| File | Category | Fix |
|------|----------|-----|
| `same.c` | Reliability | Compare `DateTime` structs member-by-member instead of with `memcmp`; the struct contains padding bytes whose values are unspecified, making `memcmp` incorrect for equality checks |
| `local.c` | Maintainability | Replace non-reentrant `localtime()` with `localtime_r()` (×2) |
| `local.c` | Maintainability | Replace non-reentrant `gmtime()` with `gmtime_r()` |

## Motivation and context

The `memcmp` equality check on a struct with padding is undefined behaviour —
padding bytes are not guaranteed to be zeroed, so two logically equal
`DateTime` values can compare as unequal. Member-by-member comparison
avoids this.

`localtime()` and `gmtime()` return pointers to a shared static buffer,
making them unsafe in multithreaded code. The `_r` variants write to a
caller-supplied buffer.

## How has this been tested?

`lib/datetime` has no dedicated C unit test suite. The functions are
exercised indirectly through the temporal module and related tools.
These changes are behaviour-preserving for single-threaded use and
correctness-fixing for the struct comparison.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md) of this project
- [ ] My change requires a change to the documentation
- [ ] I have added tests to cover my changes