### PR TITLE
temporal: handle TGIS DB connections for half initialized mapsets

### DIFF
--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -118,7 +118,7 @@ def profile_function(func) -> None:
 tgis_backend = None
 
 
-def get_tgis_backend():
+def get_tgis_backend() -> str | None:
     """Return the temporal GIS backend as string
 
     :returns: either "sqlite" or "pg"
@@ -132,7 +132,7 @@ def get_tgis_backend():
 tgis_database = None
 
 
-def get_tgis_database():
+def get_tgis_database() -> str | None:
     """Return the temporal database string specified with t.connect"""
     global tgis_database
     return tgis_database
@@ -152,7 +152,7 @@ tgis_db_version = 3
 tgis_dbmi_paramstyle = None
 
 
-def get_tgis_dbmi_paramstyle():
+def get_tgis_dbmi_paramstyle() -> str:
     """Return the temporal database backend parameter style
 
     :returns: "qmark" or ""
@@ -170,7 +170,7 @@ current_gisdbase = None
 ###############################################################################
 
 
-def get_current_mapset():
+def get_current_mapset() -> str:
     """Return the current mapset
 
     This is the fastest way to receive the current mapset.
@@ -184,7 +184,7 @@ def get_current_mapset():
 ###############################################################################
 
 
-def get_current_location():
+def get_current_location() -> str:
     """Return the current location
 
     This is the fastest way to receive the current location.
@@ -198,7 +198,7 @@ def get_current_location():
 ###############################################################################
 
 
-def get_current_gisdbase():
+def get_current_gisdbase() -> str:
     """Return the current gis database (gisdbase)
 
     This is the fastest way to receive the current gisdbase.
@@ -461,7 +461,7 @@ def get_tgis_metadata(dbif=None):
 tgis_database_string = None
 
 
-def get_tgis_database_string():
+def get_tgis_database_string() -> str | None:
     """Return the preprocessed temporal database string
 
     This string is the temporal database string set with t.connect
@@ -475,10 +475,8 @@ def get_tgis_database_string():
 ###############################################################################
 
 
-def get_sql_template_path():
-    base = os.getenv("GISBASE")
-    base_etc = os.path.join(base, "etc")
-    return os.path.join(base_etc, "sql")
+def get_sql_template_path() -> str:
+    return str(Path(os.getenv("GISBASE"), "etc", "sql"))
 
 
 ###############################################################################
@@ -499,7 +497,7 @@ def stop_subprocesses() -> None:
 atexit.register(stop_subprocesses)
 
 
