### PR TITLE
CMake: Build man pages from markdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,8 +219,9 @@ include(build_gui_in_subdir)
 include(generate_docs)
 
 set(MKHTML_PY ${CMAKE_BINARY_DIR}/utils/mkhtml.py)
+set(MKMARKDOWN_PY ${CMAKE_BINARY_DIR}/utils/mkmarkdown.py)
 set(THUMBNAILS_PY ${CMAKE_BINARY_DIR}/utils/thumbnails.py)
-set(HTML2MAN ${CMAKE_BINARY_DIR}/utils/g.html2man.py)
+set(MD2MAN ${CMAKE_BINARY_DIR}/utils/g.md2man.py)
 
 set(env_path "$ENV{PATH}")
 
@@ -299,6 +300,7 @@ if(WITH_DOCS)
   add_subdirectory(doc)
   add_subdirectory(man)
   install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/ DESTINATION ${GRASS_INSTALL_DOCDIR})
+  install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/ DESTINATION ${GRASS_INSTALL_MKDOCSDIR})
   install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_MANDIR}/ DESTINATION ${GRASS_INSTALL_MANDIR})
 endif()
 

--- a/cmake/modules/generate_docs.cmake
+++ b/cmake/modules/generate_docs.cmake
@@ -167,6 +167,7 @@ function(generate_docs name)
       COMMAND ${copy_images_command}
       COMMAND ${copy_images_command_md}
       COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file} ${tmp_md_file}
+      BYPRODUCTS ${out_md_file} ${out_man_file}
       COMMENT "Creating ${name}.[html|md|1]")
   elseif(D_GUI_TARGET_NAME)
     set(gui_html_file ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/wxGUI.${name}.html)
@@ -192,6 +193,7 @@ function(generate_docs name)
       COMMAND ${CMAKE_COMMAND} -E remove ${tmp_md_file}
       COMMAND ${mkmarkdown_cmd} ${D_GUI_TARGET_NAME} > ${gui_md_file}
       COMMAND ${md2man_cmd} ${gui_md_file} ${gui_man_file}
+      BYPRODUCTS ${out_md_file} ${out_man_file} ${gui_md_file} ${gui_man_file}
       COMMENT "Creating ${out_html_file} and ${gui_html_file}"
       DEPENDS ${D_DEPENDS})
   else()
@@ -212,6 +214,7 @@ function(generate_docs name)
       COMMAND ${copy_images_command}
       COMMAND ${copy_images_command_md}
       COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file} ${tmp_md_file}
+      BYPRODUCTS ${out_md_file} ${out_man_file}
       COMMENT "Creating ${OUT_HTML_FILE}"
       DEPENDS ${D_DEPENDS})
   endif()

--- a/cmake/modules/generate_docs.cmake
+++ b/cmake/modules/generate_docs.cmake
@@ -16,9 +16,9 @@ Generate documentation
                      [DOC_FILES <doc-files>...]
                      [IMG_FILES <image-files>...])
 
-  Generate documentation files (.html, .man1 etc.) of <doc-files>, which is
-  a list of file names without file extension. The image files <image-files>
-  are installed. The command is added to the target <target>.
+  Generate documentation files (.html, .md, man page) of <doc-files>, which
+  is a list of file names without file extension. The image files
+  <image-files> are installed. The command is added to the target <target>.
   This is a command intended for plain documentation files, not modules.
 
   generate_docs(<name>
@@ -32,8 +32,10 @@ Generate documentation
               [IMG_NO]
               [HTML_DESCR])
 
-  Generate documentation files (.html, .man1 etc.) of <name>, which is a source
-  documentation file name without extension.
+  Generate documentation files (.html, .md, man page) of <name>, which is a
+  source documentation file name without extension. The man page is built
+  from the generated Markdown; the HTML pages are generated for the legacy
+  documentation system.
 
   Typical use case is, for example:
 
@@ -60,8 +62,11 @@ macro(generate_docs_list)
       TARGET ${D_TARGET}
       PRE_BUILD
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${D_IMG_FILES} ${OUTDIR}/${GRASS_INSTALL_DOCDIR})
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${D_IMG_FILES} ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${D_IMG_FILES}
+              ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source)
     install(FILES ${D_IMG_FILES} DESTINATION ${GRASS_INSTALL_DOCDIR})
