### PR TITLE
t.list: add regression test for listing from a mapset without a temporal database

### DIFF
--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -152,15 +152,21 @@ def main():
 
     tools = Tools()
 
-    conn = tools.t_connect(flags="p", format="json", mapset=".")
+    # One entry per mapset in the current search path
+    conn = tools.t_connect(flags="p", format="json")
 
-    db_exists = conn[0]["driver"] and conn[0]["database"]
+    db_exists = any(
+        mapset_conn["driver"] and mapset_conn["database"] for mapset_conn in conn
+    )
 
-    # if no connection is found
+    # if no connection is found in any accessible mapset
     if not db_exists:
         if output_format == "plain":
             gs.message(
-                _("No temporal database exists in this mapset. No datasets to list.")
+                _(
+                    "No temporal database exists in any accessible mapset. "
+                    "No datasets to list."
+                )
             )
         with (
             open(outpath, "w")

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -152,21 +152,15 @@ def main():
 
     tools = Tools()
 
-    # One entry per mapset in the current search path
-    conn = tools.t_connect(flags="p", format="json")
+    conn = tools.t_connect(flags="p", format="json", mapset=".")
 
-    db_exists = any(
-        mapset_conn["driver"] and mapset_conn["database"] for mapset_conn in conn
-    )
+    db_exists = conn[0]["driver"] and conn[0]["database"]
 
-    # if no connection is found in any accessible mapset
+    # if no connection is found
     if not db_exists:
         if output_format == "plain":
             gs.message(
-                _(
-                    "No temporal database exists in any accessible mapset. "
-                    "No datasets to list."
-                )
+                _("No temporal database exists in this mapset. No datasets to list.")
             )
         with (
             open(outpath, "w")

--- a/temporal/t.list/tests/test_t_list.py
+++ b/temporal/t.list/tests/test_t_list.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from grass.experimental import TemporaryMapsetSession
 from grass.tools import Tools
 
 
@@ -151,3 +152,13 @@ def test_t_list_empty_database(empty_session):
     result = tools.t_connect(flags="p", format="json", mapset=".")
     db_exist = result[0]["driver"] and result[0]["database"]
     assert not db_exist
+
+
+def test_t_list_from_mapset_without_temporal_database(space_time_dataset):
+    """Datasets in accessible mapsets are listed even when the current mapset
+    has no temporal database (https://github.com/OSGeo/grass/issues/7622)."""
+    with TemporaryMapsetSession(env=space_time_dataset.session.env) as mapset_session:
+        tools = Tools(session=mapset_session)
+        result = tools.t_list(type="strds", format="json")
+        names = [record["name"] for record in result.json]
+        assert space_time_dataset.name in names


### PR DESCRIPTION
Per review, this now adds only the regression test for #7622: it lists datasets from a temporary mapset while the dataset lives in PERMANENT, so the case of running t.list from a mapset without a temporal database stays covered.

The behavior fix itself lands in #7631. I checked out that branch locally and this test passes with it, and fails on current main, so CI here will stay red until #7631 is merged. Happy to update the branch after that.
