### PR TITLE
temporal: add _readonly property to STDS and prohibit writing metadata for _readonly

### DIFF
--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -167,6 +167,10 @@ class AbstractMapDataset(AbstractDataset):
         """
         return self.base.get_map_id()
 
+    def get_readonly(self) -> bool:
+        """Return True if this map is read-only (belongs to a foreign mapset)"""
+        return self.base.get_readonly()
+
     @staticmethod
     def split_name(name: str, layer=None, mapset=None):
         """Convenient method to split a map name into three potentially
@@ -358,7 +362,7 @@ class AbstractMapDataset(AbstractDataset):
         :return: The SQL insert statement in case execute=False, or an
                  empty string otherwise
         """
-        if get_enable_timestamp_write():
+        if get_enable_timestamp_write() and not self.get_readonly():
             self.write_timestamp_to_grass()
         return AbstractDataset.insert(self, dbif=dbif, execute=execute)
 
@@ -377,7 +381,7 @@ class AbstractMapDataset(AbstractDataset):
         :return: The SQL insert statement in case execute=False, or an
                  empty string otherwise
         """
-        if get_enable_timestamp_write():
+        if get_enable_timestamp_write() and not self.get_readonly():
             self.write_timestamp_to_grass()
         return AbstractDataset.update(self, dbif, execute)
 
@@ -397,7 +401,7 @@ class AbstractMapDataset(AbstractDataset):
                  empty string otherwise
 
         """
-        if get_enable_timestamp_write():
+        if get_enable_timestamp_write() and not self.get_readonly():
             self.write_timestamp_to_grass()
         return AbstractDataset.update_all(self, dbif, execute)
 
@@ -536,7 +540,7 @@ class AbstractMapDataset(AbstractDataset):
             if connection_state_changed:
                 dbif.close()
 
-            if get_enable_timestamp_write():
+            if get_enable_timestamp_write() and not self.get_readonly():
                 self.write_timestamp_to_grass()
 
     def set_relative_time(self, start_time, end_time, unit) -> bool:
@@ -657,7 +661,7 @@ class AbstractMapDataset(AbstractDataset):
             if connection_state_changed:
                 dbif.close()
 
-            if get_enable_timestamp_write():
+            if get_enable_timestamp_write() and not self.get_readonly():
                 self.write_timestamp_to_grass()
 
     def set_temporal_extent(self, extent) -> None:

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -633,12 +633,12 @@ class DatasetBase(SQLDatabaseInterface):
     def __init__(
         self,
         table=None,
-        ident=None,
+        ident: str | None = None,
         name: str | None = None,
-        mapset=None,
-        creator=None,
-        ctime=None,
-        ttype=None,
+        mapset: str | None = None,
+        creator: str | None = None,
+        ctime: datetime | None = None,
+        ttype: str | None = None,
     ) -> None:
         """Constructor
 
@@ -662,15 +662,17 @@ class DatasetBase(SQLDatabaseInterface):
 
         self.set_id(ident)
         if ident is not None and name is None and mapset is None:
-            if ident.find("@") >= 0:
-                name, mapset = ident.split("@")
-            if name.find(":") >= 0:
-                name, layer = ident.split(":")
+            if "@" in ident:
+                name, mapset = ident.split("@", 1)
+            if ":" in name:
+                name, layer = ident.split(":", 1)
         self.set_name(name)
         self.set_mapset(mapset)
         self.set_creator(creator)
         self.set_ctime(ctime)
         self.set_ttype(ttype)
+        self._readonly = False
+        self.set_readonly()
 
     def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)
@@ -684,14 +686,14 @@ class DatasetBase(SQLDatabaseInterface):
         name = ""
 
         if ident is not None:
-            if ident.find("@") >= 0:
-                name, mapset = ident.split("@")
+            if "@" in ident:
+                name, mapset = ident.split("@", 1)
                 self.set_mapset(mapset)
                 self.set_name(name)
             else:
                 self.msgr.fatal(_("Wrong identifier, the mapset is missing"))
-            if name.find(":") >= 0:
-                name, layer = ident.split(":")
+            if ":" in name:
+                name, layer = name.split(":", 1)
                 self.set_layer(layer)
             self.set_name(name)
 
@@ -747,16 +749,14 @@ class DatasetBase(SQLDatabaseInterface):
         else:
             self.D["temporal_type"] = ttype
 
-    def get_id(self):
+    def get_id(self) -> str | None:
         """Convenient method to get the unique identifier (primary key)
 
         :return: None if not found
         """
-        if "id" in self.D:
-            return self.D["id"]
-        return None
+        return self.D.get("id")
 
-    def get_map_id(self):
+    def get_map_id(self) -> str | None:
         """Convenient method to get the unique map identifier
         without layer information
 
@@ -764,67 +764,65 @@ class DatasetBase(SQLDatabaseInterface):
                or None in case the id was not set
         """
         if self.id:
-            if self.id.find(":") >= 0:
+            if ":" in self.id:
                 # Remove the layer identifier from the id