+    install(FILES ${D_IMG_FILES} DESTINATION ${GRASS_INSTALL_MKDOCSDIR}/source)
   endif()
 endmacro()
 
@@ -83,16 +88,26 @@ function(generate_docs name)
   if(D_GUI_TARGET_NAME)
     set(html_file_name ${D_GUI_TARGET_NAME}.html)
     set(tmp_html_name ${D_GUI_TARGET_NAME}.tmp.html)
+    set(md_file_name ${D_GUI_TARGET_NAME}.md)
+    set(tmp_md_name ${D_GUI_TARGET_NAME}.tmp.md)
     set(man_file_name ${D_GUI_TARGET_NAME}.1)
   else()
     set(html_file_name ${name}.html)
     set(tmp_html_name ${name}.tmp.html)
+    set(md_file_name ${name}.md)
+    set(tmp_md_name ${name}.tmp.md)
     set(man_file_name ${name}.1)
   endif()
-  set(source_html "${sourcedir}/${html_file_name}")
-  set(html_file "${CMAKE_CURRENT_BINARY_DIR}/${html_file_name}")
-  set(tmp_html_file "${CMAKE_CURRENT_BINARY_DIR}/${tmp_html_name}")
+  # The doc generation commands run in the source directory: mkhtml.py and
+  # mkmarkdown.py read the page source and the .tmp. usage file from the
+  # current directory and derive the repository path for the source code
+  # links from it. The .tmp. files are gitignored, and the Autotools build
+  # writes them into the source directory as well.
+  set(tmp_html_file "${sourcedir}/${tmp_html_name}")
   set(out_html_file "${OUTDIR}/${GRASS_INSTALL_DOCDIR}/${html_file_name}")
+  set(mkdocs_source_dir "${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source")
+  set(tmp_md_file "${sourcedir}/${tmp_md_name}")
+  set(out_md_file "${mkdocs_source_dir}/${md_file_name}")
   set(out_man_file "${OUTDIR}/${GRASS_INSTALL_MANDIR}/${man_file_name}")
 
   if(WIN32)
@@ -114,8 +129,11 @@ function(generate_docs name)
         ${grass_env_command}
         ${name}${ext} --html-description < ${null_device} |
         ${search_cmd} ${html_search_str})
+    set(md_descr_command ${grass_env_command} ${name}${ext} --md-description
+        < ${null_device})
   else()
     set(html_descr_command ${CMAKE_COMMAND} -E echo)
+    set(md_descr_command ${CMAKE_COMMAND} -E echo)
   endif()
 
   if(NOT D_IMG_FILES)
@@ -126,41 +144,54 @@ function(generate_docs name)
   if(D_IMG_FILES AND NOT D_IMG_NO)
     set(copy_images_command ${CMAKE_COMMAND} -E copy_if_different ${D_IMG_FILES}
                             ${OUTDIR}/${GRASS_INSTALL_DOCDIR})
+    set(copy_images_command_md ${CMAKE_COMMAND} -E copy_if_different
+                               ${D_IMG_FILES} ${mkdocs_source_dir})
     install(FILES ${D_IMG_FILES} DESTINATION ${GRASS_INSTALL_DOCDIR})
+    install(FILES ${D_IMG_FILES} DESTINATION ${GRASS_INSTALL_MKDOCSDIR}/source)
   endif()
 
   set(mkhtml_cmd ${grass_env_command} ${PYTHON_EXECUTABLE} ${MKHTML_PY})
-  set(html2man_cmd ${grass_env_command} ${PYTHON_EXECUTABLE} ${HTML2MAN})
+  set(mkmarkdown_cmd ${grass_env_command} ${PYTHON_EXECUTABLE} ${MKMARKDOWN_PY})
+  set(md2man_cmd ${grass_env_command} ${PYTHON_EXECUTABLE} ${MD2MAN})
 
   if(D_TARGET)
     add_custom_command(
       TARGET ${D_TARGET}
       POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${source_html} ${html_file}
+      WORKING_DIRECTORY ${sourcedir}
       COMMAND ${html_descr_command} > ${tmp_html_file}
       COMMAND ${mkhtml_cmd} ${name} > ${out_html_file}
-      COMMAND ${html2man_cmd} ${out_html_file} ${out_man_file}
+      COMMAND ${md_descr_command} > ${tmp_md_file}
+      COMMAND ${mkmarkdown_cmd} ${name} > ${out_md_file}
+      COMMAND ${md2man_cmd} ${out_md_file} ${out_man_file}
       COMMAND ${copy_images_command}
-      COMMAND ${CMAKE_COMMAND} -E remove ${html_file}
-      COMMENT "Creating ${name}.[html|1]")
+      COMMAND ${copy_images_command_md}
+      COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file} ${tmp_md_file}
+      COMMENT "Creating ${name}.[html|md|1]")
   elseif(D_GUI_TARGET_NAME)
     set(gui_html_file ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/wxGUI.${name}.html)
