### PR TITLE
packaging: Remove locale fallbacks for Python older than 3.11

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -806,11 +806,7 @@ def GetDefaultEncoding(forceUTF8: bool = False) -> str:
 
     :return: system encoding (can be None)
     """
-    try:
-        # Python >= 3.11
-        enc = locale.getencoding()
-    except AttributeError:
-        enc = locale.getdefaultlocale()[1]
+    enc = locale.getencoding()
     if forceUTF8 and (enc is None or enc == "UTF8"):
         return "UTF-8"
 

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -410,11 +410,7 @@ class GConsole(wx.EvtHandler):
             sys.stdout = self.cmdStdOut
             sys.stderr = self.cmdStdErr
         else:
-            try:
-                # Python >= 3.11
-                enc = locale.getencoding()
-            except AttributeError:
-                enc = locale.getdefaultlocale()[1]
+            enc = locale.getencoding()
             if enc:
                 # https://stackoverflow.com/questions/4374455/how-to-set-sys-stdout-encoding-in-python-3
                 sys.stdout = codecs.getwriter(enc)(sys.__stdout__.detach())

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2430,11 +2430,7 @@ class CmdPanel(wx.Panel):
                         )
                         if p.get("value", "") and Path(p["value"]).is_file():
                             ifbb.Clear()
-                            try:
-                                # Python >= 3.11
-                                enc = locale.getencoding()
-                            except AttributeError:
-                                enc = locale.getdefaultlocale()[1]
+                            enc = locale.getencoding()
                             with codecs.open(
                                 p["value"], encoding=enc, errors="ignore"
                             ) as f:
@@ -2991,11 +2987,7 @@ class CmdPanel(wx.Panel):
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
-            try:
-                # Python >= 3.11
-                enc = locale.getencoding()
-            except AttributeError:
-                enc = locale.getdefaultlocale()[1]
+            enc = locale.getencoding()
 
             with codecs.open(path, encoding=enc, mode="w", errors="replace") as f:
                 f.write(text + os.linesep)
@@ -3017,11 +3009,7 @@ class CmdPanel(wx.Panel):
                 filename = grass.tempfile()
                 win.SetValue(filename)
 
-            try:
-                # Python >= 3.11
-                enc = locale.getencoding()
-            except AttributeError:
-                enc = locale.getdefaultlocale()[1]
+            enc = locale.getencoding()
 
             with codecs.open(filename, encoding=enc, mode="w", errors="replace") as f:
                 f.write(text)

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -254,11 +254,7 @@ class AboutWindow(wx.Frame):
         if not self.langUsed:
             import locale
 
-            try:
-                # Python >= 3.11
-                loc = locale.getlocale()
-            except AttributeError:
-                loc = locale.getdefaultlocale()
+            loc = locale.getlocale()
             if loc == (None, None):
                 self.langUsed = _("unknown")
             else:

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -57,11 +57,7 @@ class ViewFrame(wx.Frame):
         self.btn_close.Bind(wx.EVT_BUTTON, self.OnClose)
         self.btn_ok.Bind(wx.EVT_BUTTON, self.OnOk)
         self._layout()
-        try:
-            # Python >= 3.11
-            self.enc = locale.getencoding()
-        except AttributeError:
-            self.enc = locale.getdefaultlocale()[1]
+        self.enc = locale.getencoding()
 
     def _layout(self):
         """Set the layout"""

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -72,11 +72,7 @@ _WXPYTHON_BASE = None
 
 GISBASE = None
 
-try:
-    # Python >= 3.11
-    ENCODING = locale.getencoding()
-except AttributeError:
-    ENCODING = locale.getdefaultlocale()[1]
+ENCODING = locale.getencoding()
 if ENCODING is None:
     ENCODING = "UTF-8"
     print("Default locale not found, using UTF-8")  # intentionally not translatable
@@ -1097,11 +1093,7 @@ def set_language(grass_config_dir: StrPath) -> None:
                 "Default locale settings are missing. GRASS running with C locale.\n"
             )
 
-        try:
-            # Python >= 3.11
-            language, encoding = locale.getlocale()
-        except AttributeError:
-            language, encoding = locale.getdefaultlocale()
+        language, encoding = locale.getlocale()
         if not language:
             sys.stderr.write(
                 "Default locale settings are missing. GRASS running with C locale.\n"

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -17,11 +17,7 @@ import locale
 
 
 def _get_encoding():
-    try:
-        # Python >= 3.11
-        encoding = locale.getencoding()
-    except AttributeError:
-        encoding = locale.getdefaultlocale()[1]
+    encoding = locale.getencoding()
     if not encoding:
         encoding = "UTF-8"
     return encoding

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -216,11 +216,7 @@ class KeyValue(dict[str, VT]):
 
 
 def _get_encoding() -> str:
-    try:
-        # Python >= 3.11
-        encoding = locale.getencoding()
-    except AttributeError:
-        encoding = locale.getdefaultlocale()[1]
+    encoding = locale.getencoding()
     if not encoding:
         encoding = "UTF-8"
     return encoding

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -71,11 +71,7 @@ if grass_version != "unknown":
 
 
 def _get_encoding():
-    try:
-        # Python >= 3.11
-        encoding = locale.getencoding()
-    except AttributeError:
-        encoding = locale.getdefaultlocale()[1]
+    encoding = locale.getencoding()
     if not encoding:
         encoding = "UTF-8"
     return encoding


### PR DESCRIPTION
Remove fallback for pre-Python 3.11 and use exclusively locale.getencoding(). While this is changing code, this is technically a further packaging-related follow-up to #7684, which raised the minimal Python version to 3.11 but missed these places. They are marked with a `# Python >= 3.11` comment and handled through try-except ("ask for forgiveness") rather than branched with a `sys.version_info` check (sort of "ask for permission").

`locale.getencoding()` was added in Python 3.11, so the fallbacks to `locale.getdefaultlocale()` are never used now that 3.11 is the minimal supported version. On 3.11 and newer, `locale.getencoding()` is what already ran, so there is no change in behavior. As a bonus, `locale.getdefaultlocale()` is actually deprecated since 3.11, so this also removes the uses of it.

Two of the places call `locale.getlocale()` instead. That function is available in all supported versions and never raises `AttributeError`, so those fallbacks could not be reached even before this change. The (here unused) fallbacks are now removed.

Verified partially by AI agent by running the three `_get_encoding()` functions (`grass.script.utils`, `grass.gunittest.multirunner`, `utils/mkhtml.py`) and the two expressions in `lib/init/grass.py` (GUI places assumed to work as well).

AI (Claude Code with Opus) was used to find these places and to prepare this change based on the review for #7684.