### PR TITLE
wxGUI: Add the matplotlib hint as an exception note

### DIFF
--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -39,13 +39,14 @@ try:
     from matplotlib.patches import Polygon, Ellipse
     import matplotlib.image as mi
     import matplotlib.colors as mcolors
-except ImportError as e:
-    raise ImportError(
+except ImportError as error:
+    error.add_note(
         _(
             'The Scatterplot Tool needs the "matplotlib" '
-            "(python-matplotlib) package to be installed. {0}"
-        ).format(e)
+            "(python-matplotlib) package to be installed."
+        )
     )
+    raise
 
 import grass.script as gs
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -37,14 +37,15 @@ try:
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
     import matplotlib.dates as mdates
-except ImportError as e:
-    raise ImportError(
+except ImportError as error:
+    error.add_note(
         _(
             'The Timeline Tool needs the "matplotlib" '
             "(python-matplotlib and on some systems also python-matplotlib-wx) "
-            "package(s) to be installed. {}"
-        ).format(e)
+            "package(s) to be installed."
+        )
     )
+    raise
 
 import grass.script as gs
 

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -41,13 +41,14 @@ try:
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
     import matplotlib.dates as mdates
-except ImportError as e:
-    raise ImportError(
+except ImportError as error:
+    error.add_note(
         _(
             'The Temporal Plot Tool needs the "matplotlib" '
-            "(python-matplotlib) package to be installed. {0}"
-        ).format(e)
+            "(python-matplotlib) package to be installed."
+        )
     )
+    raise
 
 
 import grass.temporal as tgis


### PR DESCRIPTION
Now, the Scatterplot, Timeline, and Temporal Plot tools raise a new `ImportError` whose message is the hint, with the original error appended to it using `.format(e)`.

Add the hint as a note to the original error instead. From the [Python documentation of `BaseException.add_note()`](https://docs.python.org/3/library/exceptions.html#BaseException.add_note): "Add the string `note` to the exception's notes which appear in the standard traceback after the exception string."

Starting a tool without matplotlib then gives a single exception with the actual error as its message and the hint after it, instead of a chained pair of exceptions:

```
ModuleNotFoundError: No module named 'matplotlib'
The Timeline Tool needs the "matplotlib" (python-matplotlib and on some systems also python-matplotlib-wx) package(s) to be installed.
```

Nothing else is affected, because the tools are started with a plain `except ImportError` in *main_window* and *lmgr* which shows its own message and uses neither the message nor the traceback of the error.

A note is shown only in a traceback, never in `str(exception)`, so this is not applicable where the caller prints the message, for example *r.in.wms* with `gs.fatal()`.

Exception notes need Python 3.11, which is now the minimum version (discussed in #4032). This touches the same lines as #4032, so whichever is merged second needs a trivial conflict resolution.

## Commit message

The Scatterplot, Timeline, and Temporal Plot tools raised a new ImportError
with the hint as its message, so the message of the original error, which
says which module is actually missing, was replaced by the hint.

Add the hint as a note to the original error instead. From the Python
documentation of BaseException.add_note(): Add the string note to the
exception's notes which appear in the standard traceback after the exception
string. The traceback then shows both the missing module and the hint.

The consumer code (various places) shows always its own message, so the
not, not the original message is not used. These changes do not change that.  

Exception notes need Python 3.11, which is now the minimum version.