### PR TITLE
docs: Fix crash and simplify git calls in mkdocs generation

### DIFF
--- a/utils/mkdocs.py
+++ b/utils/mkdocs.py
@@ -92,7 +92,7 @@ def get_version_branch(major_version, addons_git_repo_url):
             if gs:
                 gs.fatal(_(message))
             else:
-                sys.stderr.write(message + "\n")
+                sys.exit(message)
         if version_branch not in branch.decode():
             version_branch = "grass{}".format(int(major_version) - 1)
     return version_branch
@@ -440,7 +440,7 @@ def get_addon_path(base_url, pgm, major_version):
         if gs:
             gs.fatal(_(message))
         else:
-            sys.stderr.write(message + "\n")
+            sys.exit(message)
     addon_paths = re.findall(
         rf".*{pgm}*.",
         addons_file_list.decode(),

--- a/utils/mkdocs.py
+++ b/utils/mkdocs.py
@@ -73,7 +73,7 @@ def get_version_branch(major_version, addons_git_repo_url):
     """
     version_branch = f"grass{major_version}"
     if source_is_remote():
-        branch = gs.Popen(
+        branch = subprocess.Popen(
             [
                 "git",
                 "ls-remote",
@@ -86,16 +86,14 @@ def get_version_branch(major_version, addons_git_repo_url):
         )
         branch, stderr = branch.communicate()
         if stderr:
-            gs.fatal(
-                _(
-                    "Failed to get branch from the Git repository"
-                    " <{repo_path}>.\n{error}"
-                ).format(
-                    repo_path=addons_git_repo_url,
-                    error=gs.decode(stderr),
-                )
-            )
-        if version_branch not in gs.decode(branch):
+            message = (
+                "Failed to get branch from the Git repository <{repo_path}>.\n{error}"
+            ).format(repo_path=addons_git_repo_url, error=stderr.decode())
+            if gs:
+                gs.fatal(_(message))
+            else:
+                sys.stderr.write(message + "\n")
+        if version_branch not in branch.decode():
             version_branch = "grass{}".format(int(major_version) - 1)
     return version_branch
 
@@ -397,14 +395,6 @@ def get_addon_path(base_url, pgm, major_version):
     if not addons_base_dir or not major_version:
         return None
     grass_addons_dir = Path(addons_base_dir) / "grass-addons"
-    if gs:
-        call = gs.call
-        popen = gs.Popen
-        fatal = gs.fatal
-    else:
-        call = subprocess.call
-        popen = subprocess.Popen
-        fatal = sys.stderr.write
     addons_branch = get_version_branch(
         major_version=major_version,
         addons_git_repo_url=urlparse.urljoin(base_url, "grass-addons/"),
@@ -419,7 +409,7 @@ def get_addon_path(base_url, pgm, major_version):
         try:
             with tempfile.TemporaryDirectory(dir=addons_base_dir) as tmpdir:
                 tmp_clone_path = Path(tmpdir) / "grass-addons"
-                call(
+                subprocess.call(
                     [
                         "git",
                         "clone",
@@ -435,7 +425,7 @@ def get_addon_path(base_url, pgm, major_version):
         except (shutil.Error, OSError):
             if not grass_addons_dir.exists():
                 raise
-    addons_file_list = popen(
+    addons_file_list = subprocess.Popen(
         ["git", "ls-tree", "--name-only", "-r", addons_branch],
         cwd=grass_addons_dir,
         stdout=subprocess.PIPE,
@@ -446,27 +436,14 @@ def get_addon_path(base_url, pgm, major_version):
         message = (
             "Failed to get addons files list from the"
             " Git repository <{repo_path}>.\n{error}"
-        )
+        ).format(repo_path=grass_addons_dir, error=stderr.decode())
         if gs:
-            fatal(
-                _(
-                    message,
-                ).format(
-                    repo_path=grass_addons_dir,
-                    error=gs.decode(stderr),
-                )
-            )
+            gs.fatal(_(message))
         else:
-            message += "\n"
-            fatal(
-                message.format(
-                    repo_path=grass_addons_dir,
-                    error=stderr.decode(),
-                )
-            )
+            sys.stderr.write(message + "\n")
     addon_paths = re.findall(
         rf".*{pgm}*.",
-        gs.decode(addons_file_list) if gs else addons_file_list.decode(),
+        addons_file_list.decode(),
     )
     for addon_path in addon_paths:
         if pgm == Path(addon_path).name:


### PR DESCRIPTION
This is trying to resolve regression after #7310 causing problems in addon compilation in CI. To be honest I am not sure I quite understand the exact mechanism, why gs is None in CI, but this PR should hopefully address the problems in logs like:
```
Traceback (most recent call last):
  File "/home/runner/install/grass86/utils/mkhtml.py", line 65, in <module>
    get_version_branch(
    ~~~~~~~~~~~~~~~~~~^
        major,
        ^^^^^^
        urlparse.urljoin(base_url, "grass-addons/"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/home/runner/install/grass86/utils/mkdocs.py", line 76, in get_version_branch
    branch = gs.Popen(
             ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'Popen'
```
This PR replaces gs.Popen/decode calls with standard Python calls.
One change I am not sure about is in `get_addon_path` where if gs was not available, it replaced fatal with sys.stderr.write, which is not the same, it does not exit. That seemed like unintentional, so I replaced it with sys.exit, but I am not sure about that.