### PR TITLE
grass.pygrass: Add the psycopg2 hint as an exception note

### DIFF
--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -856,9 +856,11 @@ class Link:
                 psycopg2.paramstyle = "qmark"
                 db = " ".join(self.database.split(","))
                 return psycopg2.connect(db)
-            except ImportError:
-                er = "You need to install psycopg2 to connect with this table."
-                raise ImportError(er)
+            except ImportError as error:
+                error.add_note(
+                    "You need to install psycopg2 to connect with this table."
+                )
+                raise
 
         str_err = "Driver is not supported yet, pleas use: sqlite or pg"
         raise TypeError(str_err)


### PR DESCRIPTION
Now, the table connection raises a new `ImportError` with the hint as its message, so a missing psycopg2 ends in a pair of chained exceptions ("During handling of the above exception, another exception occurred").

Add the hint as a note to the original error instead. From the [Python documentation of `BaseException.add_note()`](https://docs.python.org/3/library/exceptions.html#BaseException.add_note): "Add the string `note` to the exception's notes which appear in the standard traceback after the exception string."

Connecting to a PostgreSQL table without psycopg2 then gives a single exception with the actual error as its message and the hint after it:

```
ModuleNotFoundError: No module named 'psycopg2'
You need to install psycopg2 to connect with this table.
```

The error is not caught anywhere, so it reaches a traceback, which is where a note is shown. It would not be shown if a caller printed `str(exception)`.

This is the case discussed in #4032 (`table.py:865`), which was waiting for Python 3.11 as the minimum version. It touches the same lines as #4032, so whichever is merged second needs a trivial conflict resolution.