-def get_available_temporal_mapsets(mapsets: str | None = None):
+def get_available_temporal_mapsets(mapsets: str | None = None) -> dict:
     """Return a list of of mapset names with temporal database driver and names.
 
     :param mapsets: A string specifying target mapsets ('.' for current, '*'
@@ -528,17 +526,8 @@ def get_available_temporal_mapsets(mapsets: str | None = None):
         )
         if driver and database:
             # Check if the temporal sqlite database exists
-            # We need to set non-existing databases in case the mapset is the current
-            # mapset
-            # to create it
-            if (
-                driver == "sqlite" and Path(database).exists()
-            ) or mapset == get_current_mapset():
-                tgis_mapsets[mapset] = (driver, database)
-
-            # We need to warn if the connection is defined but the database does not
-            # exists
             if driver == "sqlite" and not Path(database).exists():
+                # Warn if DB for defined connection does not exists
                 message_interface.warning(
                     _(
                         "Temporal database connection for mapset <%s> "
@@ -546,7 +535,9 @@ def get_available_temporal_mapsets(mapsets: str | None = None):
                     )
                     % (mapset, database)
                 )
-                del tgis_mapsets[mapset]
+                continue
+            tgis_mapsets[mapset] = (driver, database)
+
     return tgis_mapsets
 
 
@@ -876,8 +867,12 @@ def init(
                     ).format(m=message)
                 )
         return
-
-    create_temporal_database(dbif)
+    # dbif may not contain connection info for the current mapset
+    # so we use a dedicated DB connection for the current mapset
+    # to greate the temporal database
+    create_temporal_database(
+        DBConnection(backend=tgis_backend, dbstring=tgis_database_string)
+    )
 
 
 ###############################################################################
@@ -953,19 +948,18 @@ def create_temporal_database(dbif) -> None:
 
     if tgis_backend == "sqlite":
         # We need to create the sqlite3 database path if it does not exist
-        tgis_dir = os.path.dirname(tgis_database_string)
-        if not Path(tgis_dir).exists():
-            try:
-                Path(tgis_dir).mkdir(parents=True)
-            except Exception as e:
-                msgr.fatal(
-                    _(
-                        "Unable to create SQLite temporal database\n"
-                        "Exception: %s\nPlease use t.connect to set a "
-                        "read- and writable temporal database path"
-                    )
-                    % (e)
+        tgis_dir = Path(tgis_database_string).parent
+        try:
+            tgis_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            msgr.fatal(
+                _(
+                    "Unable to create SQLite temporal database\n"
+                    "Exception: %s\nPlease use t.connect to set a "
+                    "read- and writable temporal database path"
                 )
+                % (e)
+            )
 
         # Set up the trigger that takes care of
         # the correct deletion of entries across the different tables
@@ -1120,10 +1114,10 @@ class SQLDatabaseInterfaceConnection:
 
         self.unique_connections = {}
 
-        for mapset in self.tgis_mapsets.keys():
+        for mapset in self.tgis_mapsets:
             driver, dbstring = self.tgis_mapsets[mapset]
 
-            if dbstring not in self.unique_connections.keys():
+            if dbstring not in self.unique_connections:
                 self.unique_connections[dbstring] = DBConnection(
                     backend=driver, dbstring=dbstring
                 )
@@ -1154,7 +1148,7 @@ class SQLDatabaseInterfaceConnection:
 
         Supported backends are sqlite3 and postgresql
         """
-        for mapset in self.tgis_mapsets.keys():
+        for mapset in self.tgis_mapsets:
             driver, dbstring = self.tgis_mapsets[mapset]
             conn = self.connections[mapset]
             if conn.is_connected() is False:
@@ -1171,7 +1165,7 @@ class SQLDatabaseInterfaceConnection:
         There may be several temporal databases in a location, hence
         close all temporal databases that have been opened.
         """
-        for key in self.unique_connections.keys():
+        for key in self.unique_connections:
             self.unique_connections[key].close()
 
         self.connected = False
@@ -1191,7 +1185,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _(
                     "Unable to mogrify sql statement. "
@@ -1218,7 +1212,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _("Unable to check table. " + self._create_mapset_error_message(mapset))
             )
@@ -1236,7 +1230,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _(
                     "Unable to execute sql statement. "
@@ -1251,7 +1245,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _("Unable to fetch one. " + self._create_mapset_error_message(mapset))
             )
@@ -1263,7 +1257,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _("Unable to fetch all. " + self._create_mapset_error_message(mapset))
             )

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -540,10 +540,13 @@ def get_available_temporal_mapsets(mapsets: str | None = None):
             # exists
             if driver == "sqlite" and not Path(database).exists():
                 message_interface.warning(
-                    "Temporal database connection defined as:\n"
-                    + database
-                    + "\nBut database file does not exist."
+                    _(
+                        "Temporal database connection for mapset <%s> "
+                        "defined as:\n %s\nBut database file does not exist."
+                    )
+                    % (mapset, database)
                 )
+                del tgis_mapsets[mapset]
     return tgis_mapsets
 
 

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -527,7 +527,7 @@ def get_available_temporal_mapsets(mapsets: str | None = None) -> dict:
         if driver and database:
             # Check if the temporal sqlite database exists
             if driver == "sqlite" and not Path(database).exists():
-                # Warn if DB for defined connection does not exists
+                # Warn if DB for defined connection does not exist
                 message_interface.warning(
                     _(
                         "Temporal database connection for mapset <%s> "

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -152,7 +152,7 @@ tgis_db_version = 3
 tgis_dbmi_paramstyle = None
 
 
-def get_tgis_dbmi_paramstyle() -> str:
+def get_tgis_dbmi_paramstyle() -> str | None:
     """Return the temporal database backend parameter style
 
     :returns: "qmark" or ""
