### PR TITLE
lib/ogsf, lib/nviz: Fix multiplications converted to a larger type

### DIFF
--- a/lib/nviz/lights.c
+++ b/lib/nviz/lights.c
@@ -68,9 +68,9 @@ int Nviz_set_light_bright(nv_data *data, int num, double value)
 
     data->light[num].brt = value;
 
-    r = data->light[num].r * data->light[num].brt;
-    g = data->light[num].g * data->light[num].brt;
-    b = data->light[num].b * data->light[num].brt;
+    r = (double)data->light[num].r * data->light[num].brt;
+    g = (double)data->light[num].g * data->light[num].brt;
+    b = (double)data->light[num].b * data->light[num].brt;
 
     G_debug(1,
             "Nviz_set_light_bright(): num = %d value = %f r = %f g = %f b = %f",
@@ -95,9 +95,9 @@ int Nviz_set_light_color(nv_data *data, int num, int red, int green, int blue)
     data->light[num].g = green / 255.;
     data->light[num].b = blue / 255.;
 
-    r = data->light[num].r * data->light[num].brt;
-    g = data->light[num].g * data->light[num].brt;
-    b = data->light[num].b * data->light[num].brt;
+    r = (double)data->light[num].r * data->light[num].brt;
+    g = (double)data->light[num].g * data->light[num].brt;
+    b = (double)data->light[num].b * data->light[num].brt;
 
     G_debug(1, "Nviz_set_light_color(): num = %d r = %d/%f g = %d/%f b = %d/%f",
             num, red, r, green, g, blue, b);

--- a/lib/ogsf/gs.c
+++ b/lib/ogsf/gs.c
@@ -317,7 +317,7 @@ int gs_init_normbuff(geosurf *gs)
         G_free(gs->norms);
     }
 
-    size = gs->rows * gs->cols * sizeof(unsigned long);
+    size = (long)gs->rows * gs->cols * sizeof(unsigned long);
 
     gs->norms = (unsigned long *)G_malloc(size); /* G_fatal_error */
     if (!gs->norms) {

--- a/lib/ogsf/gs_norms.c
+++ b/lib/ogsf/gs_norms.c
@@ -95,7 +95,7 @@ void init_vars(geosurf *gs)
     }
 #endif
 
-    slice = gs->y_mod * gs->cols;
+    slice = (long)gs->y_mod * gs->cols;
 
     return;
 }

--- a/lib/ogsf/gsd_cplane.c
+++ b/lib/ogsf/gsd_cplane.c
@@ -67,9 +67,9 @@ void gsd_def_cplane(int num, float *pt, float *norm)
     ppt[1] = (pt[1] + Cp_pt[1]) * sy;
     ppt[2] = (pt[2] + Cp_pt[2] - zmin) * sz;
 
-    params[0] = norm[0] * sx;
-    params[1] = norm[1] * sy;
-    params[2] = norm[2] * sz;
+    params[0] = (double)norm[0] * sx;
+    params[1] = (double)norm[1] * sy;
+    params[2] = (double)norm[2] * sz;
     GS_dv3norm(params);
     params[3] = -ppt[0] * params[0] - ppt[1] * params[1] - ppt[2] * params[2];
 

--- a/lib/ogsf/gsd_fringe.c
+++ b/lib/ogsf/gsd_fringe.c
@@ -531,7 +531,7 @@ void gsd_fringe_horiz_line2(float bot, geosurf *surf, int row, int side)
         /* bottom right */
         pt[X] = surf->xmin + (col * (surf->x_mod * surf->xres));
         pt[Y] = surf->ymax - ((row + side) * (surf->y_mod * surf->yres));
-        offset = col * surf->x_mod;
+        offset = (long)col * surf->x_mod;
         GET_MAPATT(buff, offset, pt[Z]);
         pt[Z] = pt[Z] * surf->z_exag;
         gsd_vert_func(pt);

--- a/lib/ogsf/gsd_surf.c
+++ b/lib/ogsf/gsd_surf.c
@@ -309,8 +309,8 @@ int gsd_surf_map_old(geosurf *surf)
 
         y1 = ymax - row * yres;
         y2 = ymax - (row + 1) * yres;
-        y1off = row * ymod * surf->cols;
-        y2off = (row + 1) * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
+        y2off = (long)(row + 1) * ymod * surf->cols;
 
         gsd_bgntmesh();
 
@@ -869,8 +869,8 @@ int gsd_surf_const(geosurf *surf, float k)
 
         y1 = ymax - row * yres;
         y2 = ymax - (row + 1) * yres;
-        y1off = row * ymod * surf->cols;
-        y2off = (row + 1) * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
+        y2off = (long)(row + 1) * ymod * surf->cols;
 
         gsd_bgntmesh();
 
@@ -1894,8 +1894,8 @@ int gsd_norm_arrows(geosurf *surf)
 
         y1 = ymax - row * yres;
         y2 = ymax - (row + 1) * yres;
-        y1off = row * ymod * surf->cols;
-        y2off = (row + 1) * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
+        y2off = (long)(row + 1) * ymod * surf->cols;
 
         zeros = 0;
         dr1 = dr2 = dr3 = dr4 = 1;
