### PR TITLE
t.rast.list: allow method gran with where option

### DIFF
--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1104,7 +1104,9 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return obj_list
 
-    def get_registered_maps_as_objects_by_granularity(self, gran=None, dbif=None):
+    def get_registered_maps_as_objects_by_granularity(
+        self, gran: str | None = None, where: str | None = None, dbif=None
+    ):
         """Return all registered maps as ordered (by start_time) object list
         with "gap" map objects (id==None) for spatio-temporal topological
         operations that require the temporal extent only.
@@ -1158,16 +1160,19 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         if not check:
             self.msgr.fatal(_('Wrong granularity: "%s"') % str(gran))
 
-        start, end = self.get_temporal_extent_as_tuple()
-
-        if start is None or end is None:
-            return None
-
-        maps = self.get_registered_maps_as_objects(dbif=dbif, order="start_time")
+        maps = self.get_registered_maps_as_objects(
+            dbif=dbif, order="start_time", where=where
+        )
 
         if not maps:
             return None
 
+        start = maps[0].get_temporal_extent_as_tuple()[0]
+        end_extend = maps[-1].get_temporal_extent_as_tuple()
+        end = end_extend[1] or end_extend[0]
+
+        if start is None or end is None:
+            return None
         # We need to adjust the end time in case the dataset has no
         # interval time, so we can catch time instances at the end
         if self.get_map_time() != "interval":

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1145,6 +1145,8 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                     weeks, month, months, year, years". The unit of the
                     relative time granule is always the space time dataset
                     unit and can not be changed.
+        :param where: The SQL where statement to select a subset of
+                      the registered maps without "WHERE"
         :param dbif: The database interface to be used
 
         :return: ordered list of map lists. Each list represents a single
@@ -1169,7 +1171,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         start = maps[0].get_temporal_extent_as_tuple()[0]
         end_extend = maps[-1].get_temporal_extent_as_tuple()
-        end = end_extend[1] or end_extend[0]
+        end = end_extend[1] if end_extend[1] is not None else end_extend[0]
 
         if start is None or end is None:
             return None

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -279,17 +279,12 @@ def _get_get_registered_maps_as_objects_with_method(dataset, where, method, gran
         return dataset.get_registered_maps_as_objects(
             where=where, order="start_time", dbif=dbif
         )
-    if method != "gran":
-        msg = f"Invalid method '{method}'"
-        raise ValueError(msg)
-    if where:
-        msg = f"The where parameter is not supported with method={method}"
-        raise ValueError(msg)
-    if gran is not None and gran != "":
+    if method == "gran":
         return dataset.get_registered_maps_as_objects_by_granularity(
-            gran=gran, dbif=dbif
+            gran=gran, where=where, dbif=dbif
         )
-    return dataset.get_registered_maps_as_objects_by_granularity(dbif=dbif)
+    msg = f"Invalid method '{method}'"
+    raise ValueError(msg)
 
 
 def _get_get_registered_maps_as_objects_delta_gran(
@@ -511,6 +506,8 @@ def list_maps_of_stds(
                  dataset is used
     :param outpath: The path to file where to save output
     """
+    if gran == "":
+        gran = None
     if not output_format:
         if method == "comma":
             output_format = "line"

--- a/temporal/t.rast.list/t.rast.list.py
+++ b/temporal/t.rast.list/t.rast.list.py
@@ -272,15 +272,6 @@ def main():
                         ).format(name=column, method=method),
                     )
                 )
-    if method == "gran" and where:
-        gs.fatal(
-            message_option_value_excludes_option(
-                option_name="method",
-                option_value=method,
-                excluded_option_name="where",
-                reason=_("All maps are always listed"),
-            )
-        )
 
     # Make sure the temporal database exists
     tgis.init()

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -34,8 +34,7 @@ def test_line(space_time_raster_dataset, separator, delimiter):
             input=space_time_raster_dataset.name,
             format="line",
             separator=separator,
