### PR TITLE
r.to.rast3elev: Check return-value for 'scanf'-like functions

### DIFF
--- a/raster/r.to.rast3elev/main.c
+++ b/raster/r.to.rast3elev/main.c
@@ -408,7 +408,7 @@ int main(int argc, char *argv[])
 
     /*Set the upper value */
     if (param.upper->answer) {
-        if (sscanf(param.upper->answer, "%lf", &db.upper))
+        if (sscanf(param.upper->answer, "%lf", &db.upper) == 1)
             db.useUpperVal = 2;
         else
             G_fatal_error(_("The upper value is not valid"));
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
 
     /*Set the lower value */
     if (param.lower->answer) {
-        if (sscanf(param.lower->answer, "%lf", &db.lower))
+        if (sscanf(param.lower->answer, "%lf", &db.lower) == 1)
             db.useLowerVal = 2;
         else
             G_fatal_error(_("The lower value is not valid"));


### PR DESCRIPTION
From me:

Resolves two CodeQL warning. 

In https://en.cppreference.com/c/io/fscanf, it shows how the return value of sscanf is the number of successfully assigned arguments, with can also be zero or EOF.

The change is to explicitly check for the value 1.




---

From the auto fix (adapted):

Potential fix for [https://github.com/OSGeo/grass/security/code-scanning/529](https://github.com/OSGeo/grass/security/code-scanning/529)
And [https://github.com/OSGeo/grass/security/code-scanning/530](https://github.com/OSGeo/grass/security/code-scanning/530)

The correct fix is to validate `sscanf` return values against the exact expected number of matched items, not just truthiness.

In `raster/r.to.rast3elev/main.c`, update both numeric parsing checks:

- Line around `if (sscanf(param.upper->answer, "%lf", &db.upper))`
- Line around `if (sscanf(param.lower->answer, "%lf", &db.lower))`

Change each condition to `== 1`, since each call expects exactly one `%lf` conversion. This preserves existing behavior for valid input while correctly rejecting parse failures and any non-success return values (including `EOF`).

No new methods, imports, or dependencies are needed.


