### PR TITLE
r.unpack, v.unpack: Refuse to extract archives without a tarfile filter

### DIFF
--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -60,19 +60,14 @@ def extract_tar(name, directory, tmpdir):
         extract_dir = os.path.join(tmpdir, "extract_dir")
         Path(extract_dir).mkdir()
 
-        # Extraction filters were added in Python 3.12,
-        # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
-        # See
-        # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-        # and https://peps.python.org/pep-0706/
-        # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
-        # and in Python 3.14, `filter='data'` will be the default
-        if hasattr(tarfile, "data_filter"):
-            tar.extractall(path=extract_dir, filter="data")
-        else:
-            # Remove this when no longer needed
-            debug(_("Extracting may be unsafe; consider updating Python"))
-            tar.extractall(path=extract_dir)
+        # The 'data' extraction filter was added in Python 3.12 and backported
+        # to 3.11.4 (PEP 706). Refuse to extract without it rather
+        # than extracting unsafely.
+        if not hasattr(tarfile, "data_filter"):
+            raise DownloadError(
+                _("Extracting may be unsafe; upgrade Python to 3.11.4 or newer")
+            )
+        tar.extractall(path=extract_dir, filter="data")
 
         files = os.listdir(extract_dir)
         _move_extracted_files(

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1835,19 +1835,12 @@ def extract_tar(name, directory, tmpdir):
         extract_dir = os.path.join(tmpdir, "extract_dir")
         Path(extract_dir).mkdir()
 
-        # Extraction filters were added in Python 3.12,
-        # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
-        # See
-        # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-        # and https://peps.python.org/pep-0706/
-        # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
-        # and in Python 3.14, `filter='data'` will be the default
-        if hasattr(tarfile, "data_filter"):
-            tar.extractall(path=extract_dir, filter="data")
-        else:
-            # Remove this when no longer needed
-            gs.warning(_("Extracting may be unsafe; consider updating Python"))
-            tar.extractall(path=extract_dir)
+        # The 'data' extraction filter was added in Python 3.12 and backported
+        # to 3.11.4 (PEP 706). Refuse to extract without it rather
+        # than extracting unsafely.
+        if not hasattr(tarfile, "data_filter"):
+            gs.fatal(_("Extracting may be unsafe; upgrade Python to 3.11.4 or newer"))
+        tar.extractall(path=extract_dir, filter="data")
 
         files = os.listdir(extract_dir)
         move_extracted_files(extract_dir=extract_dir, target_dir=directory, files=files)

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -106,18 +106,12 @@ def main():
             )
 
     # extract data
-    # Extraction filters were added in Python 3.12,
-    # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
-    # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-    # and https://peps.python.org/pep-0706/
-    # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
-    # and in Python 3.14, `filter='data'` will be the default
-    if hasattr(tarfile, "data_filter"):
-        tar.extractall(filter="data")
-    else:
-        # Remove this when no longer needed
-        grass.warning(_("Extracting may be unsafe; consider updating Python"))
-        tar.extractall()
+    # The 'data' extraction filter was added in Python 3.12 and backported to
+    # 3.11.4 (PEP 706). Refuse to extract without it rather than
+    # extracting unsafely.
+    if not hasattr(tarfile, "data_filter"):
+        grass.fatal(_("Extracting may be unsafe; upgrade Python to 3.11.4 or newer"))
+    tar.extractall(filter="data")
     tar.close()
     os.chdir(data_names[0])
 

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -118,18 +118,12 @@ def main():
         shutil.rmtree(new_dir, True)
 
     # extract data
-    # Extraction filters were added in Python 3.12,
-    # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
-    # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-    # and https://peps.python.org/pep-0706/
-    # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
-    # and in Python 3.14, `filter='data'` will be the default
-    if hasattr(tarfile, "data_filter"):
-        tar.extractall(filter="data")
-    else:
-        # Remove this when no longer needed
-        grass.warning(_("Extracting may be unsafe; consider updating Python"))
-        tar.extractall()
+    # The 'data' extraction filter was added in Python 3.12 and backported to
+    # 3.11.4 (PEP 706). Refuse to extract without it rather than
+    # extracting unsafely.
+    if not hasattr(tarfile, "data_filter"):
+        grass.fatal(_("Extracting may be unsafe; upgrade Python to 3.11.4 or newer"))
+    tar.extractall(filter="data")
     tar.close()
     if Path(data_name, "coor").exists():
         pass


### PR DESCRIPTION
Fixes the 2 open Bandit B202 (`tarfile_unsafe_members`, error severity) code scanning alerts in r.unpack and v.unpack.

The alerts fire on the pre-PEP 706 fallback branch, which extracted archives with a bare `extractall()` after only a warning. A crafted pack file could write outside the extraction directory. Since the minimum supported Python is now 3.11 (#7684) and the `data` filter is available in 3.11.4+ and 3.12+, the only Pythons that reach the fallback are outdated 3.11 micro releases, so refuse to extract there with a fatal error instead of proceeding unsafely.

The same fallback pattern exists (unflagged) in `g.extension` and `grass.utils.download`; this applies the identical change there for consistency.

Verified by running the v.unpack gunittest (`testsuite/test_v_unpack.py`, passes against nc_spm) and an `r.pack`/`r.unpack` round trip, both exercising the `filter="data"` path, plus a local bandit 1.9.4 run confirming the B202 findings are gone.

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
