### PR TITLE
gui/wxpython: dynamically check GRASS_ADDON_BASE for newly installed modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,7 @@ repos:
           - python
           - tex
           - xml
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.7
+    hooks:
+      - id: gersemi


### PR DESCRIPTION
### Description
This PR resolves issue #7483 where a newly installed addon fails to open its wxGUI dialog window during the same session on macOS.

### Root Cause
When the wxGUI initializes, `globalvar.grassCmd` caches the list of available GRASS commands. Running `g.extension` mid-session installs the binary correctly, but the string list cache is never refreshed. Because the command evaluates to `False` against the stale `globalvar.grassCmd` list, it defaults to background CLI execution instead of opening `GUI().ParseCommand()`. 

Forcing the tool with `--ui` runs it as an isolated process detached from the layer manager framework, triggering subsequent `NotImplementedError` failures when trying to fetch coordinates via the selection cursor.

### Fix
Added a non-intrusive dynamic check using `shutil.which` inside `GConsole.RunCmd`. If an executed command isn't tracked inside the startup `globalvar.grassCmd` cache, it actively looks inside the live environment's `GRASS_ADDON_BASE/bin` or `scripts` folders. If discovered, it updates the runtime cache pool on the fly so the dialog wrapper intercepts and builds the GUI interface seamlessly.