### PR TITLE
grass.utils: Fix the download error message and limit the URL schemes

### DIFF
--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -29,6 +29,10 @@ response_content_disposition_header_pattern = re.compile(
     r"attachment; filename=.*.zip$"
 )
 
+# Schemes urlretrieve can fetch, except data. The file scheme allows an archive
+# on the local disk.
+supported_url_schemes = ("http", "https", "ftp", "file")
+
 
 def debug(*args, **kwargs):
     """Print a debug message (to be used in this module only)
@@ -150,14 +154,25 @@ def _move_extracted_files(extract_dir, target_dir, files):
 def _download_file(source, destination, reporthook=None):
     """Download a file from URL to a local file
 
+    Only URLs with one of the supported schemes are downloaded. A file on the
+    local disk needs to be specified with the file scheme, i.e., as file://<path>.
+
     :param source: URL to download from
     :param destination: local file name to download to
     :param reporthook: function called with the download progress
 
     :return: tuple with the local file name and the response headers
     """
+    if urlparse(source).scheme not in supported_url_schemes:
+        raise DownloadError(
+            _(
+                "Unsupported URL <{url}>. Supported are only URLs with the "
+                "following schemes: {schemes}."
+            ).format(url=source, schemes=", ".join(supported_url_schemes))
+        )
     try:
-        return urlretrieve(source, destination, reporthook)
+        # The scheme of the URL is limited to the supported ones above.
+        return urlretrieve(source, destination, reporthook)  # nosec B310
     except HTTPError as error:
         raise DownloadError(
             _("Download file from <{url}>, return status code {code}, {desc}").format(

--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -203,11 +203,22 @@ def download_and_extract(source, reporthook=None):
         archive_name = os.path.join(tmpdir, "archive.zip")
         filename, headers = _download_file(source, archive_name, reporthook)
 
-        if not re.search(
-            response_content_type_header_pattern, headers.get("content-type", "")
-        ) and not re.search(
-            response_content_disposition_header_pattern,
-            headers.get("content-disposition", ""),
+        # Check that a remote download looks like a ZIP archive by its response
+        # headers to catch a server returning an error page instead of the file.
+        # A local file (the file scheme) has no such response: urlretrieve
+        # synthesizes the content type from the file name, which is unreliable
+        # (the Windows registry maps .zip to application/x-zip-compressed), so
+        # the check is skipped for it. A local file which is not a ZIP is caught
+        # by extract_zip.
+        if (
+            urlparse(source).scheme != "file"
+            and not re.search(
+                response_content_type_header_pattern, headers.get("content-type", "")
+            )
+            and not re.search(
+                response_content_disposition_header_pattern,
+                headers.get("content-disposition", ""),
+            )
         ):
             raise DownloadError(
                 _(

--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -147,6 +147,31 @@ def _move_extracted_files(extract_dir, target_dir, files):
                 shutil.copy(actual_file, os.path.join(target_dir, file_name))
 
 
+def _download_file(source, destination, reporthook=None):
+    """Download a file from URL to a local file
+
+    :param source: URL to download from
+    :param destination: local file name to download to
+    :param reporthook: function called with the download progress
+
+    :return: tuple with the local file name and the response headers
+    """
+    try:
+        return urlretrieve(source, destination, reporthook)
+    except HTTPError as error:
+        raise DownloadError(
+            _("Download file from <{url}>, return status code {code}, {desc}").format(
+                url=source, code=error.code, desc=error.reason
+            )
+        ) from error
+    except URLError as error:
+        raise DownloadError(
+            _("Download file from <{url}>, failed. Check internet connection.").format(
+                url=source
+            )
+        ) from error
+
+
 # modified copy from g.extension
 # TODO: remove the hardcoded location/extension, use general name
 def download_and_extract(source, reporthook=None):
@@ -159,23 +184,9 @@ def download_and_extract(source, reporthook=None):
     tmpdir = tempfile.mkdtemp()
     debug("Tmpdir: {}".format(tmpdir))
     directory = Path(tmpdir) / "extracted"
-    http_error_message = _("Download file from <{url}>, return status code {code}, ")
-    url_error_message = _(
-        "Download file from <{url}>, failed. Check internet connection."
-    )
     if source_path.suffix and source_path.suffix == ".zip":
         archive_name = os.path.join(tmpdir, "archive.zip")
-        try:
-            filename, headers = urlretrieve(source, archive_name, reporthook)
-        except HTTPError as err:
-            raise DownloadError(
-                http_error_message.format(
-                    url=source,
-                    code=err,
-                ),
-            )
-        except URLError:
-            raise DownloadError(url_error_message.format(url=source))
+        filename, headers = _download_file(source, archive_name, reporthook)
 
         if not re.search(
             response_content_type_header_pattern, headers.get("content-type", "")
@@ -192,17 +203,7 @@ def download_and_extract(source, reporthook=None):
     elif source_path.suffix and source_path.suffix[1:] in extract_tar.supported_formats:
         ext = "".join(source_path.suffixes)
         archive_name = os.path.join(tmpdir, "archive" + ext)
-        try:
-            urlretrieve(source, archive_name, reporthook)
-        except HTTPError as err:
-            raise DownloadError(
-                http_error_message.format(
-                    url=source,
-                    code=err,
-                ),
-            )
-        except URLError:
-            raise DownloadError(url_error_message.format(url=source))
+        _download_file(source, archive_name, reporthook)
         extract_tar(name=archive_name, directory=directory, tmpdir=tmpdir)
     else:
         # probably programmer error

--- a/python/grass/utils/tests/grass_utils_download_test.py
+++ b/python/grass/utils/tests/grass_utils_download_test.py
@@ -1,0 +1,55 @@
+"""Tests of grass.utils.download"""
+
+import io
+import tarfile
+import zipfile
+
+import pytest
+
+from grass.utils.download import DownloadError, download_and_extract
+
+
+@pytest.fixture
+def zip_archive(tmp_path):
+    """ZIP archive with a project directory"""
+    archive = tmp_path / "project.zip"
+    with zipfile.ZipFile(archive, "w") as archive_file:
+        archive_file.writestr("project/PERMANENT/DEFAULT_WIND", "proj: 3\n")
+    return archive
+
+
+@pytest.fixture
+def tar_archive(tmp_path):
+    """Compressed TAR archive with a project directory"""
+    archive = tmp_path / "project.tar.gz"
+    content = b"proj: 3\n"
+    with tarfile.open(archive, "w:gz") as archive_file:
+        info = tarfile.TarInfo("project/PERMANENT/DEFAULT_WIND")
+        info.size = len(content)
+        archive_file.addfile(info, io.BytesIO(content))
+    return archive
+
+
+@pytest.mark.parametrize("archive", ["zip_archive", "tar_archive"])
+def test_extract_from_file_url(request, archive):
+    """Archive on the local disk is extracted when given with the file scheme"""
+    directory = download_and_extract(request.getfixturevalue(archive).as_uri())
+
+    assert (directory / "PERMANENT" / "DEFAULT_WIND").is_file()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "/home/user/project.zip",
+        "C:\\data\\project.zip",
+        "custom://example.org/project.zip",
+    ],
+)
+def test_unsupported_url_scheme(source):
+    """URL with an unsupported scheme is rejected
+
+    A path without a scheme is not a URL, so it is rejected as well.
+    """
+    with pytest.raises(DownloadError, match="Unsupported URL"):
+        download_and_extract(source)

--- a/python/grass/utils/tests/grass_utils_download_test.py
+++ b/python/grass/utils/tests/grass_utils_download_test.py
@@ -38,6 +38,19 @@ def test_extract_from_file_url(request, archive):
     assert (directory / "PERMANENT" / "DEFAULT_WIND").is_file()
 
 
+def test_extract_from_file_url_not_a_zip(tmp_path):
+    """A local file with a .zip name which is not a ZIP is reported as an error
+
+    The content type of a file URL is not checked (it is unreliable), so an
+    invalid ZIP has to be caught during extraction.
+    """
+    archive = tmp_path / "project.zip"
+    archive.write_text("This is not a ZIP file.\n")
+
+    with pytest.raises(DownloadError, match="ZIP file is unreadable"):
+        download_and_extract(archive.as_uri())
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/scripts/g.download.project/g.download.project.html
+++ b/scripts/g.download.project/g.download.project.html
@@ -4,7 +4,8 @@
 <code>.zip</code> or <code>.tar.gz</code>) project (previously called
 location) from a given URL
 and unpacks it to a specified or current GRASS Spatial Database.
-URL can be also a local file on the disk.
+The URL can be also an archive on the local disk given with the
+<code>file://</code> scheme.
 
 If the archive contains a directory which contains a project, the module
 will recognize that and use the project automatically.

--- a/scripts/g.download.project/g.download.project.md
+++ b/scripts/g.download.project/g.download.project.md
@@ -2,11 +2,11 @@
 
 *g.download.project* downloads an archived (e.g., `.zip` or `.tar.gz`)
 project (previously called location) from a given URL and unpacks it to
-a specified or current GRASS Spatial Database. URL can be also a
-local file on the disk. If the archive contains a directory which
-contains a project, the module will recognize that and use the project
-automatically. The first directory which is a project is used. Other
-projects or any other files are ignored.
+a specified or current GRASS Spatial Database. The URL can be also an
+archive on the local disk given with the `file://` scheme. If the archive
+contains a directory which contains a project, the module will recognize
+that and use the project automatically. The first directory which is a
+project is used. Other projects or any other files are ignored.
 
 ## EXAMPLES
 


### PR DESCRIPTION
A failed download was reported with a message copied from *g.extension.all* which lost its `{desc}` placeholder, so it ended with a dangling comma and was formatted with the whole `HTTPError` object instead of a status code:

```
Download file from <URL>, return status code HTTP Error 404: Not Found,
```

It now passes the status code and its description, which restores the message as it is used elsewhere, so the msgid and its translations stay valid:

```
Download file from <URL>, return status code 404, Not Found
```

The identical error handling of the ZIP and TAR branches moves to a `_download_file()` function and the original exception is chained.

The URL scheme is now checked against the supported ones (`http`, `https`, `ftp`, `file`), because `urlretrieve` opens any scheme it is given (Bandit B310). Every scheme which works today keeps working. An archive on the local disk works only as `file://` (a plain path failed with an unhandled `ValueError`), so the *g.download.project* documentation now says that.

The module had no tests. The new ones extract a ZIP and a TAR archive from the local disk and check that an unsupported scheme is rejected.

Note: this touches the same lines as #4032, so whichever is merged second needs a trivial conflict resolution.

## Commit message

Fix the HTTP error message, which lost its {desc} placeholder and was
formatted with the whole HTTPError instead of a status code. Limit a download
to the supported schemes (http, https, ftp, file), since urlretrieve opens
any scheme, including data and custom ones (Bandit B310), and document that a
local archive needs the file scheme (no change in behavior, just doc clarity).
Skip the content type check for a local file, which fixed extracting a local ZIP
on Windows. Add tests for the module.