### PR TITLE
grass.temporal: Fix swapped rows and cols in map metadata

### DIFF
--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -703,8 +703,8 @@ def _read_raster_info(name, mapset):
     kvp["west"] = region.west
     kvp["nsres"] = region.ns_res
     kvp["ewres"] = region.ew_res
-    kvp["rows"] = region.cols
-    kvp["cols"] = region.rows
+    kvp["rows"] = region.rows
+    kvp["cols"] = region.cols
 
     maptype = libraster.Rast_map_type(name, mapset)
 
@@ -788,8 +788,8 @@ def _read_raster3d_info(name, mapset):
     kvp["nsres"] = region.ns_res
     kvp["ewres"] = region.ew_res
     kvp["tbres"] = region.tb_res
-    kvp["rows"] = region.cols
-    kvp["cols"] = region.rows
+    kvp["rows"] = region.rows
+    kvp["cols"] = region.cols
     kvp["depths"] = region.depths
     kvp["top"] = region.top
     kvp["bottom"] = region.bottom
@@ -1331,7 +1331,7 @@ class CLibrariesInterface(RPCServerBase):
         >>> print(check)
         True
         >>> ciface.read_raster_info("test", tgis.get_current_mapset())
-        {'rows': 12, 'north': 80.0, 'min': 1, 'datatype': 'CELL', 'max': 1, 'ewres': 10.0, 'cols': 8, 'west': 0.0, 'east': 120.0, 'nsres': 10.0, 'south': 0.0}
+        {'rows': 8, 'north': 80.0, 'min': 1, 'datatype': 'CELL', 'max': 1, 'ewres': 10.0, 'cols': 12, 'west': 0.0, 'east': 120.0, 'nsres': 10.0, 'south': 0.0}
 
         >>> info = ciface.read_raster_full_info("test", tgis.get_current_mapset())
         >>> info  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
@@ -1367,7 +1367,7 @@ class CLibrariesInterface(RPCServerBase):
         >>> print(check)
         True
         >>> ciface.read_raster3d_info("test", tgis.get_current_mapset())
-        {'tbres': 1.0, 'rows': 12, 'north': 80.0, 'bottom': 0.0, 'datatype': 'DCELL', 'max': 1.0, 'top': 1.0, 'min': 1.0, 'cols': 8, 'depths': 1, 'west': 0.0, 'ewres': 10.0, 'east': 120.0, 'nsres': 10.0, 'south': 0.0}
+        {'tbres': 1.0, 'rows': 8, 'north': 80.0, 'bottom': 0.0, 'datatype': 'DCELL', 'max': 1.0, 'top': 1.0, 'min': 1.0, 'cols': 12, 'depths': 1, 'west': 0.0, 'ewres': 10.0, 'east': 120.0, 'nsres': 10.0, 'south': 0.0}
         >>> check = ciface.has_raster3d_timestamp("test", tgis.get_current_mapset())
         >>> print(check)
         True

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -122,8 +122,8 @@ class RasterDataset(AbstractMapDataset):
         >>> rmap.metadata.print_info()
          +-------------------- Metadata information ----------------------------------+
          | Datatype:................... CELL
-         | Number of columns:.......... 8
-         | Number of rows:............. 12
+         | Number of columns:.......... 12
+         | Number of rows:............. 8
          | Number of cells:............ 96
          | North-South resolution:..... 10.0
          | East-west resolution:....... 10.0
@@ -544,8 +544,8 @@ class Raster3DDataset(AbstractMapDataset):
         >>> r3map.metadata.print_info()
          +-------------------- Metadata information ----------------------------------+
          | Datatype:................... DCELL
-         | Number of columns:.......... 8
-         | Number of rows:............. 12
+         | Number of columns:.......... 12
+         | Number of rows:............. 8
          | Number of cells:............ 960
          | North-South resolution:..... 10.0
          | East-west resolution:....... 10.0

--- a/python/grass/temporal/tests/grass_temporal_map_metadata_test.py
+++ b/python/grass/temporal/tests/grass_temporal_map_metadata_test.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Regression test for the map metadata read through the C library interface
+
+The computational region is deliberately not square, so that rows and
+columns reported the other way round are detected.
+"""
+
+import pytest
+
+import grass.script as gs
+import grass.temporal as tgis
+from grass.tools import Tools
+
+ROWS = 8
+COLS = 12
+
+
+@pytest.fixture
+def session_with_maps(tmp_path):
+    """Start a session with a raster and a 3D raster map"""
+    project = tmp_path / "project"
+    gs.create_project(project)
+    with gs.setup.init(project) as session:
+        tools = Tools(session=session)
+        tools.g_region(n=80, s=0, e=120, w=0, t=50, b=0, res=10, res3=10)
+        tools.r_mapcalc(expression="test_raster = 1")
+        tools.r3_mapcalc(expression="test_raster_3d = 1")
+        yield session
+
+
+def test_raster_rows_and_cols(session_with_maps):
+    """Rows and columns of a raster map are the ones reported by r.info"""
+    tools = Tools(session=session_with_maps)
+    tgis.init()
+    ciface = tgis.get_tgis_c_library_interface()
+
+    kvp = ciface.read_raster_info("test_raster", tgis.get_current_mapset())
+    info = tools.r_info(map="test_raster", format="json").json
+
+    assert kvp["rows"] == ROWS
+    assert kvp["cols"] == COLS
+    assert kvp["rows"] == info["rows"]
+    assert kvp["cols"] == info["cols"]
+
+
+def test_raster3d_rows_and_cols(session_with_maps):
+    """Rows and columns of a 3D raster map are the ones reported by r3.info"""
+    tools = Tools(session=session_with_maps)
+    tgis.init()
+    ciface = tgis.get_tgis_c_library_interface()
+
+    kvp = ciface.read_raster3d_info("test_raster_3d", tgis.get_current_mapset())
+    info = tools.r3_info(map="test_raster_3d", format="json").json
+
+    assert kvp["rows"] == ROWS
+    assert kvp["cols"] == COLS
+    assert kvp["rows"] == info["rows"]
+    assert kvp["cols"] == info["cols"]


### PR DESCRIPTION
## Bug

During writing tests for t.info, I found out that `t.info` reports the number of rows and columns of a registered raster or 3D raster map the other way round. It disagrees with `r.info` and `r3.info` for the same map:

```sh
g.region s=0 n=80 w=0 e=120 res=10   # 8 rows, 12 columns
r.info -g a | grep -E "^(rows|cols)="
rows=8
cols=12
t.info -g type=raster input=a | grep -E "^(rows|cols)="
cols=8
rows=12
```

The swap propagates from the region struct into the temporal database at registration time and out through t.info. number_of_cells is not affected, since it is the product of both. 

This likely dates back to 2013 (I didn't verify).


## Impact on existing data

t.info reads rows and cols from the temporal database, where they are stored when a map is registered. Maps registered before this fix keep the swapped values until they are registered again. Only new registrations are correct.