### PR TITLE
man: Use build_manpages.py for the man page sweep in both builds

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -14,8 +14,6 @@ DOC_MD := $(wildcard $(MODULE_TOPDIR)/doc/*.md) \
 	$(wildcard $(MODULE_TOPDIR)/doc/development/*.md)
 WEB_ONLY_MD := index keywords development_intro command_line_intro \
 	$(filter-out grass_database projectionintro,$(basename $(notdir $(DOC_MD))))
-MANPAGES := $(filter-out $(patsubst %,$(MANDIR)/%.$(MANSECT),$(WEB_ONLY_MD)),\
-	$(patsubst $(MDDIR)/source/%.md,$(MANDIR)/%.$(MANSECT),$(wildcard $(MDDIR)/source/*.md)))
 
 DSTFILES := \
 	$(HTMLDIR)/grassdocs.css \
@@ -83,12 +81,12 @@ default: $(DSTFILES)
 	$(MAKE) manpages
 # $(MAKE) build-mkdocs
 
-# This must be a separate target so that evaluation of $(MANPAGES)
-# is delayed until the indices have been generated
-left := (
-right := )
+# The sweep script is shared with the CMake build, so both builds convert
+# the same set of pages. It skips pages whose man page is up to date, so
+# after the tool builds this effectively converts the index pages.
 manpages:
-	$(MAKE) $(subst $(left),\$(left),$(subst $(right),\$(right),$(MANPAGES)))
+	VERSION_NUMBER=$(GRASS_VERSION_NUMBER) $(PYTHON) ./build_manpages.py \
+		$(MDDIR)/source $(MANDIR) $(GISBASE)/utils/g.md2man.py --exclude $(WEB_ONLY_MD)
 
 .PHONY: manpages
 

--- a/man/build_manpages.py
+++ b/man/build_manpages.py
@@ -4,11 +4,11 @@
 
 """Convert Markdown pages without an up-to-date man page.
 
-Used by the CMake build after the index pages are generated. Tool pages
-already converted during the tool builds are up to date and are skipped,
-so this effectively converts the index pages, including the dynamically
-named topic_* pages. Web-only pages, which have no man page equivalent,
-are passed with --exclude.
+Used by both builds (man/Makefile and the CMake build) after the index
+pages are generated. Tool pages already converted during the tool builds
+are up to date and are skipped, so this effectively converts the index
+pages, including the dynamically named topic_* pages. Web-only pages,
+which have no man page equivalent, are passed with --exclude.
 """
 
 import argparse


### PR DESCRIPTION
Follow-up to #7674, suggested in its review.

The Autotools manpages target in man/Makefile and the CMake build_manpages target maintained the same logic twice: glob the markdown tree, skip pages with an up-to-date man page, skip web-only pages. This switches man/Makefile to the build_manpages.py script the CMake build already uses, so both builds share one sweep and one exclusion list (WEB_ONLY_MD). The make-side delayed evaluation and parenthesis-escaping workarounds disappear, since the script globs at run time.

Implemented with AI assistance (Claude Fable).