### PR TITLE
db.univar: fix Python error when input table not existing

### DIFF
--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -59,8 +59,6 @@ def db_describe(table, env=None, **args):
         s = read_command("db.describe", flags="c", table=table, env=env, **args)
     except CalledModuleError:
         fatal(_("Unable to describe table <%s>") % table, env=env)
-    if not s:
-        fatal(_("Unable to describe table <%s>") % table, env=env)
 
     cols = []
     result = {}

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -55,7 +55,10 @@ def db_describe(table, env=None, **args):
         args.pop("database")
     if "driver" in args and args["driver"] == "":
         args.pop("driver")
-    s = read_command("db.describe", flags="c", table=table, env=env, **args)
+    try:
+        s = read_command("db.describe", flags="c", table=table, env=env, **args)
+    except CalledModuleError:
+        fatal(_("Unable to describe table <%s>") % table, env=env)
     if not s:
         fatal(_("Unable to describe table <%s>") % table, env=env)
 


### PR DESCRIPTION
This PR fixes a Python error when the input table is not existing:

```sh
db.univar bla column=value
WARNING: Table <bla> not found in database
         <$GISDBASE/$LOCATION_NAME/$MAPSET/sqlite/sqlite.db> using driver
         <sqlite>
ERROR: Unable to describe table <bla>
```

Fixes #3760