-        )
-        .text_split(delimiter)
+        ).text_split(delimiter)
     )
     assert names == space_time_raster_dataset.full_raster_names
 

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -29,13 +29,11 @@ def test_defaults(space_time_raster_dataset):
 def test_line(space_time_raster_dataset, separator, delimiter):
     """Line format can be parsed and contains full names by default"""
     tools = Tools(session=space_time_raster_dataset.session)
-    names = (
-        tools.t_rast_list(
-            input=space_time_raster_dataset.name,
-            format="line",
-            separator=separator,
-        ).text_split(delimiter)
-    )
+    names = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="line",
+        separator=separator,
+    ).text_split(delimiter)
     assert names == space_time_raster_dataset.full_raster_names
 
 

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -3,7 +3,6 @@
 import csv
 import datetime
 import io
-import json
 
 import pytest
 
@@ -12,18 +11,14 @@ try:
 except ImportError:
     yaml = None
 
-import grass.script as gs
 from grass.tools import Tools
 
 
 @pytest.mark.needs_solo_run
 def test_defaults(space_time_raster_dataset):
     """Check that the module runs with default parameters"""
-    gs.run_command(
-        "t.rast.list",
-        input=space_time_raster_dataset.name,
-        env=space_time_raster_dataset.session.env,
-    )
+    tools = Tools(session=space_time_raster_dataset.session)
+    tools.t_rast_list(input=space_time_raster_dataset.name)
 
 
 @pytest.mark.needs_solo_run
@@ -33,15 +28,14 @@ def test_defaults(space_time_raster_dataset):
 )
 def test_line(space_time_raster_dataset, separator, delimiter):
     """Line format can be parsed and contains full names by default"""
+    tools = Tools(session=space_time_raster_dataset.session)
     names = (
-        gs.read_command(
-            "t.rast.list",
+        tools.t_rast_list(
             input=space_time_raster_dataset.name,
             format="line",
-            env=space_time_raster_dataset.session.env,
             separator=separator,
         )
-        .strip()
+        .text.strip()
         .split(delimiter)
     )
     assert names == space_time_raster_dataset.full_raster_names
@@ -50,14 +44,11 @@ def test_line(space_time_raster_dataset, separator, delimiter):
 @pytest.mark.needs_solo_run
 def test_json(space_time_raster_dataset):
     """Check JSON can be parsed and contains the right values"""
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            format="json",
-            env=space_time_raster_dataset.session.env,
-        )
-    )
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+    ).json
     assert "data" in result
     assert "metadata" in result
     for item in result["data"]:
@@ -71,13 +62,12 @@ def test_json(space_time_raster_dataset):
 @pytest.mark.needs_solo_run
 def test_yaml(space_time_raster_dataset):
     """Check YAML can be parsed and contains the right values"""
+    tools = Tools(session=space_time_raster_dataset.session)
     result = yaml.safe_load(
-        gs.read_command(
-            "t.rast.list",
+        tools.t_rast_list(
             input=space_time_raster_dataset.name,
             format="yaml",
-            env=space_time_raster_dataset.session.env,
-        )
+        ).text
     )
     assert "data" in result
     assert "metadata" in result
@@ -98,15 +88,14 @@ def test_yaml(space_time_raster_dataset):
 )
 def test_csv(space_time_raster_dataset, separator, delimiter):
     """Check CSV can be parsed with different separators"""
+    tools = Tools(session=space_time_raster_dataset.session)
     columns = ["name", "start_time"]