-                return self.id.split("@")[0].split(":")[0] + "@" + self.id.split("@")[1]
+                return f"{self.id.split('@')[0].split(':')[0]}@{self.id.split('@')[1]}"
             return self.id
         return None
 
-    def get_layer(self):
+    def get_layer(self) -> str | None:
         """Convenient method to get the layer of the map (part of primary key)
 
         Layer are currently supported for vector maps
 
         :return: None if not found
         """
-        if "layer" in self.D:
-            return self.D["layer"]
-        return None
+        return self.D.get("layer")
 
-    def get_name(self):
+    def get_name(self) -> str | None:
         """Get the name of the dataset
 
         :return: None if not found
         """
-        if "name" in self.D:
-            return self.D["name"]
-        return None
+        return self.D.get("name")
 
-    def get_mapset(self):
+    def get_mapset(self) -> str | None:
         """Get the name of mapset of this dataset
 
         :return: None if not found
         """
-        if "mapset" in self.D:
-            return self.D["mapset"]
-        return None
+        return self.D.get("mapset")
 
-    def get_creator(self):
+    def get_creator(self) -> str | None:
         """Get the creator of the dataset
 
         :return: None if not found
         """
-        if "creator" in self.D:
-            return self.D["creator"]
-        return None
+        return self.D.get("creator")
 
-    def get_ctime(self):
+    def get_ctime(self) -> datetime | None:
         """Get the creation time of the dataset, datatype is datetime
 
         :return: None if not found
         """
-        if "creation_time" in self.D:
-            return self.D["creation_time"]
-        return None
+        return self.D.get("creation_time")
 
-    def get_ttype(self):
+    def get_ttype(self) -> str | None:
         """Get the temporal type of the map
 
         :return: None if not found
         """
-        if "temporal_type" in self.D:
-            return self.D["temporal_type"]
-        return None
+        return self.D.get("temporal_type")
+
+    def set_readonly(self) -> None:
+        """Set the readonly flag for this object"""
+        self._readonly = bool(
+            self.get_mapset() and self.get_mapset() != get_current_mapset()
+        )
+
+    def get_readonly(self) -> bool:
+        """Get the readonly flag for this object"""
+        return self._readonly
 
     # Properties of this class
     id = property(fget=get_id, fset=set_id)
@@ -834,6 +832,7 @@ class DatasetBase(SQLDatabaseInterface):
     ctime = property(fget=get_ctime, fset=set_ctime)
     ttype = property(fget=get_ttype, fset=set_ttype)
     creator = property(fget=get_creator, fset=set_creator)
+    readonly = property(fget=get_readonly)
 
     def print_info(self) -> None:
         """Print information about this class in human readable style"""
@@ -1032,9 +1031,7 @@ class STDSBase(DatasetBase):
 
         :return: None if not found
         """
-        if "semantic_type" in self.D:
-            return self.D["semantic_type"]
-        return None
+        return self.D.get("semantic_type")
 
     def get_mtime(self):
         """Get the modification time of the space time dataset, datatype is
@@ -1042,9 +1039,7 @@ class STDSBase(DatasetBase):
 
         :return: None if not found
         """
-        if "modification_time" in self.D:
-            return self.D["modification_time"]
-        return None
+        return self.D.get("modification_time")
 
     semantic_type = property(fget=get_semantic_type, fset=set_semantic_type)
 
@@ -1204,9 +1199,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
 
         :return: None if not found
         """
-        if "id" in self.D:
-            return self.D["id"]
-        return None
+        return self.D.get("id")
 
     def get_registered_stds(self):
         """Get the comma separated list of space time datasets ids
@@ -1214,9 +1207,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
 
         :return: None if not found
         """
