### PR TITLE
python: Use argument lists instead of shell=True for subprocess

### DIFF
--- a/python/grass/imaging/images2avi.py
+++ b/python/grass/imaging/images2avi.py
@@ -39,6 +39,7 @@ http://linux.die.net/man/1/ffmpeg
 """
 
 import os
+import shlex
 import time
 import subprocess
 import shutil
@@ -115,14 +116,15 @@ def writeAvi(
         formatter = "%03d"
 
     # Compile command to create avi
-    command = "ffmpeg -r %i %s " % (int(fps), inputOptions)
-    command += "-i im%s.png " % (formatter,)
-    command += "-g 1 -vcodec %s %s " % (encoding, outputOptions)
-    command += "output.avi"
+    command = ["ffmpeg", "-r", "%i" % int(fps)]
+    command += shlex.split(inputOptions)
+    command += ["-i", "im%s.png" % formatter, "-g", "1", "-vcodec", encoding]
+    command += shlex.split(outputOptions)
+    command.append("output.avi")
 
     # Run ffmpeg
     S = subprocess.Popen(
-        command, shell=True, cwd=tempDir, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        command, cwd=tempDir, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
     # Show what ffmpeg has to say
@@ -180,7 +182,7 @@ def readAvi(filename, asNumpy=True):
     shutil.copy(filename, os.path.join(tempDir, "input.avi"))
 
     # Run ffmpeg
-    command = "ffmpeg -i input.avi im%d.jpg"
+    command = ["ffmpeg", "-i", "input.avi", "im%d.jpg"]
     with subprocess.Popen(
         command,
         cwd=tempDir,

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -6,9 +6,8 @@ import shutil as sht
 from math import ceil
 from pathlib import Path
 
-from grass.script import core as gcore
 from grass.script.setup import write_gisrc
-from grass.script import append_node_pid, available_cpus, legalize_vector_name
+from grass.script import Popen, append_node_pid, available_cpus, legalize_vector_name
 
 from grass.pygrass.gis import Mapset, Location
 from grass.pygrass.gis.region import Region
@@ -226,9 +225,9 @@ def set_region(region, gisrc_src, gisrc_dst, env):
         "ewres=%r" % region_dict["ewres"],
     ]
     env["GISRC"] = gisrc_src
-    sub.Popen(reg_cmd, env=env)
+    Popen(reg_cmd, env=env)
     env["GISRC"] = gisrc_dst
-    sub.Popen(reg_cmd, env=env)
+    Popen(reg_cmd, env=env)
 
 
 def copy_rasters(rasters, gisrc_src, gisrc_dst, processes, region=None):
@@ -388,15 +387,15 @@ def cmd_exe(args):
             inputs[key] = mapnames[key]
         cmd["inputs"] = inputs.items()
         # set the region to the tile
-        gcore.Popen(["g.region", "raster=%s" % key], env=env).wait()
+        Popen(["g.region", "raster=%s" % key], env=env).wait()
     else:
         # set the computational region
         lcmd = ["g.region", *["%s=%s" % (k, v) for k, v in bbox.items()]]
-        gcore.Popen(lcmd, env=env).wait()
+        Popen(lcmd, env=env).wait()
     if groups:
         copy_groups(groups, gisrc_src, gisrc_dst, processes=1)
     # run the grass command
-    gcore.Popen(get_cmd(cmd), env=env).wait()
+    Popen(get_cmd(cmd), env=env).wait()
     # remove temp GISRC
     Path(gisrc_dst).unlink()
 

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -1,12 +1,12 @@
 import contextlib
 import os
-import sys
 import multiprocessing as mltp
 import subprocess as sub
 import shutil as sht
 from math import ceil
 from pathlib import Path
 
+from grass.script import core as gcore
 from grass.script.setup import write_gisrc
 from grass.script import append_node_pid, available_cpus, legalize_vector_name
 
@@ -215,16 +215,20 @@ def set_region(region, gisrc_src, gisrc_dst, env):
     :type env:
     :returns: None
     """
