### PR TITLE
wxGUI/pyedit: Fix saving and opening a file in docked mode

### DIFF
--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -453,10 +453,8 @@ class PyEditController:
         else:
             self.SaveAs()
 
-        if self.filename:
-            self.recent_files.AddFileToHistory(
-                filename=self.filename,
-            )
+        if self.filename and self.recent_files:
+            self.recent_files.AddFileToHistory(filename=self.filename)
 
     def IsModified(self):
         """Check if python script has been modified"""
@@ -492,10 +490,8 @@ class PyEditController:
         """Handle open event but ask about replacing content first"""
         if self.CanReplaceContent("file"):
             self.Open()
-            if self.filename:
-                self.recent_files.AddFileToHistory(
-                    filename=self.filename,
-                )
+            if self.filename and self.recent_files:
+                self.recent_files.AddFileToHistory(filename=self.filename)
 
     def OpenRecentFile(self, path, file_exists, file_history):
         """Try open recent file and read content


### PR DESCRIPTION
Fixes saving and opening a py file in the default docked mode (undocked editor works fine):

The error when saving a file:

```
Traceback (most recent call last):
  File "/home/linduska/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/pyedit.py", line 816, in OnSave

self.controller.OnSave(*args, **kwargs)
  File "/home/linduska/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/pyedit.py", line 457, in OnSave

self.recent_files.AddFileToHistory(
AttributeError
:
'NoneType' object has no attribute 'AddFileToHistory'
```

The similar error shows up when opening a file:

```
Traceback (most recent call last):
  File "/home/linduska/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/pyedit.py", line 813, in OnOpen

self.controller.OnOpen(*args, **kwargs)
  File "/home/linduska/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/pyedit.py", line 496, in OnOpen

self.recent_files.AddFileToHistory(
AttributeError
:
'NoneType' object has no attribute 'AddFileToHistory'
```

 The upper menu is not present in the docked mode, so the recent_files variable is null.