### PR TITLE
contributing: Add notes on sandbox and addon builds to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ If `ccache` is installed it is used automatically; set `CCACHE_DIR` to a
 writable path if the default cache location is read-only (e.g. in a sandbox).
 GRASS uses `~/.grass8` for user config and installed addons by default; set
 `GRASS_CONFIG_DIR` to a writable directory for a sandbox, or to isolate a
-run from existing user settings. For a rootless install (e.g. a sandbox, where the default
-`/usr/local` is not writable), set the prefix at configure time:
+run from existing user settings. For a rootless install (e.g. a sandbox,
+where the default `/usr/local` is not writable), set the prefix at configure
+time:
 `cmake -B build -DCMAKE_INSTALL_PREFIX=<writable path>`. GRASS records this
 prefix in the install, so the configure-time value (not `cmake --install
 --prefix`) is what the installed tree uses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@ on a system missing one, configure fails with a "Could not find ..." error.
 Disable it (e.g. `cmake -B build -DWITH_PDAL=OFF`) or install the dependency.
 If `ccache` is installed it is used automatically; set `CCACHE_DIR` to a
 writable path if the default cache location is read-only (e.g. in a sandbox).
+GRASS uses `~/.grass8` for user config and installed addons by default; set
+`GRASS_CONFIG_DIR` to a writable directory for a sandbox, or to isolate a
+run from existing user settings. For a rootless install (e.g. a sandbox, where the default
+`/usr/local` is not writable), set the prefix at configure time:
+`cmake -B build -DCMAKE_INSTALL_PREFIX=<writable path>`. GRASS records this
+prefix in the install, so the configure-time value (not `cmake --install
+--prefix`) is what the installed tree uses.
 
 **Compile a single tool** (after libraries are built):
 
@@ -62,7 +69,10 @@ make
 
 With Autotools, build outputs go to `bin.$ARCH/` and `dist.$ARCH/`. With
 CMake, the runnable tree (before `cmake --install`) is under `build/output/`,
-with the binary at `build/output/bin/grass`.
+with the binary at `build/output/bin/grass`. With a CMake-built GRASS,
+`g.extension` builds an addon with CMake and needs an *installed* GRASS
+(`cmake --install` to a prefix), not the `build/output/` tree, which omits the
+addon CMake package (`etc/cmake/build_addon.cmake`).
 
 ## Running Tests
 
@@ -109,10 +119,12 @@ pytest raster/r.slope.aspect/tests/r_slope_aspect_test.py
 ```
 
 **Run gunittest-style tests** (legacy `testsuite/` directories; currently the
-only way to use larger datasets like the `nc_spm` sample dataset):
+only way to use larger datasets like the `nc_spm` sample dataset) by creating a
+throwaway mapset in an existing project (judge by exit code, not the verbose
+output):
 
 ```bash
-python -m grass.gunittest.main --grassdata /path/to/grassdata --location location --location-type xyz
+grass -c <project>/<mapset> --exec ./test_x.py
 ```
 
 ## Writing Tests


### PR DESCRIPTION
Using a use case of a standalone addon tool repo (specifically, r.pops.spread is published in addons, but the developed in a standalone repo), this expands instructions in AGENTS.md on how to compile and run with CMake in a sandbox (developed with Claude Code sandbox) and how to compile an addon tool. While grass-addon and cookie cutter repo instructions would be helpful as well, the addons instruction part covers the case when you use the source code of GRASS, but don't deal with the grass-addon repo.

I'm also slighltly changing how the grass.gunittest is presented, focusing on a single file, rather than a directory run. This simplifies the project-related instructions, replacing the currently confusing version.

The addons piece is something which may possible confuse an agent (if you don't work with addons or g.extension), but I would just wait to see how it behaves.

@nilason or @HuidaeCho if you can check if the CMake prefix instructions are good, that would be great. This is a result based on how it behaved and what Claude came up with as an evaluation, but it is intended? I'm still not 100% comfortable with CMake, so it is hard for me to be sure this right and does have some red flags for me, mainly the use of `-D` vs `--prefix`.