### PR TITLE
libraries: Fix multiplications converted to a larger type

### DIFF
--- a/lib/cairodriver/draw_bitmap.c
+++ b/lib/cairodriver/draw_bitmap.c
@@ -38,7 +38,7 @@ void Cairo_Bitmap(int ncols, int nrows, int threshold, const unsigned char *buf)
 #define MULTIPLE 4
     stride = (ncols + (MULTIPLE - 1)) / MULTIPLE * MULTIPLE;
 #endif
-    data = malloc(stride * nrows);
+    data = malloc((size_t)stride * nrows);
     surf = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_A8, ncols,
                                                nrows, stride);
 

--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -390,7 +390,8 @@ static int ends_with(const char *string, const char *suffix)
 static void map_file(void)
 {
 #ifndef _WIN32
-    size_t size = HEADER_SIZE + ca.width * ca.height * sizeof(unsigned int);
+    size_t size =
+        HEADER_SIZE + (size_t)ca.width * ca.height * sizeof(unsigned int);
     void *ptr;
     int fd;
 

--- a/lib/external/ccmath/hmgen.c
+++ b/lib/external/ccmath/hmgen.c
@@ -17,7 +17,7 @@ void hmgen(Cpx *h, double *ev, Cpx *u, int n)
 
     double e;
 
-    v = (Cpx *)calloc(n * n, sizeof(Cpx));
+    v = (Cpx *)calloc((size_t)n * n, sizeof(Cpx));
     cmcpy(v, u, n * n);
     hconj(v, n);
     for (i = 0, p = v; i < n; ++i) {

--- a/lib/external/ccmath/unitary.c
+++ b/lib/external/ccmath/unitary.c
@@ -24,7 +24,7 @@ void unitary(Cpx *u, int n)
     double *g, *q, a;
 
     m = n * n;
-    g = (double *)calloc(n * n, sizeof(double));
+    g = (double *)calloc((size_t)n * n, sizeof(double));
     v = (Cpx *)calloc(m + n, sizeof(Cpx));
     e = v + m;
     h.re = 1.;

--- a/lib/gmath/del2g.c
+++ b/lib/gmath/del2g.c
@@ -46,8 +46,8 @@ int del2g(double *img[2], int size, double w)
     G_message(_("    taking FFT of image..."));
     fft(FORWARD, img, size * size, size, size);
 
-    g[0] = (double *)G_malloc(size * size * sizeof(double));
-    g[1] = (double *)G_malloc(size * size * sizeof(double));
+    g[0] = (double *)G_malloc((size_t)size * size * sizeof(double));
+    g[1] = (double *)G_malloc((size_t)size * size * sizeof(double));
 
     G_message(_("    computing del**2 g..."));
     getg(w, g, size);

--- a/lib/gmath/getg.c
+++ b/lib/gmath/getg.c
@@ -17,7 +17,7 @@ int getg(double w, double *g[2], int size)
     long i, j, totsize, n, g_row;
     float rsq, sigma, two_ssq, val, sum = 0.0;
 
-    totsize = size * size;
+    totsize = (long)size * size;
     n = size / 2;
     for (i = 0; i < totsize; i++) {
         *(g[0] + i) = 0.0;

--- a/lib/linkm/new.c
+++ b/lib/linkm/new.c
@@ -32,8 +32,8 @@ VOID_T *link_new(struct link_head *Head)
 
         /*DEBUG fprintf (stderr, "Mallocing another chunk: %d\n",
          * Head->max_ptr); */
-        if (NULL ==
-            (tmp = (VOID_T *)malloc(Head->chunk_size * Head->unit_size))) {
+        if (NULL == (tmp = (VOID_T *)malloc((size_t)Head->chunk_size *
+                                            Head->unit_size))) {
             if (Head->exit_flag)
                 link_out_of_memory();
             return NULL;

--- a/lib/pngdriver/graph_close.c
+++ b/lib/pngdriver/graph_close.c
@@ -27,7 +27,8 @@
 
 static void unmap_file(void)
 {
-    size_t size = HEADER_SIZE + png.width * png.height * sizeof(unsigned int);
+    size_t size =
+        HEADER_SIZE + (size_t)png.width * png.height * sizeof(unsigned int);
     void *ptr = (char *)png.grid - HEADER_SIZE;
 
     if (!png.mapped)

--- a/lib/pngdriver/graph_set.c
+++ b/lib/pngdriver/graph_set.c
@@ -33,7 +33,8 @@ struct png_state png;
 
 static void map_file(void)
 {
-    size_t size = HEADER_SIZE + png.width * png.height * sizeof(unsigned int);
+    size_t size =
+        HEADER_SIZE + (size_t)png.width * png.height * sizeof(unsigned int);
     void *ptr;
     int fd;
 
@@ -158,7 +159,8 @@ int PNG_Graph_set(void)
         map_file();
 
     if (!png.mapped)
-        png.grid = G_malloc(png.width * png.height * sizeof(unsigned int));
+        png.grid =
+            G_malloc((size_t)png.width * png.height * sizeof(unsigned int));
 
     if (!do_read) {
         PNG_Erase();

--- a/lib/raster/get_row.c
+++ b/lib/raster/get_row.c
@@ -90,7 +90,7 @@ static void read_data_fp_compressed(int fd, int row, unsigned char *data_buf,
     off_t t1 = fcb->row_ptr[row];
     off_t t2 = fcb->row_ptr[row + 1];
     size_t readamount = t2 - t1;
-    size_t bufsize = fcb->cellhd.cols * fcb->nbytes;
+    size_t bufsize = (size_t)fcb->cellhd.cols * fcb->nbytes;
     int ret;
 
     if (lseek(fcb->data_fd, t1, SEEK_SET) == -1)
@@ -188,7 +188,7 @@ static void read_data_uncompressed(int fd, int row, unsigned char *data_buf,
                                    int *nbytes)
 {
     struct fileinfo *fcb = &R__.fileinfo[fd];
-    ssize_t bufsize = fcb->cellhd.cols * fcb->nbytes;
+    ssize_t bufsize = (ssize_t)fcb->cellhd.cols * fcb->nbytes;
 
     *nbytes = fcb->nbytes;
 

--- a/lib/raster/put_row.c
+++ b/lib/raster/put_row.c
@@ -115,7 +115,7 @@ void Rast_put_d_row(int fd, const DCELL *buf)
 static void write_data(int fd, int row, unsigned char *buf, int n)
 {
     struct fileinfo *fcb = &R__.fileinfo[fd];
-    ssize_t nwrite = fcb->nbytes * n;
+    ssize_t nwrite = (ssize_t)fcb->nbytes * n;
 
     if (write(fcb->data_fd, buf, nwrite) != nwrite)
         G_fatal_error(
@@ -411,7 +411,7 @@ static void put_data(int fd, char *null_buf, const CELL *cell, int row, int n,
         G_free(compressed_buf);
     }
     else {
-        nwrite = fcb->nbytes * n;
+        nwrite = (ssize_t)fcb->nbytes * n;
 
         if (write(fcb->data_fd, work_buf, nwrite) != nwrite)
             G_fatal_error(

--- a/lib/raster3d/cache.c
+++ b/lib/raster3d/cache.c
@@ -75,7 +75,7 @@ static int cacheWrite_readFun(int tileIndex, void *tileBuf, void *closure)
 
     pos = -pos - 2; /* pos is shifted by 2 to avoid 0 and -1 */
 
-    nBytes = map->tileSize * map->numLengthIntern;
+    nBytes = (size_t)map->tileSize * map->numLengthIntern;
     offs = pos * (nBytes + sizeof(int));
 
     /* seek tile and read it into buffer */
@@ -149,7 +149,7 @@ static int cacheWrite_writeFun(int tileIndex, const void *tileBuf,
         return 1;
 
     map->cachePosLast++;
-    nBytes = map->tileSize * map->numLengthIntern;
+    nBytes = (size_t)map->tileSize * map->numLengthIntern;
     offs = map->cachePosLast * (nBytes + sizeof(int));
 
     if (lseek(map->cacheFD, offs, SEEK_SET) == -1) {
@@ -299,7 +299,7 @@ int Rast3d_flush_all_tiles(RASTER3D_Map *map)
 
     /* first flush all the tiles which are in the file cache */
 
-    nBytes = map->tileSize * map->numLengthIntern;
+    nBytes = (size_t)map->tileSize * map->numLengthIntern;
 
     while (map->cachePosLast >= 0) {
         offs = map->cachePosLast * (nBytes + sizeof(int)) + nBytes;

--- a/lib/raster3d/misc.c
+++ b/lib/raster3d/misc.c
@@ -67,7 +67,7 @@ void Rast3d_copy_values(const void *src, int offsSrc, int typeSrc, void *dst,
     src = G_incr_void_ptr(src, eltLength * offsSrc);
     dst = G_incr_void_ptr(dst, eltLength * offsDst);
 
-    memcpy(dst, src, nElts * eltLength);
+    memcpy(dst, src, (size_t)nElts * eltLength);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/lib/raster3d/tilewrite.c
+++ b/lib/raster3d/tilewrite.c
@@ -73,8 +73,8 @@ static int Rast3d_tile2xdrTile(RASTER3D_Map *map, const void *tile, int rows,
 
 static int Rast3d_writeTileUncompressed(RASTER3D_Map *map, int nofNum)
 {
-    if (write(map->data_fd, xdr, map->numLengthExtern * nofNum) !=
-        map->numLengthExtern * nofNum) {
+    if (write(map->data_fd, xdr, (size_t)map->numLengthExtern * nofNum) !=
+        (ssize_t)map->numLengthExtern * nofNum) {
         Rast3d_error("Rast3d_writeTileUncompressed: can't write file.");
         return 0;
     }

--- a/lib/raster3d/volume.c
+++ b/lib/raster3d/volume.c
@@ -202,7 +202,8 @@ void Rast3d_make_aligned_volume_file(void *map, const char *fileName,
     int x, y, z, eltLength;
     RASTER3D_Region region;
 
-    volumeBuf = Rast3d_malloc(nx * ny * nz * sizeof(Rast3d_get_file_type()));
+    volumeBuf =
+        Rast3d_malloc((size_t)nx * ny * nz * sizeof(Rast3d_get_file_type()));
     if (volumeBuf == NULL)
         Rast3d_fatal_error(
             "Rast3d_make_aligned_volume_file: error in Rast3d_malloc");

--- a/lib/segment/address.c
+++ b/lib/segment/address.c
@@ -85,7 +85,7 @@ int seg_address_slow(const SEGMENT *SEG, off_t row, off_t col, int *n,
     /* for simple arrays */
     else {
         *n = col / SEG->scols;
-        *index = col - *n * SEG->scols;
+        *index = col - (off_t)*n * SEG->scols;
     }
     *index *= SEG->len;
 

--- a/lib/vector/diglib/allocation.c
+++ b/lib/vector/diglib/allocation.c
@@ -151,7 +151,7 @@ void *dig__frealloc(void *oldptr, int nelem, int elsize, int oldnelem)
         register char *b;
         register size_t n;
 
-        n = oldnelem * elsize;
+        n = (size_t)oldnelem * elsize;
         a = ptr;
         b = oldptr;
         while (n--)


### PR DESCRIPTION
Fixes 24 CodeQL `cpp/integer-multiplication-cast-to-long` alerts across the C libraries (all remaining library alerts for this rule outside lib/ogsf and lib/nviz, which are in #7704).

All are the same pattern: an `int * int` product assigned to (or compared with) a wider type (`size_t`, `ssize_t`, `long`, `off_t`), so the multiplication could overflow before widening for very large dimensions. The fix casts the first operand so the product is computed in the destination type, following the idiom from ed986f8c06. Touched: png/cairo driver buffer sizes, gmath filter kernels (`del2g.c`, `getg.c`), the two ccmath `calloc` calls, linkm chunk allocation, raster row buffers (`get_row.c`, `put_row.c`), raster3d tile/cache/volume sizes, segment addressing, and diglib reallocation.

Verification: all nine libraries compile cleanly; runtime smoke tests exercise the touched paths (r.mapcalc + r.univar round trip for raster row I/O, r3.mapcalc + r3.univar for raster3d tile I/O, d.rast renders through both the png and cairo drivers, and the earlier v.unpack testsuite run covers diglib).

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