-    reg_str = (
-        "g.region n=%(north)r s=%(south)r "
-        "e=%(east)r w=%(west)r "
-        "nsres=%(nsres)r ewres=%(ewres)r"
-    )
-    reg_cmd = reg_str % dict(region.items())
+    region_dict = dict(region.items())
+    reg_cmd = [
+        "g.region",
+        "n=%r" % region_dict["north"],
+        "s=%r" % region_dict["south"],
+        "e=%r" % region_dict["east"],
+        "w=%r" % region_dict["west"],
+        "nsres=%r" % region_dict["nsres"],
+        "ewres=%r" % region_dict["ewres"],
+    ]
     env["GISRC"] = gisrc_src
-    sub.Popen(reg_cmd, shell=True, env=env)
+    sub.Popen(reg_cmd, env=env)
     env["GISRC"] = gisrc_dst
-    sub.Popen(reg_cmd, shell=True, env=env)
+    sub.Popen(reg_cmd, env=env)
 
 
 def copy_rasters(rasters, gisrc_src, gisrc_dst, processes, region=None):
@@ -377,7 +381,6 @@ def cmd_exe(args):
     src, dst = get_mapset(gisrc_src, gisrc_dst)
     env = os.environ.copy()
     env["GISRC"] = gisrc_dst
-    shell = sys.platform == "win32"
     if mapnames:
         inputs = dict(cmd["inputs"])
         # reset the inputs to
@@ -385,15 +388,15 @@ def cmd_exe(args):
             inputs[key] = mapnames[key]
         cmd["inputs"] = inputs.items()
         # set the region to the tile
-        sub.Popen(["g.region", "raster=%s" % key], shell=shell, env=env).wait()
+        gcore.Popen(["g.region", "raster=%s" % key], env=env).wait()
     else:
         # set the computational region
         lcmd = ["g.region", *["%s=%s" % (k, v) for k, v in bbox.items()]]
-        sub.Popen(lcmd, shell=shell, env=env).wait()
+        gcore.Popen(lcmd, env=env).wait()
     if groups:
         copy_groups(groups, gisrc_src, gisrc_dst, processes=1)
     # run the grass command
-    sub.Popen(get_cmd(cmd), shell=shell, env=env).wait()
+    gcore.Popen(get_cmd(cmd), env=env).wait()
     # remove temp GISRC
     Path(gisrc_dst).unlink()
 


### PR DESCRIPTION
Fixes the 6 Bandit B602 (`shell=True`, error severity) code scanning alerts in non-vendored code, as a robustness and portability cleanup:

- **`grass.imaging.images2avi.writeAvi`**: the ffmpeg command was assembled by string concatenation and run through the shell. Now built as an argument list, with the caller-provided `inputOptions`/`outputOptions` strings split via `shlex.split()`, preserving the previous argument semantics.
- **`grass.imaging.images2avi.readAvi`**: the command was a plain string passed without `shell=True`, which raises `FileNotFoundError` on non-Windows platforms (`No such file or directory: 'ffmpeg -i input.avi im%d.jpg'`), so this also fixes readAvi being broken on Linux and macOS.
- **`grass.pygrass.modules.grid`**: `set_region()` built a `g.region` command string for the shell; now an explicit argument list. `cmd_exe()` passed `shell=(sys.platform == "win32")`; it now uses `grass.script.core.Popen`, which resolves the executable with `shutil.which()` and handles script tools on Windows, so the platform flag is no longer needed.

Verified locally:
- `GridModule` (r.slope.aspect, 4 tiles, 2 processes) produces output bit-identical to a non-tiled run (`r.mapcalc` diff, max abs diff 0)
- `writeAvi`/`readAvi` round trip with real ffmpeg (5 frames, correct shapes), exercising the shlex option splitting
- direct `set_region()` call confirmed to apply the region
- bandit 1.9.4 reports no findings in the two files

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
