### PR TITLE
r.sunmask, d.linegraph: Compute trig products in double

### DIFF
--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -191,8 +191,8 @@ int main(int argc, char **argv)
     float max_y;
     float min_y;
     float height, width;
-    float xscale;
-    float yscale;
+    double xscale;
+    double yscale;
 
     char txt[1024];
     char tic_name[1024];

--- a/raster/r.sunmask/solpos00.c
+++ b/raster/r.sunmask/solpos00.c
@@ -106,11 +106,11 @@
  *++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 struct trigdata /* used to pass calculated values locally */
 {
-    float cd; /* cosine of the declination */
-    float ch; /* cosine of the hour angle */
-    float cl; /* cosine of the latitude */
-    float sd; /* sine of the declination */
-    float sl; /* sine of the latitude */
+    double cd; /* cosine of the declination */
+    double ch; /* cosine of the hour angle */
+    double cl; /* cosine of the latitude */
+    double sd; /* sine of the declination */
+    double sl; /* sine of the latitude */
 };
 
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -126,8 +126,8 @@ static int month_days[2][13] = {
 
 /* TODO: the "degrad" - "raddeg" variable names are flipped - typo or severe
  * bug?? */
-static float degrad = 57.295779513; /* converts from radians to degrees */
-static float raddeg = 0.0174532925; /* converts from degrees to radians */
+static double degrad = 57.295779513; /* converts from radians to degrees */
+static double raddeg = 0.0174532925; /* converts from degrees to radians */
 
 /*============================================================================
 *    Local function prototypes


### PR DESCRIPTION
Fixes the final 37 CodeQL `cpp/integer-multiplication-cast-to-long` alerts, the two clusters that are float-precision rather than integer-overflow (r.sunmask: 29, d.linegraph: 8). Together with #7704, #7705, #7706, and #7708 this closes out the entire 154-alert rule.

Unlike the sibling PRs, these are `float * float` products widened to `double`, so I fixed the root cause by widening the types rather than casting per site:

- **r.sunmask** (`solpos00.c`, borrowed NREL SOLPOS code): `degrad`/`raddeg` and the five `struct trigdata` sine/cosine fields were `float`, so `raddeg * angle` and `cl * cd` were computed in float and only then widened to `double` for the trig calls. Widening these to `double` computes the products in double and lets the two conversion constants (`57.295779513`, `0.0174532925`) keep their full declared precision instead of being truncated to float.
- **d.linegraph** (`main.c`): `xscale` and `yscale` are computed as `double` (from `(double)` casts) and were then stored into `float`, losing precision before every plot coordinate multiplication. Widening them to `double` clears the alerts and removes the narrowing.

**Output impact, verified on nc_spm:**
- r.sunmask shadow raster is **bit-identical** before and after (0 changed cells at three different sun angles, including low-angle winter mornings with thousands of shadow cells). Only the `-s` reported solar position changes, by about 1e-5 degrees, reflecting the now-full-precision constants.
- d.linegraph PNG render is **bit-identical** (same md5).

Because this touches borrowed SOLPOS code and nominally changes a printed value, I kept it separate from the mechanical integer-cast PRs so it can be reviewed on its own.

This is part of a larger effort to work through the open code scanning alerts, grouped into small PRs by issue type.

Written with the assistance of Claude Code.
