### PR TITLE
wxGUI: Read combobox thumbnails from gui/images instead of docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,28 +383,46 @@ if(WITH_DOCS)
     )
 endif()
 
+# The thumbnails in gui/images are used by the GUI at runtime (the color
+# table selection widget), so they are generated regardless of WITH_DOCS;
+# the documentation trees get their own copies.
 add_custom_target(
     r_colors_thumbnails
     ALL
     COMMAND
         ${CMAKE_COMMAND} -E make_directory
-        ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
+        ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
     COMMAND
         ${grass_env_command} ${PYTHON_EXECUTABLE} ${THUMBNAILS_PY}
-        ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
-    COMMAND
-        ${CMAKE_COMMAND} -E copy_directory
-        ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
-        ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/colortables
-    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
+        ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
+    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
     COMMENT "Creating thumbnails"
     DEPENDS ALL_MODULES
 )
 set_target_properties(r_colors_thumbnails PROPERTIES FOLDER Misc)
 install(
-    DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
-    DESTINATION ${GRASS_INSTALL_DOCDIR}
+    DIRECTORY ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
+    DESTINATION ${GRASS_INSTALL_GUIDIR}/images
 )
+if(WITH_DOCS)
+    add_custom_command(
+        TARGET r_colors_thumbnails
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_directory
+            ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
+            ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_directory
+            ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/colortables
+            ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/colortables
+        COMMENT "Copying thumbnails to the documentation trees"
+    )
+    install(
+        DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/colortables
+        DESTINATION ${GRASS_INSTALL_DOCDIR}
+    )
+endif()
 
 set(misc_files
     AUTHORS

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -51,6 +51,9 @@ if(WITH_DOCS)
 endif()
 
 build_program_in_subdir(d.barscale DEPENDS grass_symb grass_display grass_gis)
+# The thumbnails in gui/images are used by the GUI at runtime (the barscale
+# selection widget), so they are copied regardless of WITH_DOCS; the
+# documentation trees get their own copies.
 file(
     GLOB d_barscale_png
     ${CMAKE_CURRENT_SOURCE_DIR}/d.barscale/thumbnails/*.png
@@ -60,22 +63,39 @@ add_custom_command(
     POST_BUILD
     COMMAND
         ${CMAKE_COMMAND} -E make_directory
-        ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+        ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/barscales
     COMMAND
         ${CMAKE_COMMAND} -E copy ${d_barscale_png}
-        ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
-    COMMAND
-        ${CMAKE_COMMAND} -E make_directory
-        ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/barscales
-    COMMAND
-        ${CMAKE_COMMAND} -E copy ${d_barscale_png}
-        ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/barscales
-    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+        ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/barscales
+    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/barscales
 )
 install(
-    DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
-    DESTINATION ${GRASS_INSTALL_DOCDIR}
+    DIRECTORY ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/barscales
+    DESTINATION ${GRASS_INSTALL_GUIDIR}/images
 )
+if(WITH_DOCS)
+    add_custom_command(
+        TARGET d.barscale
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory
+            ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${d_barscale_png}
+            ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory
+            ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/barscales
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${d_barscale_png}
+            ${OUTDIR}/${GRASS_INSTALL_MKDOCSDIR}/source/barscales
+        BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+    )
+    install(
+        DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/barscales
+        DESTINATION ${GRASS_INSTALL_DOCDIR}
+    )
+endif()
 
 build_program_in_subdir(
     d.colorlist
@@ -141,12 +161,22 @@ build_program_in_subdir(
     d.northarrow
     DEPENDS ${LIBM} grass_display grass_gis grass_symb
 )
+# The thumbnails in gui/images are used by the GUI at runtime (the north
+# arrow selection widget), so they are copied regardless of WITH_DOCS; the
+# documentation trees get their own copies.
+file(
+    GLOB d_northarrow_png
+    ${CMAKE_CURRENT_SOURCE_DIR}/d.northarrow/thumbnails/*.png
+)
+file(
+    COPY ${d_northarrow_png}
+    DESTINATION ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/northarrows
+)
+install(
+    DIRECTORY ${OUTDIR}/${GRASS_INSTALL_GUIDIR}/images/northarrows
+    DESTINATION ${GRASS_INSTALL_GUIDIR}/images
+)
 if(WITH_DOCS)
-    file(MAKE_DIRECTORY ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/northarrows)
-    file(
-        GLOB d_northarrow_png
-        ${CMAKE_CURRENT_SOURCE_DIR}/d.northarrow/thumbnails/*.png
-    )
     file(
         COPY ${d_northarrow_png}
         DESTINATION ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/northarrows

--- a/display/d.barscale/Makefile
+++ b/display/d.barscale/Makefile
@@ -7,12 +7,15 @@ DEPENDENCIES = $(DISPLAYDEP) $(SYMBDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-# thumbnail previews
+# Thumbnail previews. The copy in $(GUIDIR)/images is used by the GUI at
+# runtime (the barscale selection widget); the documentation trees have
+# their own copies.
 IMGSRC := $(wildcard thumbnails/*.png)
 IMGDST := $(patsubst thumbnails/%,$(HTMLDIR)/barscales/%,$(IMGSRC))
 MDIMGDST := $(patsubst thumbnails/%,$(MDDIR)/source/barscales/%,$(IMGSRC))
+GUIIMGDST := $(patsubst thumbnails/%,$(GUIDIR)/images/barscales/%,$(IMGSRC))
 
-default: cmd $(IMGDST) $(MDIMGDST)
+default: cmd $(IMGDST) $(MDIMGDST) $(GUIIMGDST)
 
 $(HTMLDIR)/barscales/%.png: thumbnails/%.png | $(HTMLDIR)/barscales
 	$(INSTALL_DATA) $< $@
@@ -20,8 +23,14 @@ $(HTMLDIR)/barscales/%.png: thumbnails/%.png | $(HTMLDIR)/barscales
 $(MDDIR)/source/barscales/%.png: thumbnails/%.png | $(MDDIR)/source/barscales
 	$(INSTALL_DATA) $< $@
 
+$(GUIDIR)/images/barscales/%.png: thumbnails/%.png | $(GUIDIR)/images/barscales
+	$(INSTALL_DATA) $< $@
+
 $(HTMLDIR)/barscales: $(HTMLDIR)
 	$(MKDIR) $@
 
 $(MDDIR)/source/barscales: $(MDDIR)
+	$(MKDIR) $@
+
+$(GUIDIR)/images/barscales:
 	$(MKDIR) $@

--- a/display/d.northarrow/Makefile
+++ b/display/d.northarrow/Makefile
@@ -7,12 +7,15 @@ DEPENDENCIES = $(DISPLAYDEP) $(SYMBDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-# thumbnail previews
+# Thumbnail previews. The copy in $(GUIDIR)/images is used by the GUI at
+# runtime (the north arrow selection widget); the documentation trees have
+# their own copies.
 IMGSRC := $(wildcard thumbnails/*.png)
 IMGDST := $(patsubst thumbnails/%,$(HTMLDIR)/northarrows/%,$(IMGSRC))
 MDIMGDST := $(patsubst thumbnails/%,$(MDDIR)/source/northarrows/%,$(IMGSRC))
+GUIIMGDST := $(patsubst thumbnails/%,$(GUIDIR)/images/northarrows/%,$(IMGSRC))
 
-default: cmd $(IMGDST) $(MDIMGDST)
+default: cmd $(IMGDST) $(MDIMGDST) $(GUIIMGDST)
 
 $(HTMLDIR)/northarrows/%.png: thumbnails/%.png | $(HTMLDIR)/northarrows
 	$(INSTALL_DATA) $< $@
@@ -20,8 +23,14 @@ $(HTMLDIR)/northarrows/%.png: thumbnails/%.png | $(HTMLDIR)/northarrows
 $(MDDIR)/source/northarrows/%.png: thumbnails/%.png | $(MDDIR)/source/northarrows
 	$(INSTALL_DATA) $< $@
 
+$(GUIDIR)/images/northarrows/%.png: thumbnails/%.png | $(GUIDIR)/images/northarrows
+	$(INSTALL_DATA) $< $@
+
 $(HTMLDIR)/northarrows: $(HTMLDIR)
 	$(MKDIR) $@
 
 $(MDDIR)/source/northarrows: $(MDDIR)
+	$(MKDIR) $@
+
+$(GUIDIR)/images/northarrows:
 	$(MKDIR) $@

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1752,7 +1752,7 @@ class ColorTablesComboBox(PictureComboBox):
 
     def _getPath(self, name):
         return os.path.join(
-            os.getenv("GISBASE"), "docs", "html", "colortables", "%s.png" % name
+            os.getenv("GISBASE"), "gui", "images", "colortables", "%s.png" % name
         )
 
 
@@ -1761,7 +1761,7 @@ class BarscalesComboBox(PictureComboBox):
 
     def _getPath(self, name):
         return os.path.join(
-            os.getenv("GISBASE"), "docs", "html", "barscales", name + ".png"
+            os.getenv("GISBASE"), "gui", "images", "barscales", name + ".png"
         )
 
 
@@ -1770,7 +1770,7 @@ class NArrowsComboBox(PictureComboBox):
 
     def _getPath(self, name):
         return os.path.join(
-            os.getenv("GISBASE"), "docs", "html", "northarrows", "%s.png" % name
+            os.getenv("GISBASE"), "gui", "images", "northarrows", "%s.png" % name
         )
 
 

--- a/raster/r.colors/Makefile
+++ b/raster/r.colors/Makefile
@@ -12,16 +12,22 @@ include $(MODULE_TOPDIR)/include/Make/Multi.make
 
 default: multi thumbnails
 
-thumbnails: $(BIN)/r.mapcalc$(EXE) $(BIN)/r.colors$(EXE) $(HTMLDIR)/colortables $(MDDIR)/source/colortables
+# The copy in $(GUIDIR)/images is used by the GUI at runtime (the color
+# table selection widget); the documentation trees have their own copies.
+thumbnails: $(BIN)/r.mapcalc$(EXE) $(BIN)/r.colors$(EXE) $(HTMLDIR)/colortables $(MDDIR)/source/colortables $(GUIDIR)/images/colortables
 ifndef CROSS_COMPILING
 	$(call run_grass, $(GRASS_HOME)/utils/thumbnails.py $(MDDIR)/source/colortables)
 	$(call run_grass, $(GRASS_HOME)/utils/thumbnails.py $(HTMLDIR)/colortables)
+	$(call run_grass, $(GRASS_HOME)/utils/thumbnails.py $(GUIDIR)/images/colortables)
 endif
 
 $(HTMLDIR)/colortables: $(HTMLDIR)
 	$(MKDIR) $@
 
 $(MDDIR)/source/colortables: $(MDDIR)
+	$(MKDIR) $@
+
+$(GUIDIR)/images/colortables:
 	$(MKDIR) $@
 
 .PHONY: thumbnails


### PR DESCRIPTION
The GUI's color table, barscale, and north arrow comboboxes load their thumbnail previews from `$GISBASE/docs/html/`, a runtime dependency of the GUI on the legacy HTML documentation tree, which is being phased
out (noticed in the #7719 review discussion).

This moves the runtime copies to `$GISBASE/gui/images/`, next to the GUI's other image assets: both build systems generate them there regardless of the documentation options, and the GUI reads them from there. The documentation trees keep their own copies for the manual pages, now consistently generated only when documentation is built.


Implemented with AI assistance (Claude Fable).