### PR TITLE
libpython: Speed up grass.lib import by registering $GISBASE/lib

### DIFF
--- a/python/libgrass_interface_generator/libgrass__init__.py
+++ b/python/libgrass_interface_generator/libgrass__init__.py
@@ -1,3 +1,21 @@
+import os
+
+from .ctypes_loader import add_library_search_dirs
+
+# Register $GISBASE/lib (where the GRASS shared libraries are installed) with
+# the ctypes loader before any wrapper module loads its library. The loader
+# searches these directories first, so it finds the libraries by absolute path
+# and never reaches its ctypes.util.find_library() fallback. That fallback is
+# expensive on Linux, where find_library() spawns the toolchain (ldconfig, gcc,
+# ld, objdump) once per library; for the chain pulled in by grass.temporal that
+# was about 90 subprocesses and the bulk of the import time. The libraries are
+# still resolvable through the runtime linker path, so this is a startup
+# optimization, not a correctness fix; outside a GRASS session GISBASE may be
+# unset, in which case the loader keeps its original behavior.
+_gisbase = os.environ.get("GISBASE")
+if _gisbase:
+    add_library_search_dirs([os.path.join(_gisbase, "lib")])
+
 __all__ = [
     'arraystats',
     'cluster',

--- a/python/libgrass_interface_generator/libgrass__init__.py
+++ b/python/libgrass_interface_generator/libgrass__init__.py
@@ -2,16 +2,9 @@ import os
 
 from .ctypes_loader import add_library_search_dirs
 
-# Register $GISBASE/lib (where the GRASS shared libraries are installed) with
-# the ctypes loader before any wrapper module loads its library. The loader
-# searches these directories first, so it finds the libraries by absolute path
-# and never reaches its ctypes.util.find_library() fallback. That fallback is
-# expensive on Linux, where find_library() spawns the toolchain (ldconfig, gcc,
-# ld, objdump) once per library; for the chain pulled in by grass.temporal that
-# was about 90 subprocesses and the bulk of the import time. The libraries are
-# still resolvable through the runtime linker path, so this is a startup
-# optimization, not a correctness fix; outside a GRASS session GISBASE may be
-# unset, in which case the loader keeps its original behavior.
+# Register $GISBASE/lib with the ctypes loader so wrapper modules resolve GRASS
+# shared libraries by absolute path, skipping the expensive
+# ctypes.util.find_library() fallback. No-op when GISBASE is unset.
 _gisbase = os.environ.get("GISBASE")
 if _gisbase:
     add_library_search_dirs([os.path.join(_gisbase, "lib")])


### PR DESCRIPTION
Context is #7585 (import tgis takes too long). We found out that for Mac it is much faster, which triggered this solution. Claude debugged it:

## Root cause

GRASS libraries live in `$GISBASE/lib`, which the ctypes loader does not search  before falling back to `ctypes.util.find_library()`. On Linux that fallback  shells out to `ldconfig`/`gcc`/`ld`/`objdump` once per library (~90 subprocesses  for the `grass.temporal` chain). macOS is unaffected because its `find_library()`  spawns nothing.

  ## Fix

  Register `$GISBASE/lib` with the loader in `grass/lib/__init__.py` so libraries  resolve by absolute path and the fallback is never reached. Gated on `GISBASE`,  so out-of-session imports are unchanged.

  ## Results

  Cold `import grass.temporal` on Linux: ~2560 ms / 90 subprocesses → ~200 ms / 0.  ~13x faster, matching macOS.


@nilason I would appreciate your review on this. I tested the fix, seems fine, but I don't know if there are any unintended consequences.