### PR TITLE
CI: Set OMP_NUM_THREADS=1 for tests run in parallel

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -104,6 +104,9 @@ jobs:
             @.github/workflows/pytest_args_parallel.txt \
             --junitxml=pytest.xdist.junit.xml \
             -k 'not testsuite'
+        env:
+          OMP_NUM_THREADS: 1
+
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         shell: micromamba-shell {0}
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -105,6 +105,8 @@ jobs:
             @.github/workflows/pytest_args_parallel.txt \
             --junitxml=pytest.xdist.junit.xml \
             -k 'not testsuite'
+        env:
+          OMP_NUM_THREADS: 1
 
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         run: |


### PR DESCRIPTION
We observed some random, transient timeouts on different tests. For one of them, t.list, there was no reason to fail on macOS, where there are 3 cores instead of 2 in GitHub Actions. There's a possibility that there's a problem with the temporal library locking up somewhere, but there’s also a small chance that the r.mapcalc calls are now using multiple processors. It "costs" not much to add this env var so that the number of threads is limited, even if it doesn't fix all problems; it might just fix some potential ones, since we are already running in parallel in that section.