### PR TITLE
grass.temporal: Use an explicit env in the gui_support test session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,7 @@ global `os.environ`, and `init()` prepends the GRASS executable paths to
 `PATH` on every call without removing them again, so `PATH` keeps growing for
 the rest of the pytest process. Tests are not isolated from each other:
 pytest runs them in one process, and a later test which copies `os.environ`
-inherits whatever earlier tests left there. On Windows this has broken
-unrelated tools which look up a tool on `PATH` in a subprocess.
+inherits whatever earlier tests left there.
 
 Some APIs, notably `grass.temporal`, still read the session from
 `os.environ` and cannot take an `env`. When a test needs one of those, create

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,23 @@ pass `env=session.env` explicitly. gunittest-style tests (`testsuite/`) run
 in an existing GRASS session and need neither `Tools` setup nor `env`
 passing.
 
+Always create sessions with `gs.setup.init(project, env=os.environ.copy())`,
+never `gs.setup.init(project)`. Without `env`, the session is set up in the
+global `os.environ`, and `init()` prepends the GRASS executable paths to
+`PATH` on every call without removing them again, so `PATH` keeps growing for
+the rest of the pytest process. Tests are not isolated from each other:
+pytest runs them in one process, and a later test which copies `os.environ`
+inherits whatever earlier tests left there. On Windows this has broken
+unrelated tools which look up a tool on `PATH` in a subprocess.
+
+Some APIs, notably `grass.temporal`, still read the session from
+`os.environ` and cannot take an `env`. When a test needs one of those, create
+the session with `env=os.environ.copy()` and mirror it into `os.environ`
+using the `monkeypatch` fixture (or `pytest.MonkeyPatch.context()` in a
+fixture which is not function-scoped), so the environment is restored
+afterwards. See `python/grass/temporal/tests/grass_temporal_gui_support_test.py`
+for this pattern.
+
 With `grass.tools`, numpy arrays can be passed as raster inputs (the array
 is written to a temporary raster matching the computation region) and
 requested as outputs using the `parameter=np.array` pattern (e.g.,

--- a/python/grass/temporal/tests/grass_temporal_gui_support_test.py
+++ b/python/grass/temporal/tests/grass_temporal_gui_support_test.py
@@ -39,7 +39,7 @@ def session_with_stds(tmp_path_factory):
     create_mapset(project / "second")
     create_mapset(project / "plain")
 
-    with gs.setup.init(project / "second") as session:
+    with gs.setup.init(project / "second", env=os.environ.copy()) as session:
         tools = Tools(session=session)
         tools.g_region(n=3, s=0, e=3, w=0, res=1)
         tools.r_mapcalc(expression="other_map = 1")
@@ -47,7 +47,19 @@ def session_with_stds(tmp_path_factory):
         tools.t_create(output="other", type="strds", title="other", description="other")
         tools.t_register(input="other", maps="other_map", start="2020-01-01")
 
-    with gs.setup.init(project) as session:
+    # tgis reads the session from os.environ, so the session has to be
+    # visible there. Mirror it via monkeypatch rather than letting init()
+    # modify the global environment directly, so the environment is restored
+    # for the tests which run after this module. Once tgis accepts env, the
+    # session can be passed explicitly and the mirroring can go away.
+    with (
+        pytest.MonkeyPatch.context() as monkeypatch,
+        gs.setup.init(project, env=os.environ.copy()) as session,
+    ):
+        for key, value in session.env.items():
+            if os.environ.get(key) != value:
+                monkeypatch.setenv(key, value)
+
         tools = Tools(session=session)
         tools.g_region(n=3, s=0, e=3, w=0, res=1)
         for expression in ("a_map = 1", "b_map = 1", "rel_a = 1", "rel_b = 1"):


### PR DESCRIPTION
The temporal tests needs separate environment like all the other tests, but env can't be explicitly passes as for the rest of the API, so this uses pytest's monkeypatch to work around that. 

<details>

## Problem

The fixture added in #7714 creates its sessions with `gs.setup.init(...)` without `env`, which sets the session up in the global `os.environ`. `init()` calls `setup_runtime_env()` unconditionally, which prepends the GRASS executable paths to `PATH` and never removes them again, so every such call grows `PATH` permanently for the rest of the pytest process (measured: +404 characters per call). pytest runs everything in one process, so later tests which copy `os.environ` inherit it.

## Fix

Create the sessions with `env=os.environ.copy()`. `tgis` reads the session from `os.environ` and cannot take an `env`, so the second session is mirrored there with `monkeypatch`, which restores the environment when the module finishes. `test_project_without_temporal_database` in the same file already does this, so this only makes the fixture consistent with it.

`AGENTS.md` gets the rule and the `tgis` exception documented in its *Writing Tests* section.

## What it broke

*r.coin* has been failing in the OSGeo4W (Windows) CI on `main` since #7714 was merged, with nothing in *r.coin* changed. It is not flaky: every run whose base contains c7fc4ea573ef fails, every run without it passes (20 runs checked). *r.coin* runs *r.stats* in a subprocess rather than computing the table itself, and on the inherited `PATH` `cmd.exe` could no longer resolve it:

```
'r.stats' is not recognized as an internal or external command,
```

so *r.coin* printed an empty table and the test saw `[(0, 1, 0), (0, 2, 0), (0, 3, 0)]`. It is the only tested tool which runs another tool, which is why it alone is affected.

## Follow-ups, not in this PR

- The ultimate fix is for `grass.temporal` to accept `env`; the mirroring here could then go away.
- `gs.setup.init()` re-prepending to `PATH` on every call is worth fixing on its own, since it is what turns one env-less `init()` into a process-wide leak. 18 other env-less call sites remain.

## Verification

Fixture before/after in an identical harness: `PATH` growth goes **+444 to +0**. The mirroring pattern was verified against a local build: `tgis.init()` and `tlist_grouped()` still work through the mirrored environment and `os.environ` is restored. The Windows threshold at which `cmd.exe` stops resolving *r.stats* was not reproduced locally (no Windows machine, and `PATH` is not printed in CI logs); CI on this PR is the check for that.

The investigation and the patch were done with the assistance of Claude Code.

</details>