### PR TITLE
CI: add CycloneDX SBOM generation for releases

### DIFF
--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -73,6 +73,15 @@ jobs:
           xz -9e "${GRASS}.tar"
           md5sum "${GRASS}.tar.xz" > "${GRASS}.tar.xz.md5"
           sha256sum "${GRASS}.tar.xz" > "${GRASS}.tar.xz.sha256"
+      - name: Generate CycloneDX SBOM (for tags only)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: ${{ env.OUT_DIR }}/grass.cyclonedx.json
+          upload-artifact: false
+          upload-release-assets: false
       - name: Publish draft distribution to GitHub (for tags only)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
@@ -93,3 +102,4 @@ jobs:
               ${{ env.OUT_DIR }}/${{ env.GRASS }}.tar.xz.sha256
               ${{ env.OUT_DIR }}/ChangeLog.gz
               ${{ env.OUT_DIR }}/core_modules_with_last_commit.patch
+              ${{ env.OUT_DIR }}/grass.cyclonedx.json

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -73,14 +73,14 @@ jobs:
           xz -9e "${GRASS}.tar"
           md5sum "${GRASS}.tar.xz" > "${GRASS}.tar.xz.md5"
           sha256sum "${GRASS}.tar.xz" > "${GRASS}.tar.xz.sha256"
-      - name: Generate CycloneDX SBOM (for tags only)
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: cyclonedx-json
-          output-file: ${{ env.OUT_DIR }}/grass.cyclonedx.json
-          upload-artifact: false
+          output-file: ${{ env.OUT_DIR }}/grass.cdx.json
+          artifact-name: grass.cdx.json
+          upload-artifact: true
           upload-release-assets: false
       - name: Publish draft distribution to GitHub (for tags only)
         if: startsWith(github.ref, 'refs/tags/')
@@ -102,4 +102,4 @@ jobs:
               ${{ env.OUT_DIR }}/${{ env.GRASS }}.tar.xz.sha256
               ${{ env.OUT_DIR }}/ChangeLog.gz
               ${{ env.OUT_DIR }}/core_modules_with_last_commit.patch
-              ${{ env.OUT_DIR }}/grass.cyclonedx.json
+              ${{ env.OUT_DIR }}/grass.cdx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,39 @@
+---
+name: Generate SBOM
+
+on:
+  workflow_dispatch:
+    inputs:
+      source-path:
+        description: Path to scan for SBOM generation
+        required: false
+        default: '.'
+      output-file:
+        description: Output SBOM file name
+        required: false
+        default: 'grass.cyclonedx.json'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: ${{ inputs.source-path }}
+          format: cyclonedx-json
+          output-file: ${{ inputs.output-file }}
+          upload-artifact: true
+          artifact-name: grass-sbom

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: ${{ inputs.source-path }}
+          path: .
           format: cyclonedx-json
-          output-file: ${{ inputs.output-file }}
+          artifact-name: grass.cdx.json
           upload-artifact: true
-          artifact-name: grass-sbom
+          upload-release-assets: false

--- a/Makefile
+++ b/Makefile
@@ -126,15 +126,16 @@ code-coverage-clean:
 sbom:
 	@if command -v syft > /dev/null 2>&1; then \
 		echo "Generating CycloneDX SBOM using Syft..."; \
-		syft dir:. -o cyclonedx-json=grass.cyclonedx.json; \
-		echo "SBOM written to grass.cyclonedx.json"; \
+		syft dir:. -o cyclonedx-json=grass.cdx.json; \
+		echo "SBOM written to grass.cdx.json"; \
 	else \
-		echo "Syft not found. Install it from https://github.com/anchore/syft"; \
+		echo "Syft not found. Install it from https://github.com/anchore/syft" >&2; \
 		exit 1; \
 	fi
 
 distclean: clean
 	-rm -f config.cache config.log config.status config.status.$(ARCH) 2>/dev/null