@@ -170,7 +170,7 @@ current_gisdbase = None
 ###############################################################################
 
 
-def get_current_mapset() -> str:
+def get_current_mapset() -> str | None:
     """Return the current mapset
 
     This is the fastest way to receive the current mapset.
@@ -184,7 +184,7 @@ def get_current_mapset() -> str:
 ###############################################################################
 
 
-def get_current_location() -> str:
+def get_current_location() -> str | None:
     """Return the current location
 
     This is the fastest way to receive the current location.
@@ -198,7 +198,7 @@ def get_current_location() -> str:
 ###############################################################################
 
 
-def get_current_gisdbase() -> str:
+def get_current_gisdbase() -> str | None:
     """Return the current gis database (gisdbase)
 
     This is the fastest way to receive the current gisdbase.
@@ -779,6 +779,7 @@ def init(
         )
         if dbif.fetchone()[0]:
             db_exists = True
+        dbif.close()
 
     if tgis_db_version > 2:
         backup_howto = _(
@@ -869,7 +870,7 @@ def init(
         return
     # dbif may not contain connection info for the current mapset
     # so we use a dedicated DB connection for the current mapset
-    # to greate the temporal database
+    # to create the temporal database
     create_temporal_database(
         DBConnection(backend=tgis_backend, dbstring=tgis_database_string)
     )
@@ -1091,7 +1092,7 @@ def _create_tgis_metadata_table(content, dbif=None) -> None:
     statement = "CREATE TABLE tgis_metadata (key VARCHAR NOT NULL, value VARCHAR);\n"
     dbif.execute_transaction(statement)
 
-    for key in content.keys():
+    for key in content:
         statement = (
             "INSERT INTO tgis_metadata (key, value) VALUES "
             + "('%s' , '%s');\n" % (str(key), str(content[key]))
@@ -1276,7 +1277,7 @@ class SQLDatabaseInterfaceConnection:
             mapset = self.current_mapset
 
         mapset = decode(mapset)
-        if mapset not in self.tgis_mapsets.keys():
+        if mapset not in self.tgis_mapsets:
             self.msgr.fatal(
                 _(
                     "Unable to execute transaction. "

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -527,8 +527,8 @@ def get_available_temporal_mapsets(mapsets: str | None = None) -> dict:
         if driver and database:
             # Check if the temporal sqlite database exists
             if driver == "sqlite" and not Path(database).exists():
-                # Warn if DB for defined connection does not exist
-                message_interface.warning(
+                # Inform if DB for defined connection does not exist
+                message_interface.verbose(
                     _(
                         "Temporal database connection for mapset <%s> "
                         "defined as:\n %s\nBut database file does not exist."
@@ -694,7 +694,7 @@ def init(
     msgr.debug(1, "Initiate the temporal database")
     # We must run t.connect at first to create the temporal database and to
     # get the environmental variables
-    gs.run_command("t.connect", flags="c")
+    gs.run_command("t.connect", flags="c", superquiet=True)
 
     driver_string = ciface.get_driver_name(current_mapset)
     database_string = ciface.get_database_name(current_mapset)
@@ -732,7 +732,7 @@ def init(
             )
     else:
         # Set the default sqlite3 connection in case nothing was defined
-        gs.run_command("t.connect", flags="d")
+        gs.run_command("t.connect", flags="d", superquiet=True)
         current_mapset = decode(gs.gisenv().get("MAPSET"))
         driver_string = ciface.get_driver_name(current_mapset)
         database_string = ciface.get_database_name(current_mapset)
@@ -945,7 +945,7 @@ def create_temporal_database(dbif) -> None:
     stvds_tables_sql = stds_tables_template_sql.replace("STDS", "stvds")
     str3ds_tables_sql = stds_tables_template_sql.replace("STDS", "str3ds")
 
-    msgr.message(_("Creating temporal database: %s") % (str(tgis_database_string)))
+    msgr.verbose(_("Creating temporal database: %s") % (str(tgis_database_string)))
 
     if tgis_backend == "sqlite":
         # We need to create the sqlite3 database path if it does not exist

--- a/python/grass/temporal/tests/grass_temporal_core_init_skip_db_test.py
+++ b/python/grass/temporal/tests/grass_temporal_core_init_skip_db_test.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 import sqlite3
 
-from grass.grassdb.create import create_mapset
 import grass.script as gs
 import grass.temporal as tgis
+from grass.grassdb.create import create_mapset
+from grass.tools import Tools
 
 ds_types_dict = {
     "strds": ("strds"),
@@ -149,3 +150,37 @@ def test_stds_construction_with_tgis_db_initialization(
             assert stds.get_id() == ident
             assert stds.get_type() in valid_ds_types
             assert stds.is_in_db(dbif) is False
+
+
+def test_tools_work_in_half_initialized_mapset(simple_mapset):
+    """Check that tools still work in a half-initialized mapset."""
+
+    with gs.setup.init(simple_mapset) as session:
+        tools = Tools(session=session)
+        tools.t_connect(flags="d")
+        tgis_db_dir = simple_mapset / "tgis"
+        assert not tgis_db_dir.exists()
+        tools.t_list(type="strds")
+        tools.t_create(
+            output="test",
+            type="strds",
+            temporaltype="absolute",
+            title="test",
+            description="test",
+        )
+        assert tgis_db_dir.exists()
+        assert (tgis_db_dir / "sqlite.db").exists()
+        list_result = tools.t_list(type="strds", format="json").json
+        reference = {
+            "id": "test@c",
+            "temporal_type": "absolute",
+            "title": "test",
+            "description": "test",
+            "number_of_maps": None,
+            "start_time": None,
+            "end_time": None,
+            "mapset": "c",
+        }
+        for k, v in reference.items():
+            assert k in list_result[0]
+            assert v == list_result[0][k]

--- a/temporal/t.connect/t.connect.html
+++ b/temporal/t.connect/t.connect.html
@@ -1,8 +1,11 @@
 <h2>DESCRIPTION</h2>
 
-<em>t.connect</em> allows the user to set the temporal database connection.
-The default setting is that the temporal database of
-type <em>sqlite3</em> is located in the current mapset directory.
+<em>t.connect</em> allows the user to set or print the temporal database connection.
+<p>
+The default setting is that the temporal database uses the <em>sqlite</em> backend,
+where the path to the SQLite database is set to "tgis/sqlite.db" in the current
+mapset directory. That way it will not interfere with the <em>sqlite</em> database
+used for vector attribute storage.
 
 <p>The <b>-p</b> flag will display the current temporal database connection parameters.
 <p>The <b>-pg</b> flag will display the current temporal database connection parameters
@@ -10,18 +13,17 @@ using shell style.
 <p>The <b>-c</b> flag will silently check if the temporal database connection
 parameters have been set, and if not will set them to use GRASS's
 default values.
+<p>The <b>-d</b> flag will set the default TGIS connection parameters.
 
 <h2>NOTES</h2>
 
-Setting the connection with <em>t.connect</em> will not test the connection for validity.
-Hence a database connection will not be established.
-<p>
-The connection values are stored in the mapset's <code>VAR</code> file.
-The <b>-d</b> flag will set the default
-TGIS connection parameters.
-A SQLite database "tgis/sqlite.db" will be created in the current mapset directory.
-It will be located in the "tgis" sub-directory to not
-interfere with the <em>sqlite3</em> database used for vector attribute storage.
+Setting the connection with <em>t.connect</em> will only store connection values
+in the mapset's `VAR` file. It will not test the connection for validity.
+Hence a database connection will not be established. Neither will
+<em>t.connect</em> create the temporal database. The temporal database will
+be created by the first run of a tool that creates SpaceTimeDataSets (STDS),
+either based on connection values set by <em>t.connect</em> or - if not defined -
+the global default (sqlite).
 <p>
 In case you have tens of thousands of maps to register in the
 temporal database or you need concurrent read and write access in the

--- a/temporal/t.connect/t.connect.md
+++ b/temporal/t.connect/t.connect.md
@@ -4,7 +4,7 @@
 
 The default setting is that the temporal database uses the *sqlite* backend,
 where the path to the SQLite database is set to "tgis/sqlite.db" in the current
-mapset directory. That way it will not interfere with the *sqlite* database
+mapset directory. In that way it will not interfere with the *sqlite* database
 used for vector attribute storage.
 
 The **-p** flag will display the current temporal database connection
@@ -36,9 +36,7 @@ Setting the connection with *t.connect* will only store connection values
 in the mapset's `VAR` file. It will not test the connection for validity.
 Hence a database connection will not be established. Neither will
 *t.connect* create the temporal database. The temporal database will
-be created by the first run of a tool that creates SpaceTimeDataSets (STDS),
-either based on connection values set by *t.connect* or - if not defined -
-the global default (sqlite).
+be created by the first run of a tool that creates SpaceTimeDataSets (STDS).
 
 In case you have tens of thousands of maps to register in the temporal
 database or you need concurrent read and write access in the temporal

--- a/temporal/t.connect/t.connect.md
+++ b/temporal/t.connect/t.connect.md
@@ -1,8 +1,11 @@
 ## DESCRIPTION
 
-*t.connect* allows the user to set the temporal database connection. The
-default setting is that the temporal database of type *sqlite3* is
-located in the current mapset directory.
+*t.connect* allows the user to set or print the temporal database connection.
+
+The default setting is that the temporal database uses the *sqlite* backend,
+where the path to the SQLite database is set to "tgis/sqlite.db" in the current
+mapset directory. That way it will not interfere with the *sqlite* database
+used for vector attribute storage.
 
 The **-p** flag will display the current temporal database connection
 parameters. Use the **format** option to specify the output format: `plain`,
@@ -25,16 +28,17 @@ The **-c** flag will silently check if the temporal database connection
 parameters have been set, and if not will set them to use GRASS's
 default values.
 
+The **-d** flag will set the default TGIS connection parameters.
+
 ## NOTES
 
-Setting the connection with *t.connect* will not test the connection for
-validity. Hence a database connection will not be established.
-
-The connection values are stored in the mapset's `VAR` file. The **-d**
-flag will set the default TGIS connection parameters. A SQLite database
-"tgis/sqlite.db" will be created in the current mapset directory. It
-will be located in the "tgis" sub-directory to not interfere with the
-*sqlite3* database used for vector attribute storage.
+Setting the connection with *t.connect* will only store connection values
+in the mapset's `VAR` file. It will not test the connection for validity.
+Hence a database connection will not be established. Neither will
+*t.connect* create the temporal database. The temporal database will
+be created by the first run of a tool that creates SpaceTimeDataSets (STDS),
+either based on connection values set by *t.connect* or - if not defined -
+the global default (sqlite).
 
 In case you have tens of thousands of maps to register in the temporal
 database or you need concurrent read and write access in the temporal

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -153,7 +153,7 @@ def main():
                 ).format(num_columns=len(columns_list))
             )
 
-    elif not separator:  # output_format == "plain"
+    elif not separator:
         separator = "|"
 
     # Lazy import and initialize TGIS


### PR DESCRIPTION
Users may have run **t.connect** in a mapset (esp. in their current mapset), so the connection information is written to the VAR file, but the tgis DB is not created. The recent changes to _tgis.init()_ did not account for that possibility and DB creation failed.
So, the following failed with unexpected error messages:

```bash
t.connect -d
t.list type=strds
t.create output=test type=strds temporaltype=absolute title=test description=test
```

With this PR the above should be good again and also the related test (_tests/grass_temporal_core_init_skip_db_test.py_) passes.