### PR TITLE
CMake: Fix stale staging of headers, modules list, and temporal SQL in build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,10 +263,13 @@ if(MSVC)
   include_directories("${CMAKE_SOURCE_DIR}/msvc")
 endif()
 
+set(modules_list
+    ""
+    CACHE INTERNAL "list of modules")
+
 add_subdirectory(lib)
 add_subdirectory(python)
 add_subdirectory(utils)
-set(modules_list)
 
 set(ALL_SUBDIRS
     db

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -111,6 +111,7 @@ foreach(srch ${SRCHS})
     OUTPUT ${output_dir}/${srch_NAME}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${output_dir}
     COMMAND ${CMAKE_COMMAND} -E copy ${srch} ${output_dir}
+    DEPENDS ${srch}
     COMMENT "Copy ${srch} to ${output_dir}/${srch_NAME}")
   list(APPEND include_depends ${output_dir}/${srch_NAME})
 endforeach()

--- a/lib/temporal/CMakeLists.txt
+++ b/lib/temporal/CMakeLists.txt
@@ -10,3 +10,10 @@ build_library_in_subdir(
   grass_gis
   grass_dbmibase
   grass_datetime)
+
+add_custom_command(
+  TARGET grass_temporal
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/sql
+  COMMAND ${CMAKE_COMMAND} -E copy ${SQLFILES}
+          ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/sql)


### PR DESCRIPTION
These were identified problems by AI during unrelated work, below is the AI explanation. Probably not high priority, but could be useful. 



This PR fixes three CMake staging defects that leave the runnable tree under `build/output` stale or incomplete, typically after editing headers or switching branches. Each showed up as confusing failures unrelated to
the change under test.

**What changed:**

- Staged headers now refresh. The copy command in `include/CMakeLists.txt`  had no `DEPENDS`, so once a header was staged it was never re-copied.  Editing a header (e.g. `include/grass/gis.h`) caused compilation against  the stale copy and `GIS_H_VERSION` mismatch fatal errors at runtime.

- Stale modules no longer linger in `ALL_MODULES`. Modules append  themselves to `modules_list` as `CACHE INTERNAL`, but the top-level  `set(modules_list)` only cleared the normal variable, so the cached list  accumulated across configures. After switching to a branch where a  module no longer exists, builds failed with "No rule to make target".  The cache entry is now reset at the start of each configure, before any  module registers, which keeps the previous membership (including the  helper programs from `lib/` and `utils/`) while dropping stale entries.

- Temporal SQL templates are staged. `lib/temporal/SQL/*.sql` were  install-only, so temporal database creation failed when running from  `build/output` before `cmake --install`. They are now copied next to the  library, following the `lib/gis` etc-file staging pattern. As with that  pattern, the copy runs when the library relinks, not when only a `.sql`  file changes.

**Verification:**

- Touching `gis.h` and building `INCLUDE_HEADERS` re-runs the copy.
- A bogus module name injected into the cached `modules_list` disappears  on reconfigure, and the pre-existing helper program entries are kept.
- After deleting the staged `etc/sql`, rebuilding `grass_temporal` stages  all 30 `.sql` files (and only those, not the Makefile in the same  directory).

**AI disclosure:** implemented and verified by Claude (Fable).