### PR TITLE
grass.gunittest: Add the module name as an exception note

### DIFF
--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -168,16 +168,16 @@ def discover_modules(
                             add = True  # standard case with given location
                         if not locations:
                             add = True  # count not specified as universal
-            except ImportError as e:
+            except ImportError as error:
                 if add_failed_imports:
                     add = True
                 else:
-                    raise ImportError(
-                        "Cannot import module named %s in %s (%s)"
-                        % (name, full, e.message)
+                    error.add_note(
+                        "Cannot import module named {} in {}".format(name, full)
                     )
                     # alternative is to create TestClass which will raise
                     # see unittest.loader
+                    raise
             if add:
                 modules.append(
                     GrassTestPythonModule(


### PR DESCRIPTION
Now, the test loader raises a new `ImportError` to say which module could not be imported, but its message uses `e.message`, which does not exist in Python 3. The handler therefore raises `AttributeError` instead of the intended error.

Add the module name as a note to the original error instead. From the [Python documentation of `BaseException.add_note()`](https://docs.python.org/3/library/exceptions.html#BaseException.add_note): "Add the string `note` to the exception's notes which appear in the standard traceback after the exception string."

The traceback then shows the import error and the module which could not be imported:

```
ModuleNotFoundError: No module named 'something'
Cannot import module named test_something in /path/to/testsuite
```

The error is not caught anywhere, so it reaches a traceback, which is where a note is shown. The handler is not reached now, because the `try` block does not import the test module.

Exception notes need Python 3.11, which is now the minimum version (discussed in #4032). This touches the same lines as #4032, so whichever is merged second needs a trivial conflict resolution.