-        if "registered_stds" in self.D:
-            return self.D["registered_stds"]
-        return None
+        return self.D.get("registered_stds")
 
     # Properties of this class
     id = property(fget=get_id, fset=set_id)

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -472,7 +472,8 @@ class RasterDataset(AbstractMapDataset):
         :param str semantic_label: semantic label (eg. S2_1)
         """
         self.metadata.set_semantic_label(semantic_label)
-        self.write_semantic_label_to_grass()
+        if not self.get_readonly():
+            self.write_semantic_label_to_grass()
 
 
 ###############################################################################

--- a/python/grass/temporal/tests/grass_temporal_readonly_mapset_test.py
+++ b/python/grass/temporal/tests/grass_temporal_readonly_mapset_test.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Test that registering a map from another mapset does not
+write file-based metadata (timestamps, semantic labels) to
+the source mapset or create ghost metadata files in the current mapset.
+
+A map in a foreign mapset is read-only from the perspective of the current
+mapset, so timestamps and semantic labels must only be stored in the temporal
+database, not written back to the file-system metadata of that foreign map.
+The C-level write functions ignore the mapset argument and always write into
+the current mapset, so without the read-only guard a registration would create
+ghost cell_misc entries in PERMANENT for a map that does not exist there.
+"""
+
+import pytest
+from pathlib import Path
+
+from grass.grassdb.create import create_mapset
+import grass.script as gs
+import grass.temporal as tgis
+from grass.tools import Tools
+
+
+@pytest.fixture(scope="module")
+def cross_mapset_session(tmp_path_factory):
+    """Project with a *source* mapset and PERMANENT.
+
+    source: raster map *foreign_map* (no timestamp, no semantic label)
+    PERMANENT: raster map *local_map* registered in *test_strds*; also
+    registers *foreign_map@source* with an absolute timestamp and a
+    semantic label via a file.
+    """
+    project = tmp_path_factory.mktemp("data") / "project"
+    file_dir = tmp_path_factory.mktemp("files")
+    gs.create_project(project)
+    create_mapset(project / "source")
+
+    with gs.setup.init(project / "source"):
+        tools = Tools()
+        tools.g_region(s=0, n=1, w=0, e=1, res=1)
+        tools.r_mapcalc(expression="foreign_map = 1")
+
+    with gs.setup.init(project) as session:
+        tools = Tools(session=session)
+        tools.g_region(s=0, n=1, w=0, e=1, res=1)
+        tools.r_mapcalc(expression="local_map = 1")
+
+        tools.t_create(output="test_strds", type="strds", title="T", description="T")
+        tools.t_register(input="test_strds", maps="local_map", start="2001-01-01")
+
+        # Pipe in a timestamp and semantic label for the foreign map.
+        map_file = file_dir / "maps.txt"
+        map_file.write_text("foreign_map@source|2010-06-01|S2_1\n")
+        tools.t_register(input="test_strds", file=map_file)
+
+        yield session
+
+
+def test_local_map_gets_file_timestamp(cross_mapset_session):
+    """A map in the current mapset receives a file-based timestamp."""
+    tgis.init()
+    rmap = tgis.RasterDataset("local_map@PERMANENT")
+    assert not rmap.get_readonly()
+    assert rmap.has_grass_timestamp(), (
+        "local_map should have a file-based timestamp after t.register"
+    )
+
+
+def test_foreign_map_no_file_timestamp(cross_mapset_session):
+    """A map in another mapset must not receive a file-based timestamp."""
+    tgis.init()
+    rmap = tgis.RasterDataset("foreign_map@source")
+    assert rmap.get_readonly()
+    assert not rmap.has_grass_timestamp(), (
+        "foreign_map in source mapset must not have its file-based timestamp "
+        "written when registered from PERMANENT"
+    )
+
+
+def test_foreign_map_no_file_semantic_label(cross_mapset_session):
+    """A map in another mapset must not have a semantic label written to file."""
+    tgis.init()
+    rmap = tgis.RasterDataset("foreign_map@source")
+    # read_semantic_label_from_grass returns False when no label is on disk
+    assert rmap.get_readonly()
+    assert not rmap.read_semantic_label_from_grass(), (
+        "foreign_map in source mapset must not have its semantic label "
+        "written to the file system when registered from PERMANENT"
+    )
+
+
+def test_foreign_map_has_db_timestamp(cross_mapset_session):
+    """The temporal DB entry for the foreign map has the registered time."""
+    tgis.init()
+    dbif = tgis.SQLDatabaseInterfaceConnection()
+    dbif.connect()
+    try:
+        rmap = tgis.RasterDataset("foreign_map@source")
+        rmap.select(dbif=dbif, mapset=tgis.get_current_mapset())
+        start, _ = rmap.get_absolute_time()
+    finally:
+        dbif.close()
+    assert rmap.get_readonly()
+    assert start is not None
+    assert start.year == 2010
+
+
+def test_no_ghost_timestamp_in_current_mapset(cross_mapset_session):
+    """Registering a foreign map must not create a ghost timestamp in PERMANENT.
+
+    G_write_*_timestamp ignores the mapset argument and always writes into the
+    current mapset.  Without the read-only guard this would create
+    cell_misc/foreign_map/timestamp in PERMANENT for a map that lives in source.
+    """
+    env = gs.gisenv()
+    project = Path(env["GISDBASE"]) / env["LOCATION_NAME"]
+    ghost = project / "PERMANENT" / "cell_misc" / "foreign_map" / "timestamp"
+    assert not ghost.exists(), (
+        "Registering foreign_map@source must not create a ghost timestamp "
+        "file in PERMANENT/cell_misc/foreign_map/"
+    )
+
+
+def test_no_ghost_semantic_label_in_current_mapset(cross_mapset_session):
+    """Registering a foreign map must not create a ghost semantic label in PERMANENT."""
+    env = gs.gisenv()
+    project = Path(env["GISDBASE"]) / env["LOCATION_NAME"]
+    ghost = project / "PERMANENT" / "cell_misc" / "foreign_map" / "semantic_label"
+    assert not ghost.exists(), (
+        "Registering foreign_map@source must not create a ghost semantic_label "
+        "file in PERMANENT/cell_misc/foreign_map/"
+    )


### PR DESCRIPTION
This PR makes sure the temporal framework does not write file metadata to the source mapset of map from another mapset and that it does not write "ghost" metadata for that map in the current mapset (the C-tools should write to current anyway).

The readonly property may become useful in other contexts as well (see e.g.: #2448).

Fixes: #3394
Replaces: #7211