-    text = gs.read_command(
-        "t.rast.list",
+    text = tools.t_rast_list(
         input=space_time_raster_dataset.name,
         columns=columns,
         format="csv",
         separator=separator,
-        env=space_time_raster_dataset.session.env,
-    )
+    ).text
     io_string = io.StringIO(text)
     reader = csv.DictReader(
         io_string,
@@ -125,6 +114,7 @@ def test_csv(space_time_raster_dataset, separator, delimiter):
 @pytest.mark.needs_solo_run
 def test_columns_list(space_time_raster_dataset):
     """Check that specific columns are returned correctly for the list method"""
+    tools = Tools(session=space_time_raster_dataset.session)
     # All relevant columns from the interface.
     columns = [
         "id",
@@ -148,16 +138,12 @@ def test_columns_list(space_time_raster_dataset):
         "min",
         "max",
     ]
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            method="list",
-            columns=columns,
-            format="json",
-            env=space_time_raster_dataset.session.env,
-        )
-    )
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        method="list",
+        columns=columns,
+        format="json",
+    ).json
     data = result["data"]
     assert len(data) == len(space_time_raster_dataset.raster_names)
     for row in data:
@@ -167,6 +153,7 @@ def test_columns_list(space_time_raster_dataset):
 @pytest.mark.needs_solo_run
 def test_columns_delta_gran(space_time_raster_dataset):
     """Check that specific columns are returned correctly for the gran method"""
+    tools = Tools(session=space_time_raster_dataset.session)
     # All relevant columns from the interface.
     columns = [
         "id",
@@ -177,16 +164,12 @@ def test_columns_delta_gran(space_time_raster_dataset):
         "interval_length",
         "distance_from_begin",
     ]
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            method="gran",
-            columns=columns,
-            format="json",
-            env=space_time_raster_dataset.session.env,
-        )
-    )
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        method="gran",
+        columns=columns,
+        format="json",
+    ).json
     data = result["data"]
     assert len(data) == len(space_time_raster_dataset.raster_names)
     for row in data:
@@ -196,14 +179,11 @@ def test_columns_delta_gran(space_time_raster_dataset):
 @pytest.mark.needs_solo_run
 def test_json_empty_result(space_time_raster_dataset):
     """Check JSON is generated for no returned values"""
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            format="json",
-            where="FALSE",
-            env=space_time_raster_dataset.session.env,
-        )
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+        where="FALSE",
     )
     assert "data" in result
     assert "metadata" in result
@@ -214,13 +194,12 @@ def test_json_empty_result(space_time_raster_dataset):
 @pytest.mark.parametrize("output_format", ["plain", "line"])
 def test_plain_empty_result(space_time_raster_dataset, output_format):
     """Check module fails with non-zero return code for empty result"""
-    return_code = gs.run_command(
-        "t.rast.list",
+    tools = Tools(session=space_time_raster_dataset.session)
+    return_code = tools.t_rast_list(
         input=space_time_raster_dataset.name,
         format=output_format,
         where="FALSE",
         errors="status",
-        env=space_time_raster_dataset.session.env,
     )
     assert return_code != 0
 
@@ -229,11 +208,10 @@ def test_plain_empty_result(space_time_raster_dataset, output_format):
 @pytest.mark.parametrize("output_format", ["csv", "plain"])
 def test_no_header_accepted(space_time_raster_dataset, output_format):
     """Check that the no column names flag is accepted"""
-    gs.run_command(
-        "t.rast.list",
+    tools = Tools(session=space_time_raster_dataset.session)
+    tools.t_rast_list(
         input=space_time_raster_dataset.name,
         format=output_format,
-        env=space_time_raster_dataset.session.env,
     )
 
 
@@ -252,13 +230,12 @@ def test_no_header_accepted(space_time_raster_dataset, output_format):
 )
 def test_no_header_rejected(space_time_raster_dataset, output_format):
     """Check that the no column names flag is rejected"""
-    return_code = gs.run_command(
-        "t.rast.list",
+    tools = Tools(session=space_time_raster_dataset.session)
+    return_code = tools.t_rast_list(
         input=space_time_raster_dataset.name,
         format=output_format,
         flags="u",
         errors="status",
-        env=space_time_raster_dataset.session.env,
     )
     assert return_code != 0
 
@@ -292,15 +269,12 @@ def test_separator_rejected(space_time_raster_dataset, output_format):
 @pytest.mark.parametrize("method", ["delta", "deltagaps", "gran"])
 def test_other_methods_json(space_time_raster_dataset, method):
     """Test methods other than list"""
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            format="json",
-            method=method,
-            env=space_time_raster_dataset.session.env,
-        )
-    )
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+        method=method,
+    ).json
     assert "data" in result
     assert "metadata" in result
     for item in result["data"]:
