### PR TITLE
gui: Actually raise GExceptions in iscatt_core

### DIFF
--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -82,7 +82,7 @@ def ApplyColormap(vals, vals_mask, colmap, out_vals):
 
 def MergeArrays(merged_arr, overlay_arr, alpha):
     if merged_arr.shape != overlay_arr.shape:
-        GException("MergeArrays: merged_arr.shape != overlay_arr.shape")
+        raise GException("MergeArrays: merged_arr.shape != overlay_arr.shape")
 
     c_uint8_p = POINTER(c_uint8)
     merged_p = merged_arr.ctypes.data_as(c_uint8_p)

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -82,7 +82,8 @@ def ApplyColormap(vals, vals_mask, colmap, out_vals):
 
 def MergeArrays(merged_arr, overlay_arr, alpha):
     if merged_arr.shape != overlay_arr.shape:
-        raise GException("MergeArrays: merged_arr.shape != overlay_arr.shape")
+        msg = "MergeArrays: merged_arr.shape != overlay_arr.shape"
+        raise GException(msg)
 
     c_uint8_p = POINTER(c_uint8)
     merged_p = merged_arr.ctypes.data_as(c_uint8_p)

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -383,7 +383,8 @@ class AnalyzedData:
 
         self.region = GetRegion()
         if self.region["rows"] * self.region["cols"] > MAX_NCELLS:
-            raise GException("too big region")
+            msg = "too big region"
+            raise GException(msg)
 
         self.bands_info = {}
 

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -139,7 +139,7 @@ class Core:
         )
 
         if returncode < 0:
-            GException(_("Computing of scatter plots failed."))
+            raise GException(_("Computing of scatter plots failed."))
 
     def CatRastUpdater(self):
         return self.cat_rast_updater
@@ -274,7 +274,7 @@ class CatRastUpdater:
             region = self.an_data.GetRegion()
             ret = UpdateCatRast(patch_rast, region, self.scatts_dt.GetCatRastCond(cat))
             if ret < 0:
-                GException(_("Patching category raster conditions file failed."))
+                raise GException(_("Patching category raster conditions file failed."))
             RunCommand("g.remove", flags="f", type="raster", name=patch_rast)
 
     def _rasterize(self, grass_region, layer, cat, out_rast):
@@ -296,7 +296,7 @@ class CatRastUpdater:
         )
 
         if ret != 0:
-            GException(_("v.build failed:\n%s") % msg)
+            raise GException(_("v.build failed:\n%s") % msg)
 
         environs = os.environ.copy()
         environs["GRASS_REGION"] = grass_region["GRASS_REGION"]
@@ -316,7 +316,7 @@ class CatRastUpdater:
         )
 
         if ret != 0:
-            GException(_("v.to.rast failed:\n{messages}").format(messages=msg))
+            raise GException(_("v.to.rast failed:\n{messages}").format(messages=msg))
 
     def _create_grass_region_env(self, bbox):
         r = self.an_data.GetRegion()
@@ -383,7 +383,7 @@ class AnalyzedData:
 
         self.region = GetRegion()
         if self.region["rows"] * self.region["cols"] > MAX_NCELLS:
-            GException("too big region")
+            raise GException("too big region")
 
         self.bands_info = {}
 
@@ -391,7 +391,7 @@ class AnalyzedData:
             i = GetRasterInfo(b)
 
             if i is None:
-                GException("raster %s is not CELL type" % (b))
+                raise GException("raster %s is not CELL type" % (b))
 
             self.bands_info[b] = i
             # TODO check size of raster


### PR DESCRIPTION
Some code in iscatt was not raising the exception it was creating. Thus, it was not having any effect.

Here is the PR text for one of the fixes that was generated by AI. I did the others.


General fix: when an error condition is detected, **raise** the exception instead of just constructing it.

Best fix here: in `gui/wxpython/iscatt/iscatt_core.py`, inside `CatRastUpdater._updateCatRast`, change line 277 from:
- `GException(_("Patching category raster conditions file failed."))` to:
- `raise GException(_("Patching category raster conditions file failed."))`

This preserves intended functionality (error reporting via `GException`) while ensuring the failure is not silently ignored. No new imports, methods, or definitions are required.