### PR TITLE
contributing: Link AGENTS.md from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ leads you through a first time setup and shows how to create a pull request.
 To contribute effectively, please familiarize yourself with our
 [Programming Style Guide](./doc/development/style_guide.md).
 
+If you use an AI assistant or agent, see [`AGENTS.md`](./AGENTS.md) for
+project-specific instructions and conventions.
+
 ### Testing changes
 
 Testing helps to ensure that the changes work well with the rest


### PR DESCRIPTION
Add the AGENTS.md file as another file linked from CONTRIBUTING.md so there is a clear contributing policy on using AGENTS.md. Additionally, this may also help humans who truly read the doc and agents who, for some reason, read the human-centered instructions first.

I considered adding there something like 'you use _or are_ an AI assistant' but a reasonable agent will understand either way and the document is meant for humans, so simpler and cleaner wording seems more fitting.
