### PR TITLE
g.md2man: Expand tests on other cases

### DIFF
--- a/utils/g.md2man/tests/g_md2man_test.py
+++ b/utils/g.md2man/tests/g_md2man_test.py
@@ -161,6 +161,14 @@ def test_unordered_list_nested(tmp_path):
     result = convert("- first\n- second\n    - nested\n", tmp_path)
     assert result.count(".IP \\(bu 4n") == 3  # codespell:ignore bu
     assert ".RS 4n" in result
+    assert ".RE" in result
+
+    rs_index = result.find(".RS 4n")
+    re_index = result.find(".RE", rs_index)
+    assert rs_index != -1
+    assert re_index != -1
+    assert rs_index < re_index
+    assert ".IP \\(bu 4n" in result[rs_index:re_index]
 
 
 def test_wrapped_number_line_is_not_a_list(tmp_path):

--- a/utils/g.md2man/tests/g_md2man_test.py
+++ b/utils/g.md2man/tests/g_md2man_test.py
@@ -409,4 +409,9 @@ def test_comment_parsing_unit():
 
 def test_strip_html_comments_keeps_comment_in_fenced_code_unit():
     lines = ["```html", "<!-- required -->", "```", "x <!-- drop --> y"]
-    assert gmd.strip_html_comments(lines) == ["```html", "<!-- required -->", "```", "x  y"]
+    assert gmd.strip_html_comments(lines) == [
+        "```html",
+        "<!-- required -->",
+        "```",
+        "x  y",
+    ]

--- a/utils/g.md2man/tests/g_md2man_test.py
+++ b/utils/g.md2man/tests/g_md2man_test.py
@@ -397,3 +397,8 @@ def test_comment_kept_in_fenced_code(tmp_path):
 def test_comment_parsing_unit():
     lines = ["a <!-- x --> b <!-- y", "z --> c", "<!-- lone -->d"]
     assert gmd.strip_html_comments(lines) == ["a  b ", " c", "d"]
+
+
+def test_strip_html_comments_keeps_comment_in_fenced_code_unit():
+    lines = ["```html", "<!-- required -->", "```", "x <!-- drop --> y"]
+    assert gmd.strip_html_comments(lines) == ["```html", "<!-- required -->", "```", "x  y"]


### PR DESCRIPTION
CodeQL Code Quality had some AI findings on a recently changed file, a test file for g.md2man. The tests suggested seemed legitimate, and they are passing. I am thus submitting them here, after testing them in my fork.

Original text explaining the findings: 

-------

The test asserts that there are exactly 3 bullet list markers for the input `"- first\n- second\n - nested\n"`, but this input only has 3 items (first, second, nested). The assertion `== 3` may be correct, but it should be verified that the nested item also produces the same `.IP \(bu 4n` marker, since nested items could produce a different marker format. If the nested list intentionally uses the same marker, this is fine, but the test name `test_unordered_list_nested` suggests the nesting behavior is what's being tested, and there is no assertion verifying that the nested item is actually rendered as nested (e.g., inside `.RS`/`.RE` blocks relative to the parent items). Consider adding an assertion that checks the order of `.RS`, `.IP`, and `.RE` to confirm correct nesting structure.


----------

The `test_comment_parsing_unit` test covers multi-line and inline comments, but there is no unit test for `strip_html_comments` behavior inside a fenced code block (i.e., that a comment inside a fence is preserved). The integration test `test_comment_kept_in_fenced_code` covers this via subprocess, but a direct unit test of `strip_html_comments` with a fenced block containing a comment would provide more precise coverage of that branch in `gmd.py`.