+    set(gui_md_file ${mkdocs_source_dir}/wxGUI.${name}.md)
     set(gui_man_file ${OUTDIR}/${GRASS_INSTALL_MANDIR}/wxGUI.${name}.1)
     set(py_script_file ${OUTDIR}/${GRASS_INSTALL_SCRIPTDIR}/${D_GUI_TARGET_NAME}${py})
 
     add_custom_command(
       OUTPUT ${out_html_file}
-      COMMAND ${CMAKE_COMMAND} -E copy ${source_html} ${html_file}
+      WORKING_DIRECTORY ${sourcedir}
       COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${py_script_file}
               --html-description < ${null_device} | ${search_cmd}
               ${html_search_str} > ${tmp_html_file}
       COMMAND ${mkhtml_cmd} ${D_GUI_TARGET_NAME} > ${out_html_file}
-      COMMAND ${html2man_cmd} ${out_html_file} ${out_man_file}
       COMMAND ${copy_images_command}
       COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file}
       COMMAND ${mkhtml_cmd} ${D_GUI_TARGET_NAME} > ${gui_html_file}
-      COMMAND ${html2man_cmd} ${gui_html_file} ${gui_man_file}
-      COMMAND ${CMAKE_COMMAND} -E remove ${html_file}
+      COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${py_script_file}
+              --md-description < ${null_device} > ${tmp_md_file}
+      COMMAND ${mkmarkdown_cmd} ${D_GUI_TARGET_NAME} > ${out_md_file}
+      COMMAND ${md2man_cmd} ${out_md_file} ${out_man_file}
+      COMMAND ${copy_images_command_md}
+      COMMAND ${CMAKE_COMMAND} -E remove ${tmp_md_file}
+      COMMAND ${mkmarkdown_cmd} ${D_GUI_TARGET_NAME} > ${gui_md_file}
+      COMMAND ${md2man_cmd} ${gui_md_file} ${gui_man_file}
       COMMENT "Creating ${out_html_file} and ${gui_html_file}"
       DEPENDS ${D_DEPENDS})
   else()
@@ -169,14 +200,18 @@ function(generate_docs name)
 
     add_custom_command(
       OUTPUT ${out_html_file}
-      COMMAND ${CMAKE_COMMAND} -E copy ${source_html} ${html_file}
+      WORKING_DIRECTORY ${sourcedir}
       COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${py_script_file}
               --html-description < ${null_device} | ${search_cmd}
               ${html_search_str} > ${tmp_html_file}
       COMMAND ${mkhtml_cmd} ${name} > ${out_html_file}
-      COMMAND ${html2man_cmd} ${out_html_file} ${out_man_file}
+      COMMAND ${grass_env_command} ${PYTHON_EXECUTABLE} ${py_script_file}
+              --md-description < ${null_device} > ${tmp_md_file}
+      COMMAND ${mkmarkdown_cmd} ${name} > ${out_md_file}
+      COMMAND ${md2man_cmd} ${out_md_file} ${out_man_file}
       COMMAND ${copy_images_command}
-      COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file} ${html_file}
+      COMMAND ${copy_images_command_md}
+      COMMAND ${CMAKE_COMMAND} -E remove ${tmp_html_file} ${tmp_md_file}
       COMMENT "Creating ${OUT_HTML_FILE}"
       DEPENDS ${D_DEPENDS})
   endif()

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -61,6 +61,11 @@ add_custom_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/build_class_graphical.py
     html
     ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
+  COMMAND
+    ${grass_env_command} ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_class_graphical.py
+    md
+    ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source
   DEPENDS build_index
   COMMENT "man generation: build_class_graphical")
 set_target_properties(build_class_graphical PROPERTIES FOLDER Man)
