### PR TITLE
grass.pygrass: Pin fork start method for RPC servers on Python 3.14

### DIFF
--- a/python/grass/pygrass/rpc/__init__.py
+++ b/python/grass/pygrass/rpc/__init__.py
@@ -12,7 +12,6 @@ for details.
 
 import sys
 from ctypes import CFUNCTYPE, c_void_p
-from multiprocessing import Lock, Pipe, Process
 
 import grass.lib.gis as libgis
 from grass.exceptions import FatalError
@@ -22,7 +21,7 @@ from grass.pygrass.raster import RasterRow, raster2numpy_img
 from grass.pygrass.vector import VectorTopo
 from grass.pygrass.vector.basic import Bbox
 
-from .base import RPCServerBase
+from .base import MP_CONTEXT, RPCServerBase
 
 ###############################################################################
 ###############################################################################
@@ -249,9 +248,9 @@ class DataProvider(RPCServerBase):
 
     def start_server(self):
         """This function must be re-implemented in the subclasses"""
-        self.client_conn, self.server_conn = Pipe(True)
-        self.lock = Lock()
-        self.server = Process(
+        self.client_conn, self.server_conn = MP_CONTEXT.Pipe(True)
+        self.lock = MP_CONTEXT.Lock()
+        self.server = MP_CONTEXT.Process(
             target=data_provider_server, args=(self.lock, self.server_conn)
         )
         self.server.daemon = True

--- a/python/grass/pygrass/rpc/base.py
+++ b/python/grass/pygrass/rpc/base.py
@@ -16,7 +16,7 @@ import logging
 import sys
 import threading
 import time
-from multiprocessing import Lock, Pipe, Process
+import multiprocessing as mp
 from typing import TYPE_CHECKING, NoReturn
 
 from grass.exceptions import FatalError
@@ -27,6 +27,17 @@ if TYPE_CHECKING:
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Python 3.14 changed the default multiprocessing start method from "fork" to
+# "forkserver" on all platforms except macOS. The RPC worker process relies on
+# "fork" semantics: subclasses run libgis via ctypes in the worker, which must
+# inherit the initialized library state and the GRASS session environment from
+# the parent. Pin "fork" where it used to be the default; macOS and Windows
+# keep their default start method ("spawn").
+if sys.platform != "darwin" and "fork" in mp.get_all_start_methods():
+    MP_CONTEXT = mp.get_context("fork")
+else:
+    MP_CONTEXT = mp.get_context()
 
 
 ###############################################################################
@@ -142,9 +153,11 @@ class RPCServerBase:
         """This function must be re-implemented in the subclasses"""
         logger.debug("Start the libgis server")
 
-        self.client_conn, self.server_conn = Pipe(True)
-        self.lock = Lock()
-        self.server = Process(target=dummy_server, args=(self.lock, self.server_conn))
+        self.client_conn, self.server_conn = MP_CONTEXT.Pipe(True)
+        self.lock = MP_CONTEXT.Lock()
+        self.server = MP_CONTEXT.Process(
+            target=dummy_server, args=(self.lock, self.server_conn)
+        )
         self.server.daemon = True
         self.server.start()
 

--- a/python/grass/pygrass/rpc/base.py
+++ b/python/grass/pygrass/rpc/base.py
@@ -28,12 +28,12 @@ if TYPE_CHECKING:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# Python 3.14 changed the default multiprocessing start method from "fork" to
-# "forkserver" on all platforms except macOS. The RPC worker process relies on
-# "fork" semantics: subclasses run libgis via ctypes in the worker, which must
-# inherit the initialized library state and the GRASS session environment from
-# the parent. Pin "fork" where it used to be the default; macOS and Windows
-# keep their default start method ("spawn").
+# Python 3.14 changed the default multiprocessing start method from "fork"
+# to "forkserver" (on platforms where "fork" is available, except macOS),
+# which breaks the RPC server processes. Use "fork" wherever it is available,
+# i.e. the default before 3.14, except on macOS, which has defaulted to
+# "spawn" since Python 3.8 and where "fork" is unsafe. Everywhere else
+# (Windows) keep the platform default.
 if sys.platform != "darwin" and "fork" in mp.get_all_start_methods():
     MP_CONTEXT = mp.get_context("fork")
 else:

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -16,7 +16,6 @@ import logging
 import sys
 from ctypes import CFUNCTYPE, POINTER, byref, c_int, c_void_p, cast
 from datetime import datetime
-from multiprocessing import Lock, Pipe, Process
 from typing import TYPE_CHECKING, Any, Literal
 
 import grass.lib.date as libdate
@@ -27,7 +26,7 @@ import grass.lib.temporal as libtgis
 import grass.lib.vector as libvector
 from grass.exceptions import FatalError
 from grass.pygrass.raster import RasterRow
-from grass.pygrass.rpc.base import RPCServerBase
+from grass.pygrass.rpc.base import MP_CONTEXT, RPCServerBase
 from grass.pygrass.utils import decode
 from grass.pygrass.vector import VectorTopo
 from grass.script.utils import encode
@@ -1471,9 +1470,9 @@ class CLibrariesInterface(RPCServerBase):
         RPCServerBase.__init__(self)
 
     def start_server(self) -> None:
-        self.client_conn, self.server_conn = Pipe(True)
-        self.lock = Lock()
-        self.server = Process(
+        self.client_conn, self.server_conn = MP_CONTEXT.Pipe(True)
+        self.lock = MP_CONTEXT.Lock()
+        self.server = MP_CONTEXT.Process(
             target=c_library_server, args=(self.lock, self.server_conn)
         )
         self.server.daemon = True


### PR DESCRIPTION
## Problem

Running temporal tools under Python 3.14 fails, e.g. `t.list strds`:
```
    Exception in thread Thread-1 (thread_checker):
    ...
    File ".../grass/temporal/c_libraries_interface.py", line 1480, in start_server
        self.server.start()
    ...
    File ".../multiprocessing/forkserver.py", line 94, in connect_to_new_process
        client.connect(self._forkserver_address)
    FileNotFoundError: [Errno 2] No such file or directory
    resource_tracker: There appear to be 1 leaked semaphore objects to clean up
```
Reported by @veroandreo  (WSL, Python 3.14).

## Cause

Python 3.14 changed the default `multiprocessing` start method from `fork` to `forkserver` on every platform except macOS
([python/cpython#84559](https://github.com/python/cpython/issues/84559)).

GRASS's RPC servers were relying on the implicit `fork` default. Their worker processes run `libgis` through ctypes and depend on `fork` semantics: they inherit the already-initialized C library state and the live GRASS session environment (GISRC, etc.) from the parent. Under `forkserver`, the worker is forked from an early, clean forkserver process that never had the GRASS runtime set up, and the forkserver control socket gets torn down as the session exits — producing the `FileNotFoundError` in the checker thread and the leaked-semaphore warning.

## Fix
*This targeted fix pins fork to restore prior behavior*. A longer-term move to spawn is worth evaluating separately...

Pin `fork` in one shared place and reuse it. The `start_server` pattern is duplicated across three implementations that all share `RPCServerBase`:

- `python/grass/pygrass/rpc/base.py` — add a module-level `MP_CONTEXT` that  selects `fork` where it was the previous default, and use it in  `start_server`.
- `python/grass/pygrass/rpc/__init__.py` (`DataProvider`) and  `python/grass/temporal/c_libraries_interface.py` (`CLibrariesInterface`) —  import `MP_CONTEXT` and use it in their overridden `start_server`.

```python
if sys.platform != "darwin" and "fork" in mp.get_all_start_methods():
    MP_CONTEXT = mp.get_context("fork")
else:
    MP_CONTEXT = mp.get_context()
```
macOS was already on spawn (since 3.8) and Windows has no fork, so the change is a deliberate no-op on those platforms and on Python <= 3.13, where fork was already the default.

## Testing

Tested with @veroandreo and locally on linux with Python 3.12,  worked fine.