### PR TITLE
raster: Fix three single-alert CodeQL findings

### DIFF
--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -491,7 +491,7 @@ int main(int argc, char *argv[])
                                 *p = '\0';
                         }
                     }
-                    if (sdsdesc && *sdsdesc)
+                    if (*sdsdesc)
                         fprintf(stderr, "  Description: %s\n", sdsdesc);
                     if (sdsdim && *sdsdim)
                         fprintf(stderr, "  Dimension: %s\n", sdsdim);

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -972,7 +972,7 @@ void save_io_vis_and_elev_to_GRASS(IOVisibilityGrid *visgrid, char *elevfname,
 
         Rast_get_row(elevfd, elevrast, i, elev_data_type);
 
-        for (j = 0; j < Rast_window_cols(); j++) {
+        for (j = 0; j < (dimensionType)ncols; j++) {
 
             /* read the current elevation value */
             // int isNull = 0;

--- a/raster/r.watershed/ram/init_vars.c
+++ b/raster/r.watershed/ram/init_vars.c
@@ -83,7 +83,7 @@ int init_vars(int argc, char *argv[])
         else if (sscanf(argv[r], "blocking=%s", ob_name) == 1)
             ob_flag++;
         else if (sscanf(argv[r], "disturbed_land=%s", ril_name) == 1) {
-            if (sscanf(ril_name, "%lf", &ril_value) == 0) {
+            if (sscanf(ril_name, "%lf", &ril_value) != 1) {
                 ril_value = -1.0;
                 ril_flag++;
             }


### PR DESCRIPTION
Fixes three single-alert CodeQL code scanning findings, one per tool:

- **r.watershed** (`ram/init_vars.c`, `cpp/incorrectly-checked-scanf`, error severity): `sscanf(ril_name, "%lf", &ril_value) == 0` misses the EOF (-1) return. Changed to `!= 1`, which is also exactly what the seg variant (`seg/init_vars.c`) already does on the same line.
- **r.viewshed** (`grass.cpp`, `cpp/comparison-with-wider-type`): the inner column loop counter `j` is `dimensionType` (unsigned short) but was compared against `int Rast_window_cols()`. Now bounded by the existing local `ncols` cast to `dimensionType`, matching the row loop one line above. The comparison is safe in practice because of the `maxDimension` guard, but the loop now mirrors the row loop and avoids the repeated function call.
- **r.in.gdal** (`main.c`, `cpp/redundant-null-check-simple`, error severity): `sdsdesc` is unconditionally assigned a non-null pointer before the `if (sdsdesc && *sdsdesc)` check, so the null test is dead code; dropped it.

All three tools compile and their testsuites pass locally against nc_spm (r.watershed, r.viewshed, and r.in.gdal's 12 tests).

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
