### PR TITLE
lib/psdriver: Print double coordinates with %f, not %d

### DIFF
--- a/lib/psdriver/draw_bitmap.c
+++ b/lib/psdriver/draw_bitmap.c
@@ -4,7 +4,7 @@ void PS_Bitmap(int ncols, int nrows, int threshold, const unsigned char *buf)
 {
     int i, j;
 
-    output("%d %d %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
+    output("%f %f %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
 
     for (j = 0; j < nrows; j++) {
         unsigned int bit = 0x80;

--- a/lib/psdriver/erase.c
+++ b/lib/psdriver/erase.c
@@ -3,7 +3,7 @@
 void PS_Erase(void)
 {
     if (ps.encapsulated)
-        output("%d %d %d %d BOX\n", ps.left, ps.top, ps.right, ps.bot);
+        output("%f %f %f %f BOX\n", ps.left, ps.top, ps.right, ps.bot);
     else
         output("ERASE\n");
 }


### PR DESCRIPTION
Fixes 6 CodeQL `cpp/wrong-type-format-argument` alerts (error severity), all in the PS driver:

- `draw_bitmap.c`: `PS_Bitmap()` printed the `double` globals `cur_x`, `cur_y` with `%d`
- `erase.c`: `PS_Erase()` printed the `double` fields `ps.left`, `ps.top`, `ps.right`, `ps.bot` with `%d`

This is a real bug, not just a style issue: on x86_64 the doubles go into SSE registers while `%d` reads the integer registers, so the emitted PostScript operators received garbage operands. Before the fix, `d.text` (with a freetype font) emitted e.g.

```
16 20 -12276336 -12276336 BITMAP
```

(glyph size in the position slots, garbage for the rest). After the fix:

```
322.000000 220.000000 16 20 BITMAP
0.000000 480.000000 640.000000 0.000000 BOX
```

`%f` matches how `box.c` already prints the same `BOX` procedure, and the `BITMAP` prolog passes the first two operands to `translate`, which accepts reals (the integer-only `idiv` operates on `ncols`, which stays `%d`).

Verified by compiling and rendering `d.erase -f` and `d.text` with `GRASS_RENDER_IMMEDIATE=ps` and inspecting the output above.

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