@@ -2241,9 +2241,9 @@ int gsd_surf_map(geosurf *surf)
         y2 = ymax - (row - (step_val / 2)) * yres;
         y3 = ymax - (row + (step_val / 2)) * yres;
 
-        y1off = row * ymod * surf->cols;
-        y2off = (row - (step_val / 2)) * ymod * surf->cols;
-        y3off = (row + (step_val / 2)) * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
+        y2off = (long)(row - (step_val / 2)) * ymod * surf->cols;
+        y3off = (long)(row + (step_val / 2)) * ymod * surf->cols;
 
         for (col = start_val; col < xcnt; col += step_val) {
             datacol1 = col * xmod;

--- a/lib/ogsf/gsd_views.c
+++ b/lib/ogsf/gsd_views.c
@@ -447,11 +447,11 @@ void gsd_surf2model(Point3 point)
     GS_get_scale(&sx, &sy, &sz, 1);
     GS_get_zrange(&min, &max, 0);
 
-    point[Z] = (sz ? (point[Z] - min) * sz : 0.0);
+    point[Z] = (sz ? (point[Z] - min) * sz : 0.0f);
 
     /* need to unscale x & y */
-    point[X] = (sx ? point[X] * sx : 0.0);
-    point[Y] = (sy ? point[Y] * sy : 0.0);
+    point[X] = (sx ? point[X] * sx : 0.0f);
+    point[Y] = (sy ? point[Y] * sy : 0.0f);
 
     return;
 }

--- a/lib/ogsf/gsd_wire.c
+++ b/lib/ogsf/gsd_wire.c
@@ -163,7 +163,7 @@ int gsd_wire_surf_map(geosurf *surf)
     /* would also be good to check if colormap == surfmap, to increase speed */
     for (row = 0; row < ycnt; row++) {
         pt[Y] = ymax - row * yres;
-        y1off = row * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
 
         gsd_bgnline();
         cnt = 0;
@@ -219,7 +219,7 @@ int gsd_wire_surf_map(geosurf *surf)
 
         for (row = 0; row < ycnt; row++) {
             pt[Y] = ymax - row * yres;
-            y1off = row * ymod * surf->cols;
+            y1off = (long)row * ymod * surf->cols;
             offset = x1off + y1off;
 
             if (check_mask) {
@@ -337,7 +337,7 @@ int gsd_wire_surf_const(geosurf *surf, float k)
 
     for (row = 0; row < ycnt; row++) {
         pt[Y] = ymax - row * yres;
-        y1off = row * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
 
         gsd_bgnline();
         cnt = 0;
@@ -388,7 +388,7 @@ int gsd_wire_surf_const(geosurf *surf, float k)
 
         for (row = 0; row < ycnt; row++) {
             pt[Y] = ymax - row * yres;
-            y1off = row * ymod * surf->cols;
+            y1off = (long)row * ymod * surf->cols;
             offset = x1off + y1off;
 
             if (check_mask) {
@@ -522,11 +522,11 @@ int gsd_wire_arrows(geosurf *surf)
 
     for (row = 0; row < ycnt; row++) {
         pt[Y] = ymax - row * yres;
-        y1off = row * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
 
         for (col = 0; col < xcnt; col++) {
             pt[X] = col * xres;
-            offset = col * xmod + y1off;
+            offset = (long)col * xmod + y1off;
 
             if (check_mask) {
                 if (BM_get(surf->curmask, col * xmod, row * ymod)) {
@@ -723,9 +723,9 @@ int gsd_coarse_surf_map(geosurf *surf)
         y2 = ymax - (row - (step_val / 2)) * yres;
         y3 = ymax - (row + (step_val / 2)) * yres;
 
-        y1off = row * ymod * surf->cols;
-        y2off = (row - (step_val / 2)) * ymod * surf->cols;
-        y3off = (row + (step_val / 2)) * ymod * surf->cols;
+        y1off = (long)row * ymod * surf->cols;
+        y2off = (long)(row - (step_val / 2)) * ymod * surf->cols;
+        y3off = (long)(row + (step_val / 2)) * ymod * surf->cols;
 
         for (col = start_val; col <= xcnt - start_val; col += step_val) {
 


### PR DESCRIPTION
Fixes the 33 CodeQL `cpp/integer-multiplication-cast-to-long` alerts in lib/ogsf and lib/nviz.

Three patterns, following the idiom from ed986f8c06 (cast the first operand so the product is computed in the destination type):

- Row/column offset arithmetic assigned to `long` (`y1off = row * ymod * surf->cols` and friends in `gsd_surf.c`, `gsd_wire.c`, `gsd_fringe.c`, `gs_norms.c`, and the `norms` buffer size in `gs.c`): the product was computed in `int` and could overflow for very large rasters before being widened. Now computed in `long`.
- `float` products assigned to `double` (`lights.c`, `gsd_cplane.c`): computed in `double` via a cast on the first operand.
- `gsd_views.c` `gsd_surf2model()`: the multiplication result was widened to `double` only because the ternary's other branch was the double literal `0.0`, then narrowed back into a float `Point3`. Made the literals `0.0f` instead, which keeps the arithmetic in float and removes the pointless round trip.

Verification: both libraries compile cleanly, and `m.nviz.image` renders (fine-mode surface exercising `gsd_surf.c`, and wireframe exercising `gsd_wire.c`) are **bit-identical** before and after the change.

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
