### PR TITLE
checks: Exclude vendored code from bandit scanning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -552,6 +552,9 @@ exclude_dirs = [
     "*/tests/*",
     "*/testsuite/*",
     "utils/test_generate_last_commit_file.py",
+    # Vendored code, matching the pylint ignore-paths entries below.
+    "python/grass/temporal/ply",
+    "python/libgrass_interface_generator",
 ]
 skips = ["B324", "B110", "B101", "B112", "B311", "B404", "B603"]
 


### PR DESCRIPTION
This addresses 13 open code scanning (Bandit) alerts that all point into vendored code GRASS does not maintain:

- `python/libgrass_interface_generator/` (vendored ctypesgen): 4x B102 (exec), 4x B403 (pickle import), 1x B605, 1x B307, 1x B602, 1x B607
- `python/grass/temporal/ply/` (vendored PLY): 1x B307 (eval)

Both directories are already excluded from pylint (`ignore-paths`) and from the formatter (`extend-exclude`) in `pyproject.toml`, so this brings bandit in line with existing practice for vendored code.

Verified locally with bandit 1.9.4 (the version currently used in CI): before the change, `bandit -c pyproject.toml -iii -r` on the two directories reports exactly the 13 findings above; after the change it reports none.

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