@@ -73,6 +78,11 @@ add_custom_target(
     "${CMAKE_SOURCE_DIR}/lib/gis/parser_standard_options.c" -f "grass" -o
     "${OUTDIR}/${GRASS_INSTALL_DOCDIR}/parser_standard_options.html" -p
     "id='opts_table' class='scroolTable'"
+  COMMAND
+    ${grass_env_command} ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/parser_standard_options.py -t
+    "${CMAKE_SOURCE_DIR}/lib/gis/parser_standard_options.c" -f "grass" -o
+    "${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/parser_standard_options.md"
   DEPENDS ${target_names}
   COMMENT "man generation: parser standard options")
 set_target_properties(build_pso PROPERTIES FOLDER Man)
@@ -99,11 +109,22 @@ foreach(category ${categories})
     COMMAND
       ${grass_env_command} ${PYTHON_EXECUTABLE}
       ${CMAKE_CURRENT_SOURCE_DIR}/build_class.py ${prefix} ${class_name}
-      ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
+      ${YEAR}
     DEPENDS build_pso
     COMMENT "man generation: build class ${class_name}")
   set_target_properties(build_class_${class_name} PROPERTIES FOLDER Man)
 endforeach()
+
+add_custom_target(
+  build_manpages
+  COMMAND
+    ${grass_env_command} ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_manpages.py
+    ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source ${OUTDIR}/${GRASS_INSTALL_MANDIR}
+    ${MD2MAN}
+  DEPENDS ${category_targets} build_class_graphical
+  COMMENT "man generation: man pages from markdown")
+set_target_properties(build_manpages PROPERTIES FOLDER Man)
 
 # TODO: this shouldn't depend on GUI_WXPYTHON
 add_custom_target(
@@ -111,7 +132,8 @@ add_custom_target(
   COMMAND
     ${grass_env_command} ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/build_check.py ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
-  DEPENDS ${category_targets} build_class_graphical ALL_MODULES LIB_PYTHON GUI_WXPYTHON
+  DEPENDS ${category_targets} build_class_graphical build_manpages ALL_MODULES
+          LIB_PYTHON GUI_WXPYTHON
   COMMENT "man generation: check output")
 set_target_properties(build_check PROPERTIES FOLDER Man)
 

--- a/man/build_manpages.py
+++ b/man/build_manpages.py
@@ -9,26 +9,36 @@ already converted during the tool builds are up to date and are skipped,
 so this effectively converts the index pages, including the dynamically
 named topic_* pages.
 
-Usage: build_manpages.py <markdown-directory> <man-directory> <g.md2man.py>
+Every page in the markdown directory gets a man page: this assumes the
+CMake build puts no web-only pages (WEB_ONLY_MD in man/Makefile) into the
+markdown tree, which holds until the MkDocs site files are added to the
+CMake build; that change must add an exclusion mechanism here.
+
 """
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
 
 
 def main():
-    md_dir = Path(sys.argv[1])
-    man_dir = Path(sys.argv[2])
-    md2man = sys.argv[3]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("md_dir", type=Path, help="directory with Markdown pages")
+    parser.add_argument("man_dir", type=Path, help="directory for man pages")
+    parser.add_argument("md2man", help="path to g.md2man.py")
+    args = parser.parse_args()
 
-    man_dir.mkdir(parents=True, exist_ok=True)
-    for md_file in sorted(md_dir.glob("*.md")):
-        man_file = man_dir / (md_file.stem + ".1")
-        if man_file.exists() and man_file.stat().st_mtime >= md_file.stat().st_mtime:
+    args.man_dir.mkdir(parents=True, exist_ok=True)
+    for md_file in sorted(args.md_dir.glob("*.md")):
+        man_file = args.man_dir / (md_file.stem + ".1")
+        # Convert also on equal timestamps: with coarse mtime granularity
+        # a page regenerated within the same second would otherwise be
+        # skipped, and a redundant conversion is cheaper than a stale page.
+        if man_file.exists() and man_file.stat().st_mtime > md_file.stat().st_mtime:
             continue
         subprocess.run(
-            [sys.executable, md2man, str(md_file), str(man_file)], check=True
+            [sys.executable, args.md2man, str(md_file), str(man_file)], check=True
         )
 
 

--- a/man/build_manpages.py
+++ b/man/build_manpages.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 by the GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Convert Markdown pages without an up-to-date man page.
+
+Used by the CMake build after the index pages are generated. Tool pages
+already converted during the tool builds are up to date and are skipped,
+so this effectively converts the index pages, including the dynamically
+named topic_* pages.
+
+Usage: build_manpages.py <markdown-directory> <man-directory> <g.md2man.py>
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    md_dir = Path(sys.argv[1])
+    man_dir = Path(sys.argv[2])
+    md2man = sys.argv[3]
+
+    man_dir.mkdir(parents=True, exist_ok=True)
+    for md_file in sorted(md_dir.glob("*.md")):
+        man_file = man_dir / (md_file.stem + ".1")
+        if man_file.exists() and man_file.stat().st_mtime >= md_file.stat().st_mtime:
+            continue
+        subprocess.run(
+            [sys.executable, md2man, str(md_file), str(man_file)], check=True
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -3,6 +3,8 @@ set(py_files
   g.html2man/g.html2man.py
   g.html2man/ggroff.py
   g.html2man/ghtml.py
+  g.md2man/g.md2man.py
+  g.md2man/gmd.py
   generate_last_commit_file.py
   mkdocs.py
   mkhtml.py
@@ -65,6 +67,12 @@ add_custom_target(
     ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/ghtml.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
   COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/g.md2man.py
+    ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/gmd.py
+    ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
+  COMMAND
     ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/mkhtml.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}
   COMMAND
@@ -79,9 +87,11 @@ set_target_properties(python_doc_utils PROPERTIES FOLDER Docs)
 install(
   PROGRAMS
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/g.html2man.py
+    ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/g.md2man.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/generate_last_commit_file.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/ggroff.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/ghtml.py
+    ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/gmd.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkdocs.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkhtml.py
     ${OUTDIR}/${GRASS_INSTALL_UTILSDIR}/mkmarkdown.py


### PR DESCRIPTION
This PR adds markdown documentation generation to the CMake build and switches man page generation from HTML (g.html2man) to the generated markdown (g.md2man), mirroring what #7540 did for Autotools. The CMake and Autotools builds now produce man pages the same way.

**Context:** Follow-up to #7540. Man pages no longer depend on the HTML build in either build system, which unblocks removing the HTML documentation later.

**What changed:**

- `generate_docs.cmake` runs each tool's `--md-description`, assembles the   page with `mkmarkdown.py` into `docs/mkdocs/source/`, and converts the man  page from it with `g.md2man` (all three doc paths: modules, GUI double
  pages, scripts). Images are copied to the markdown tree as well.
- `g.md2man.py`/`gmd.py` are wired into the build and install, replacing  `g.html2man` in the man pipeline (HTML pages themselves are still built).
- New `man/build_manpages.py`: converts any markdown page without an  up-to-date man page. This is `man/Makefile`'s `MANPAGES` wildcard ported to  CMake (which has no build-time glob) and it produces the index and  dynamically named `topic_*` man pages — the CMake build previously shipped  no index man pages at all.
- The generated `docs/mkdocs` tree is now installed (previously it was not  installed at all).
- md variants added for `build_class_graphical` and  `parser_standard_options` in `man/CMakeLists.txt`.

**Fixes to pre-existing CMake doc bugs found along the way:**

- The doc generators ran from the build directory, so the SOURCE CODE footer  of every CMake-built page linked to a nonexistent repository path (e.g.  `.../commits/main/build/display`) and showed an "Accessed" fallback date  instead of the last commit. The generators now run in the tool source  directory like in the Autotools build; the `.tmp.` usage files land there
  too (gitignored, same as Autotools), and the copy-source-into-build-dir  steps became unnecessary.
- `build_class.py` was passed the documentation directory as its *year*  argument.

**Verification (AI-assisted):** full CMake build compared against an Autotools-built tree. Man page sets match modulo environment differences (PDAL/LIBLAS/PostgreSQL availability) and intentional post-#7540 exclusions (`index.1`, `keywords.1`); converting the same generated markdown with `g.md2man` yields byte-identical man pages in both builds.

**Out of scope (follow-ups):**

- MkDocs site statics (`mkdocs.yml`, overrides, `index.md`, ...) are not  copied; building/serving the MkDocs site with CMake is a separate step.
- `build_addon.cmake` still uses the HTML pipeline (belongs with the  g.extension markdown work).
- `test.raster3d.lib` is in `NO_HTML_DESCR_TARGETS`, so its page lacks the  generated usage section (pre-existing, also affects its HTML page).

**AI disclosure:** implemented and verified by Claude (Fable), including the comparison against the Autotools documentation tree.