@@ -313,16 +287,13 @@ def test_other_methods_json(space_time_raster_dataset, method):
 @pytest.mark.needs_solo_run
 def test_gran_json(space_time_raster_dataset):
     """Test granularity method"""
-    result = json.loads(
-        gs.read_command(
-            "t.rast.list",
-            input=space_time_raster_dataset.name,
-            format="json",
-            method="gran",
-            gran="15 days",
-            env=space_time_raster_dataset.session.env,
-        )
-    )
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+        method="gran",
+        gran="15 days",
+    ).json
     assert "data" in result
     assert "metadata" in result
     for item in result["data"]:
@@ -335,3 +306,55 @@ def test_gran_json(space_time_raster_dataset):
     assert len(result["data"]) > len(space_time_raster_dataset.raster_names), (
         "There should be more entries because of finer granularity"
     )
+
+
+@pytest.mark.needs_solo_run
+def test_gran_where_json(space_time_raster_dataset):
+    """Test granularity method with where condition"""
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+        method="gran",
+        where="True",
+        gran="15 days",
+    ).json
+    assert "data" in result
+    assert "metadata" in result
+    for item in result["data"]:
+        assert item["interval_length"] == 15.0
+        assert item["distance_from_begin"] >= 0
+        assert (
+            item["name"] in space_time_raster_dataset.raster_names
+            or item["name"] is None
+        )
+    assert len(result["data"]) > len(space_time_raster_dataset.raster_names), (
+        "There should be more entries because of finer granularity"
+    )
+    assert len(result["data"]) == 13
+
+
+@pytest.mark.needs_solo_run
+def test_gran_where_larger_json(space_time_raster_dataset):
+    """Test granularity method with where condition and lager granuarity"""
+    tools = Tools(session=space_time_raster_dataset.session)
+    result = tools.t_rast_list(
+        input=space_time_raster_dataset.name,
+        format="json",
+        method="gran",
+        where="True",
+        gran="2 months",
+    ).json
+    assert "data" in result
+    assert "metadata" in result
+    for item in result["data"]:
+        assert item["interval_length"] >= 58.0
+        assert item["distance_from_begin"] >= 0
+        assert (
+            item["name"] in space_time_raster_dataset.raster_names
+            or item["name"] is None
+        )
+    assert len(result["data"]) < len(space_time_raster_dataset.raster_names), (
+        "There should be fewer entries because of finer granularity."
+    )
+    assert len(result["data"]) == 3

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -35,8 +35,7 @@ def test_line(space_time_raster_dataset, separator, delimiter):
             format="line",
             separator=separator,
         )
-        .text.strip()
-        .split(delimiter)
+        .text_split(delimiter)
     )
     assert names == space_time_raster_dataset.full_raster_names
 

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -312,7 +312,7 @@ def test_gran_where_json(space_time_raster_dataset):
         input=space_time_raster_dataset.name,
         format="json",
         method="gran",
-        where="True",
+        where="start_time >= '2001-02-01 00:00:00'",
         gran="15 days",
     ).json
     assert "data" in result
@@ -327,7 +327,7 @@ def test_gran_where_json(space_time_raster_dataset):
     assert len(result["data"]) > len(space_time_raster_dataset.raster_names), (
         "There should be more entries because of finer granularity"
     )
-    assert len(result["data"]) == 13
+    assert len(result["data"]) == 10
 
 
 @pytest.mark.needs_solo_run


### PR DESCRIPTION
This is a step towards solving #7344 with tools instead of the API.
There did not seem to be a technical requirement to not allow a _where_ clause with the _gran_ method. This PR enables it.
pytests are add and all tests moved to Tools API. 