### PR TITLE
libraries: Avoid check-then-use races on file operations

### DIFF
--- a/display/d.mon/start.c
+++ b/display/d.mon/start.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -72,14 +73,13 @@ char *start(const char *name, const char *output, int width, int height,
                           output_name);
         G_free(dir_name);
 
-        /* check if file exists */
-        if (!update && access(output_name, F_OK) == 0) {
-            if (G_get_overwrite()) {
+        /* delete existing file if overwrite is enabled */
+        if (!update && G_get_overwrite()) {
+            if (unlink(output_name) == 0)
                 G_warning(_("File <%s> already exists and will be overwritten"),
                           output_name);
-                if (0 != unlink(output_name))
-                    G_fatal_error(_("Unable to delete <%s>"), output_name);
-            }
+            else if (errno != ENOENT)
+                G_fatal_error(_("Unable to delete <%s>"), output_name);
         }
     }
 

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -176,11 +176,12 @@ static int write_file(LOGIN *login)
         return -1;
     }
 
-    /* fchmod is not available on Windows */
-    /* fchmod ( fileno(fd), S_IRUSR | S_IWUSR ); */
 #ifndef _MSC_VER
-    /* tighten permissions of a pre-existing file */
-    chmod(file, S_IRUSR | S_IWUSR);
+    /* Tighten permissions of a pre-existing file (a newly created one already
+     * has them from open() above). Operate on the descriptor rather than the
+     * path to avoid a time-of-check/time-of-use race. fchmod is not available
+     * on Windows, where the file is created with fopen() above. */
+    fchmod(fdes, S_IRUSR | S_IWUSR);
 #endif
     for (i = 0; i < login->n; i++) {
         fprintf(fd, "%s|%s", login->data[i].driver, login->data[i].database);

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -12,6 +12,7 @@
    \author Joel Jones (CERL/UIUC), Radim Blazek
  */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -154,12 +155,22 @@ static int write_file(LOGIN *login)
     int i;
     const char *file;
     FILE *fd;
+#ifndef _MSC_VER
+    int fdes;
+#endif
 
     file = login_filename();
 
     G_debug(3, "write_file(): DB login file = <%s>", file);
 
+#ifdef _MSC_VER
     fd = fopen(file, "w");
+#else
+    /* open with owner-only permissions from the start, so the file never
+     * exists with wider permissions */
+    fdes = open(file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    fd = fdes < 0 ? NULL : fdopen(fdes, "w");
+#endif
     if (fd == NULL) {
         G_warning(_("Unable to write file '%s'"), file);
         return -1;
@@ -168,6 +179,7 @@ static int write_file(LOGIN *login)
     /* fchmod is not available on Windows */
     /* fchmod ( fileno(fd), S_IRUSR | S_IWUSR ); */
 #ifndef _MSC_VER
+    /* tighten permissions of a pre-existing file */
     chmod(file, S_IRUSR | S_IWUSR);
 #endif
     for (i = 0; i < login->n; i++) {

--- a/lib/gis/get_projinfo.c
+++ b/lib/gis/get_projinfo.c
@@ -132,18 +132,18 @@ char *G_get_projwkt(void)
     int c;
 
     G_file_name(path, "", WKT_FILE, "PERMANENT");
-    if (access(path, 0) != 0) {
-        if (G_projection() != PROJECTION_XY) {
-            G_debug(1, "<%s> file not found for location <%s>", WKT_FILE,
-                    G_location());
-        }
-        return NULL;
-    }
-
     fp = fopen(path, "r");
-    if (!fp)
+    if (!fp) {
+        if (errno == ENOENT) {
+            if (G_projection() != PROJECTION_XY) {
+                G_debug(1, "<%s> file not found for location <%s>", WKT_FILE,
+                        G_location());
+            }
+            return NULL;
+        }
         G_fatal_error(_("Unable to open input file <%s>: %s"), path,
                       strerror(errno));
+    }
 
     wktstring = G_malloc(1024 * sizeof(char));
     nalloc = 1024;
@@ -241,7 +241,11 @@ char *G_get_projsrid(void)
     int c;
 
     G_file_name(path, "", SRID_FILE, "PERMANENT");
-    if (access(path, 0) != 0) {
+    fp = fopen(path, "r");
+    if (!fp) {
+        if (errno != ENOENT)
+            G_fatal_error(_("Unable to open input file <%s>: %s"), path,
+                          strerror(errno));
         if (G_projection() != PROJECTION_XY) {
             struct Key_Value *projepsg;
             const char *epsg_num;
@@ -264,11 +268,6 @@ char *G_get_projsrid(void)
         }
         return NULL;
     }
-
-    fp = fopen(path, "r");
-    if (!fp)
-        G_fatal_error(_("Unable to open input file <%s>: %s"), path,
-                      strerror(errno));
 
     sridstring = G_malloc(1024 * sizeof(char));
     nalloc = 1024;

--- a/lib/gis/mkstemp.c
+++ b/lib/gis/mkstemp.c
@@ -63,11 +63,12 @@ static int G__mkstemp(char *template, int flags, int mode)
         if (!next(replace, num_replace))
             return -1;
 
-        if (access(template, F_OK) == 0)
-            continue;
-
-        if (!flags)
+        if (!flags) {
+            /* caller only wants a name, so a check is all we can do */
+            if (access(template, F_OK) == 0)
+                continue;
             return 0;
+        }
 
         fd = open(template, flags, mode);
         if (fd < 0) {

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -540,21 +540,17 @@ int Vect__open_old(struct Map_info *Map, const char *name, const char *mapset,
         char file_path[GPATH_MAX];
 
         Vect__get_element_path(file_path, Map, GV_TOPO_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* topo file exists? */
-            unlink(file_path);
+        unlink(file_path); /* delete topo file if it exists */
 
         Vect__get_element_path(file_path, Map, GV_SIDX_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* sidx file exists? */
-            unlink(file_path);
+        unlink(file_path); /* delete sidx file if it exists */
 
         Vect__get_element_path(file_path, Map, GV_CIDX_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* cidx file exists? */
-            unlink(file_path);
+        unlink(file_path); /* delete cidx file if it exists */
 
         if (format == GV_FORMAT_OGR || format == GV_FORMAT_POSTGIS) {
             Vect__get_element_path(file_path, Map, GV_FIDX_ELEMENT);
-            if (access(file_path, F_OK) == 0) /* fidx file exists? */
-                unlink(file_path);
+            unlink(file_path); /* delete fidx file if it exists */
         }
         Map->support_updated = TRUE;
     }

--- a/lib/vector/Vlib/open_nat.c
+++ b/lib/vector/Vlib/open_nat.c
@@ -121,12 +121,10 @@ int V1_open_new_nat(struct Map_info *Map, const char *name, int with_z)
     if (Map->dig_fp.file == NULL)
         return -1;
 
-    /* if overwrite OK, any existing files have already been deleted by
-     * Vect_open_new(): remove this check ? */
-    /* check to see if dig_plus file exists and if so, remove it */
+    /* remove topo file if it exists (if overwrite is set, any existing
+     * files have already been deleted by Vect_open_new()) */
     Vect__get_element_path(path, Map, GV_TOPO_ELEMENT);
-    if (access(path, F_OK) == 0)
-        unlink(path); /* remove topo file if exists */
+    unlink(path);
 
     /* set conversion matrices */
     dig_init_portable(&(Map->head.port), dig__byte_order_out());

--- a/raster/r.li/r.li.daemon/daemon.c
+++ b/raster/r.li/r.li.daemon/daemon.c
@@ -207,15 +207,17 @@ int parseSetup(char *path, struct list *l, struct g_area *g, char *raster)
     int sa_x, sa_y, sa_rl, sa_cl;
     int size;
 
-    if (stat(path, &s) != 0)
+    setup = open(path, O_RDONLY, 0755);
+    if (setup == -1)
         G_fatal_error(_("Cannot find configuration file <%s>"), path);
+
+    if (fstat(setup, &s) != 0) {
+        close(setup);
+        G_fatal_error(_("Cannot read setup file"));
+    }
 
     size = s.st_size * sizeof(char);
     buf = G_malloc(size);
-
-    setup = open(path, O_RDONLY, 0755);
-    if (setup == -1)
-        G_fatal_error(_("Cannot read setup file"));
 
     letti = read(setup, buf, s.st_size);
     if (letti < s.st_size) {


### PR DESCRIPTION
Addresses 11 of the 14 CodeQL `cpp/toctou-race-condition` alerts. These are check-then-use patterns on per-user mapset and config files, so none is a privilege boundary; the changes are correctness/robustness cleanups that also make the code simpler:

- **lib/vector** (`Vlib/open.c`, `open_nat.c`): `access()` before `unlink()` of topo/sidx/cidx/fidx support files. `unlink()` on a missing file is harmless, so the precheck is gone (a code comment in `open_nat.c` already asked "remove this check?").
- **lib/gis** (`get_projinfo.c`): `access()` before `fopen()` in `G_get_projwkt()`/`G_get_projsrid()`. Now `fopen()` runs first and `ENOENT` takes the old "not found" path (including the PROJ_EPSG fallback); other errors stay fatal. Verified in both a projected project (WKT returned) and an XY project (returns NULL, no error).
- **lib/gis** (`mkstemp.c`): the `access()` existence probe is now only used for the name-only `G_mktemp()` variant (which is inherently just a probe, as its docs note); the creating variants rely solely on the existing `O_CREAT|O_EXCL` + `EEXIST` handling.
- **display/d.mon** (`start.c`): delete an existing output file based on `unlink()` errno instead of `access()` first; behavior (warning with `--overwrite`, fatal when undeletable) is unchanged.
- **raster/r.li** (`daemon.c`): open the configuration file first, then size the read buffer with `fstat()` on the open descriptor instead of `stat()` by path.
- **lib/db** (`login.c`): the dblogin file is now created with owner-only (0600) permissions atomically via `open(O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR)` + `fdopen()` instead of `fopen()` followed by `chmod()`, so it never exists with wider permissions. The `chmod()` remains to tighten a pre-existing file. Verified: `db.login` produces a `-rw-------` file with correct content. (MSVC keeps plain `fopen()`, matching the existing `#ifndef _MSC_VER` treatment of `chmod`.)

The remaining 3 alerts (`lib/init/clean_temp.c`) are left as is: the `stat()` result there decides file-vs-directory handling for the user's own tmp entries, the return values are already checked, and restructuring would not remove the race meaningfully. I propose dismissing those with justification.

Verification: all five directories compile; runtime checks exercised each path (v.random + v.build topo rebuild, `g.proj -w` in projected and XY projects, `d.mon start` over an existing file with `--overwrite`, `r.li.patchdensity` with a conf file, `db.login`).

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