+	-rm -f grass.cdx.json
 	-rm -f ChangeLog ChangeLog.bak $(ERRORLOG) grass.pc
 	-rm -f include/grass/config.h include/grass/version.h
 	-rm -f include/Make/Platform.make include/Make/Doxyfile_arch_html include/Make/Doxyfile_arch_latex 2>/dev/null

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,16 @@ code-coverage-clean:
 	-find . -type f \( -name "*.gcda" -o -name "*.gcno" -o -name "*.gcov" \) -delete
 	-rm -f .coverage
 
+sbom:
+	@if command -v syft > /dev/null 2>&1; then \
+		echo "Generating CycloneDX SBOM using Syft..."; \
+		syft dir:. -o cyclonedx-json=grass.cyclonedx.json; \
+		echo "SBOM written to grass.cyclonedx.json"; \
+	else \
+		echo "Syft not found. Install it from https://github.com/anchore/syft"; \
+		exit 1; \
+	fi
+
 distclean: clean
 	-rm -f config.cache config.log config.status config.status.$(ARCH) 2>/dev/null
 	-rm -f ChangeLog ChangeLog.bak $(ERRORLOG) grass.pc
@@ -136,5 +146,5 @@ include $(MODULE_TOPDIR)/include/Make/Sphinx.make
 
 DOXNAME=grass
 
-.PHONY: default libs
+.PHONY: default libs sbom
 .PHONY: cleandistdirs cleanscriptstrings clean libsclean distclean

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,4 +55,19 @@ in allowing us time to address any reported vulnerabilities before disclosing
 them publicly. We ask that you refrain from disclosing any details of the
 vulnerability until we have had adequate time to provide a fix.
 
+## Software Bill of Materials (SBOM)
+
+GRASS publishes a CycloneDX SBOM with every official release.
+
+- The SBOM is generated automatically in CI via [Syft](https://github.com/anchore/syft)
+  and attached as `grass.cyclonedx.json` to each GitHub release draft.
+- For Docker images, an SBOM is embedded at build time (`sbom: true` in
+  `docker/build-push-action`) and attestations are published via
+  `actions/attest-build-provenance`.
+- To generate an SBOM locally, install Syft and run `make sbom` from the
+  repository root.
+- SBOM generation can also be triggered manually via the
+  [Generate SBOM](https://github.com/OSGeo/grass/actions/workflows/sbom.yml)
+  workflow on GitHub Actions.
+
 Thank you for helping to keep GRASS secure!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,11 @@ vulnerability until we have had adequate time to provide a fix.
 GRASS publishes a CycloneDX SBOM with every official release.
 
 - The SBOM is generated automatically in CI via [Syft](https://github.com/anchore/syft)
-  and attached as `grass.cyclonedx.json` to each GitHub release draft.
+  and attached as `grass.cdx.json` to each GitHub release draft.
+  It covers dependencies declared in the source tree (Python package
+  requirements); components linked at build time (GDAL, PROJ, GEOS,
+  etc.) are resolved only in built artifacts and appear in the Docker
+  image SBOMs where they are installed from OS package repositories.
 - For Docker images, an SBOM is embedded at build time (`sbom: true` in
   `docker/build-push-action`) and attestations are published via
   `actions/attest-build-provenance`.


### PR DESCRIPTION
Background: A software [bill of materials](https://en.wikipedia.org/wiki/Bill_of_materials) (**SBOM**) declares the inventory of components used to build a software artifact, including any [open source](https://en.wikipedia.org/wiki/Open-source_software) and [proprietary software](https://en.wikipedia.org/wiki/Proprietary_software) components (source: [Wikipedia](https://en.wikipedia.org/wiki/Software_supply_chain))

Generate a CycloneDX Software Bill of Materials (SBOM) automatically in CI for every tagged release, attached as `grass.cyclonedx.json` alongside the tarballs in the release draft.

A standalone `sbom.yml` workflow allows ad-hoc generation via `workflow_dispatch`. Local generation is available with `make sbom` (requires [Syft](https://github.com/anchore/syft)).

The resulting JSON can be visualized in a SBOM analyser tool (e.g. [sbom-analyzer](https://sbom.observer/free/sbom-analyzer))

Addresses #7215

Written with support by opencode (DeepSeek V4 Flash Free via OpenCode Zen)