### PR TITLE
contributing: Use SPDX copyright tags in more complicated file headers

### DIFF
--- a/imagery/i.albedo/main.c
+++ b/imagery/i.albedo/main.c
@@ -5,11 +5,8 @@
  * PURPOSE:      Calculate Broadband Albedo (0.3-3 Micrometers)
  *               from Surface Reflectance (Modis, AVHRR, Landsat, Aster).
  *
- * COPYRIGHT:    (C) 2004-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2004-2014 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/imagery/i.albedo/main.c
+++ b/imagery/i.albedo/main.c
@@ -5,11 +5,8 @@
  * PURPOSE:      Calculate Broadband Albedo (0.3-3 Micrometers)
  *               from Surface Reflectance (Modis, AVHRR, Landsat, Aster).
  *
- * COPYRIGHT:    (C) 2004-2014 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2004-2014 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -5,11 +5,8 @@
  * PURPOSE:      Calculate TOA Reflectance for Aster from DN.
  *               Input 9 bands (VNIR and SWIR).
  *
- * COPYRIGHT:    (C) 2002-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2002-2010 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -5,11 +5,8 @@
  * PURPOSE:      Calculate TOA Reflectance for Aster from DN.
  *               Input 9 bands (VNIR and SWIR).
  *
- * COPYRIGHT:    (C) 2002-2010 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2002-2010 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -6,11 +6,8 @@
  * PURPOSE:      Integrate in time the evapotranspiration from satellite,
  *               following a daily pattern from meteorological ETo.
  *
- * COPYRIGHT:    (C) 2008-2009, 2011 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2008-2009, 2011 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -6,11 +6,8 @@
  * PURPOSE:      Integrate in time the evapotranspiration from satellite,
  *               following a daily pattern from meteorological ETo.
  *
- * COPYRIGHT:    (C) 2008-2009, 2011 by the GRASS Development Team
- *
- *               This program is free software under the GNU Lesser General
- *               Public License. Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2008-2009, 2011 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -2,19 +2,11 @@
  *
  * MODULE:       gis library
  * AUTHOR(S):    Glynn Clements <glynn@gclements.plus.com>
- * COPYRIGHT:    (C) 2007 Glynn Clements and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2007 Glynn Clements
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * NOTE:         Based upon open.c
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
  *
  *****************************************************************************/
 

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -2,19 +2,11 @@
  *
  * MODULE:       gis library
  * AUTHOR(S):    Glynn Clements <glynn@gclements.plus.com>
- * COPYRIGHT:    (C) 2007 Glynn Clements and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2007 Glynn Clements
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * NOTE:         Based upon open.c
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
  *
  *****************************************************************************/
 

--- a/macos/build_grass_app.bash
+++ b/macos/build_grass_app.bash
@@ -5,15 +5,14 @@
 # TOOL:         build_grass_app.bash
 # AUTHOR(s):    Nicklas Larsson
 # PURPOSE:      Build and bundle GRASS app for macOS
-# COPYRIGHT:    (c) 2020-2025 Nicklas Larsson and the GRASS Development Team
-#               (c) 2020 Michael Barton
-#               (c) 2018 Eric Hutton, Community Surface Dynamics Modeling
-#                   System
+# SPDX-FileCopyrightText: 2020-2025 Nicklas Larsson
+# SPDX-FileCopyrightText: 2020 Michael Barton
+# SPDX-FileCopyrightText: 2018 Eric Hutton, Community Surface Dynamics Modeling System
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This package is written by Nicklas Larsson and is heavily based
 # on work by Eric Hutton with contributions by Michael Barton.
-#
-# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/macos/build_grass_app.bash
+++ b/macos/build_grass_app.bash
@@ -5,15 +5,14 @@
 # TOOL:         build_grass_app.bash
 # AUTHOR(s):    Nicklas Larsson
 # PURPOSE:      Build and bundle GRASS app for macOS
-# COPYRIGHT:    (c) 2020-2025 Nicklas Larsson and the GRASS Development Team
-#               (c) 2020 Michael Barton
-#               (c) 2018 Eric Hutton, Community Surface Dynamics Modeling
-#                   System
+# SPDX-FileCopyrightText: 2020-2025 Nicklas Larsson
+# SPDX-FileCopyrightText: 2020 Michael Barton
+# SPDX-FileCopyrightText: 2018 Eric Hutton, Community Surface Dynamics Modeling System
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This package is written by Nicklas Larsson and is heavily based
 # on work by Eric Hutton with contributions by Michael Barton.
-#
-# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -12,12 +12,8 @@
  *               well as several geomorphometrical parameters This technology
  *               is currently capable of "experimental" stage.
  *
- * COPYRIGHT:    (C) 2002,2012 by the GRASS Development Team
- *               (C) Scientific idea of geomorphon copyrighted to authors.
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2002,2012 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -12,12 +12,8 @@
  *               well as several geomorphometrical parameters This technology
  *               is currently capable of "experimental" stage.
  *
- * COPYRIGHT:    (C) 2002,2012 by the GRASS Development Team
- *               (C) Scientific idea of geomorphon copyrighted to authors.
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2002,2012 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/raster/r.stats.zonal/main.c
+++ b/raster/r.stats.zonal/main.c
@@ -7,12 +7,10 @@
  *
  * PURPOSE:      Category or object oriented statistics
  *
- * COPYRIGHT:    (C) 2007,2008 Martin Schroeder, Glynn Clements
- *                   and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2007,2008 Martin Schroeder
+ * SPDX-FileCopyrightText: 2007,2008 Glynn Clements
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/raster/r.stats.zonal/main.c
+++ b/raster/r.stats.zonal/main.c
@@ -7,12 +7,10 @@
  *
  * PURPOSE:      Category or object oriented statistics
  *
- * COPYRIGHT:    (C) 2007,2008 Martin Schroeder, Glynn Clements
- *                   and the GRASS Development Team
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2007,2008 Martin Schroeder
+ * SPDX-FileCopyrightText: 2007,2008 Glynn Clements
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/raster/r.texture/main.c
+++ b/raster/r.texture/main.c
@@ -9,11 +9,9 @@
  *
  * PURPOSE:      Create map raster with textural features.
  *
- * COPYRIGHT:    (C) 2003 by University of Sannio (BN), Benevento, Italy
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2003 University of Sannio (BN), Benevento, Italy
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation for any purpose and without fee is hereby granted. This

--- a/raster/r.texture/main.c
+++ b/raster/r.texture/main.c
@@ -9,11 +9,9 @@
  *
  * PURPOSE:      Create map raster with textural features.
  *
- * COPYRIGHT:    (C) 2003 by University of Sannio (BN), Benevento, Italy
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 2003 University of Sannio (BN), Benevento, Italy
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation for any purpose and without fee is hereby granted. This

--- a/scripts/i.band.library/i.band.library.py
+++ b/scripts/i.band.library/i.band.library.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:      Prints available semantic label information used for multispectral data.
 #
-# COPYRIGHT:    (C) 2019 by mundialis GmbH & Co.KG, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2019 mundialis GmbH & Co.KG
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/i.band.library/i.band.library.py
+++ b/scripts/i.band.library/i.band.library.py
@@ -7,11 +7,9 @@
 #
 # PURPOSE:      Prints available semantic label information used for multispectral data.
 #
-# COPYRIGHT:    (C) 2019 by mundialis GmbH & Co.KG, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2019 mundialis GmbH & Co.KG
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.out.xyz/r.out.xyz.py
+++ b/scripts/r.out.xyz/r.out.xyz.py
@@ -8,11 +8,10 @@
 # PURPOSE:      Export a raster map as x,y,z values based on cell centers
 #               This is a simple wrapper script for "r.stats -1ng"
 #
-# COPYRIGHT:    (c) 2006 Hamish Bowman, and the GRASS Development Team
-#               (c) 2008 Glynn Clements, and the GRASS Development Team
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2006 Hamish Bowman
+# SPDX-FileCopyrightText: 2008 Glynn Clements
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.out.xyz/r.out.xyz.py
+++ b/scripts/r.out.xyz/r.out.xyz.py
@@ -8,11 +8,10 @@
 # PURPOSE:      Export a raster map as x,y,z values based on cell centers
 #               This is a simple wrapper script for "r.stats -1ng"
 #
-# COPYRIGHT:    (c) 2006 Hamish Bowman, and the GRASS Development Team
-#               (c) 2008 Glynn Clements, and the GRASS Development Team
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2006 Hamish Bowman
+# SPDX-FileCopyrightText: 2008 Glynn Clements
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.semantic.label/r.semantic.label.py
+++ b/scripts/r.semantic.label/r.semantic.label.py
@@ -8,11 +8,9 @@
 # PURPOSE:      Manages semantic label information assigned to a single
 #               raster map or to a list of raster maps.
 #
-# COPYRIGHT:    (C) 2019 by mundialis GmbH & Co.KG, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2019 mundialis GmbH & Co.KG
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.semantic.label/r.semantic.label.py
+++ b/scripts/r.semantic.label/r.semantic.label.py
@@ -8,11 +8,9 @@
 # PURPOSE:      Manages semantic label information assigned to a single
 #               raster map or to a list of raster maps.
 #
-# COPYRIGHT:    (C) 2019 by mundialis GmbH & Co.KG, and the GRASS Development Team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2019 mundialis GmbH & Co.KG
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -9,11 +9,10 @@
 #
 # PURPOSE:      To produce tilings of regions in other projections.
 #
-# COPYRIGHT:    (C) 2006-2009 by Cedric Shoc, Martin Landa, and GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2006-2009 Cedric Shoc
+# SPDX-FileCopyrightText: 2006-2009 Martin Landa
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -9,11 +9,10 @@
 #
 # PURPOSE:      To produce tilings of regions in other projections.
 #
-# COPYRIGHT:    (C) 2006-2009 by Cedric Shoc, Martin Landa, and GRASS development team
-#
-#               This program is free software under the GNU General
-#               Public License (>=v2). Read the file COPYING that
-#               comes with GRASS for details.
+# SPDX-FileCopyrightText: 2006-2009 Cedric Shoc
+# SPDX-FileCopyrightText: 2006-2009 Martin Landa
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 

--- a/scripts/r3.in.xyz/r3.in.xyz.py
+++ b/scripts/r3.in.xyz/r3.in.xyz.py
@@ -7,16 +7,11 @@
 # 		a 3D raster. Unlike r.in.xyz, reading from stdin and z-scaling
 # 		won't work.
 #
-# COPYRIGHT:    (c) 2011-2012 Hamish Bowman, and the GRASS Development Team
-# 		Port of r3.in.xyz(.sh) for GRASS 6.4.
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2011-2012 Hamish Bowman
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# 		This program is distributed in the hope that it will be useful,
-# 		but WITHOUT ANY WARRANTY; without even the implied warranty of
-# 		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# 		GNU General Public License for more details.
+# 		Port of r3.in.xyz(.sh) for GRASS 6.4.
 #
 #############################################################################
 

--- a/scripts/r3.in.xyz/r3.in.xyz.py
+++ b/scripts/r3.in.xyz/r3.in.xyz.py
@@ -7,16 +7,11 @@
 # 		a 3D raster. Unlike r.in.xyz, reading from stdin and z-scaling
 # 		won't work.
 #
-# COPYRIGHT:    (c) 2011-2012 Hamish Bowman, and the GRASS Development Team
-# 		Port of r3.in.xyz(.sh) for GRASS 6.4.
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2011-2012 Hamish Bowman
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# 		This program is distributed in the hope that it will be useful,
-# 		but WITHOUT ANY WARRANTY; without even the implied warranty of
-# 		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# 		GNU General Public License for more details.
+# 		Port of r3.in.xyz(.sh) for GRASS 6.4.
 #
 #############################################################################
 

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -10,11 +10,9 @@
 # PURPOSE:      Import E00 data into a GRASS vector map
 # 		Imports single and split E00 files (.e00, .e01, .e02 ...)
 #
-# COPYRIGHT:    (c) 2004, 2005 GDF Hannover bR, http://www.gdf-hannover.de
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2004, 2005 GDF Hannover bR, http://www.gdf-hannover.de
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 #

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -10,11 +10,9 @@
 # PURPOSE:      Import E00 data into a GRASS vector map
 # 		Imports single and split E00 files (.e00, .e01, .e02 ...)
 #
-# COPYRIGHT:    (c) 2004, 2005 GDF Hannover bR, http://www.gdf-hannover.de
-#
-#               This program is free software under the GNU General Public
-#               License (>=v2). Read the file COPYING that comes with GRASS
-#               for details.
+# SPDX-FileCopyrightText: 2004, 2005 GDF Hannover bR, http://www.gdf-hannover.de
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 #############################################################################
 #

--- a/vector/v.delaunay/data_types.h
+++ b/vector/v.delaunay/data_types.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/data_types.h
+++ b/vector/v.delaunay/data_types.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/edge.c
+++ b/vector/v.delaunay/edge.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/edge.c
+++ b/vector/v.delaunay/edge.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/edge.h
+++ b/vector/v.delaunay/edge.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/edge.h
+++ b/vector/v.delaunay/edge.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/geom_primitives.h
+++ b/vector/v.delaunay/geom_primitives.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/geom_primitives.h
+++ b/vector/v.delaunay/geom_primitives.h
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/geometry.c
+++ b/vector/v.delaunay/geometry.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/geometry.c
+++ b/vector/v.delaunay/geometry.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/in_out.c
+++ b/vector/v.delaunay/in_out.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/in_out.c
+++ b/vector/v.delaunay/in_out.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/main.c
+++ b/vector/v.delaunay/main.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/main.c
+++ b/vector/v.delaunay/main.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/memory.c
+++ b/vector/v.delaunay/memory.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.delaunay/memory.c
+++ b/vector/v.delaunay/memory.c
@@ -8,12 +8,9 @@
  *
  * PURPOSE:      Creates a Delaunay triangulation vector map
  *
- * COPYRIGHT:    (C) RMIT 1993
- *               (C) 2008-2009 by the GRASS Development Team
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2).  Read the file COPYING that
- *               comes with GRASS for details.
+ * SPDX-FileCopyrightText: 1993 RMIT
+ * SPDX-FileCopyrightText: 2008-2009 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * The following notices apply to portions of the code originally
  * derived from work by Geoff Leach of RMIT:

--- a/vector/v.perturb/main.c
+++ b/vector/v.perturb/main.c
@@ -5,8 +5,9 @@
  *                  http://mccauley-usa.com/
  * PURPOSE:      Random location perturbations of vector points
  *
- * COPYRIGHT:    (C) 1994-2009 by James Darrell McCauley and the GRASS
- *               Development Team
+ * SPDX-FileCopyrightText: 1994-2009 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Modification History:
  * 3/2006              added min and seed MN/SM ITC-irst
@@ -15,10 +16,6 @@
  * 0.2B <02 Jan 1995>  clean man page, added html page (jdm)
  * 0.3B <25 Feb 1995>  cleaned up 'gcc -Wall' warnings (jdm)
  * <13 Sept 2000>      released under GPL
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that
- *               comes with GRASS for details.
  *
  *****************************************************************************/
 

--- a/vector/v.perturb/main.c
+++ b/vector/v.perturb/main.c
@@ -5,8 +5,9 @@
  *                  http://mccauley-usa.com/
  * PURPOSE:      Random location perturbations of vector points
  *
- * COPYRIGHT:    (C) 1994-2009 by James Darrell McCauley and the GRASS
- *               Development Team
+ * SPDX-FileCopyrightText: 1994-2009 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Modification History:
  * 3/2006              added min and seed MN/SM ITC-irst
@@ -15,10 +16,6 @@
  * 0.2B <02 Jan 1995>  clean man page, added html page (jdm)
  * 0.3B <25 Feb 1995>  cleaned up 'gcc -Wall' warnings (jdm)
  * <13 Sept 2000>      released under GPL
- *
- *               This program is free software under the GNU General
- *               Public License (>=v2). Read the file COPYING that
- *               comes with GRASS for details.
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/dataoct.c
+++ b/vector/v.vol.rst/dataoct.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/dataoct.c
+++ b/vector/v.vol.rst/dataoct.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/main.c
+++ b/vector/v.vol.rst/main.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *              License (>=v2). Read the file COPYING that comes with GRASS
- *              for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/main.c
+++ b/vector/v.vol.rst/main.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *              License (>=v2). Read the file COPYING that comes with GRASS
- *              for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/oct.c
+++ b/vector/v.vol.rst/oct.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/oct.c
+++ b/vector/v.vol.rst/oct.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user2.c
+++ b/vector/v.vol.rst/user2.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user2.c
+++ b/vector/v.vol.rst/user2.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user3.c
+++ b/vector/v.vol.rst/user3.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 #include <stdio.h>

--- a/vector/v.vol.rst/user3.c
+++ b/vector/v.vol.rst/user3.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 #include <stdio.h>

--- a/vector/v.vol.rst/user4.c
+++ b/vector/v.vol.rst/user4.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/user4.c
+++ b/vector/v.vol.rst/user4.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/vector.c
+++ b/vector/v.vol.rst/vector.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 

--- a/vector/v.vol.rst/vector.c
+++ b/vector/v.vol.rst/vector.c
@@ -16,12 +16,13 @@
  *               Regularized spline with tension is used for the
  *               interpolation.
  *
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
- *
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *****************************************************************************/
 


### PR DESCRIPTION
Converts the 31 files that #7743 left out because their notices needed reading rather than pattern matching.

* Names and years preserved as is; notices naming several people are split into one line per person, with a shared range repeated on each line.
* Organization names with punctuation stay on one line (`mundialis GmbH & Co.KG`, `GDF Hannover bR, http://www.gdf-hannover.de`).
* Text interleaved with the old notices survives unchanged, including the third-party permission notice in r.texture and the RMIT license text in v.delaunay.

The largest split, `vector/v.vol.rst`:

```diff
- * COPYRIGHT:    (C) 1989, 1993, 2000 L. Mitas,  H. Mitasova,
- *               I. Kosinovsky, D. Gerdes, J. Hofierka
-
- *               This program is free software under the GNU General Public
- *               License (>=v2). Read the file COPYING that comes with GRASS
- *               for details.
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 L. Mitas
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 H. Mitasova
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 I. Kosinovsky
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 D. Gerdes
+ * SPDX-FileCopyrightText: 1989, 1993, 2000 J. Hofierka
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
```

Two decisions here go beyond the mechanical rules of #7743:

* The r.geomorphon clause `(C) Scientific idea of geomorphon copyrighted to authors.` is dropped. It was likely meant as an acknowledgement of the authors of the geomorphon concept rather than as a record of a legal right, and that acknowledgement is given by the tool documentation, which cites their papers and lists them as authors.
* Three imagery tools (i.albedo, i.aster.toar, i.evapo.time) whose prose named an unversioned GNU Lesser General Public License while pointing at the GPL `COPYING` file are converted to `GPL-2.0-or-later`, following the `COPYING` reference.

Like #7743, this should technically merge after #7749, which defines the "GRASS Development Team" line, but it does not have to.

Written with AI assistance (Claude Code with Opus 4.8 and Fable 5); the decisions are the author's.

<details>
<summary>Details: per-file resolutions and how it was checked (AI generated)</summary>

## Splits into one line per holder

- `vector/v.vol.rst/*` (8 files): five holders, shared years `1989, 1993, 2000` repeated on each line.
- `raster/r.stats.zonal/main.c`: `2007,2008 Martin Schroeder` and `2007,2008 Glynn Clements`.
- `scripts/r.tileset/r.tileset.py`: `2006-2009 Cedric Shoc` and `2006-2009 Martin Landa`, spelling as written.
- `scripts/r.out.xyz/r.out.xyz.py`: two clauses, each with its own year, `2006 Hamish Bowman` and `2008 Glynn Clements`.

## Single holders whose names carry punctuation

`2019 mundialis GmbH & Co.KG` (two files), `2003 University of Sannio (BN), Benevento, Italy`, and `2004, 2005 GDF Hannover bR, http://www.gdf-hannover.de`, each on one line exactly as written.

## Interleaved text kept in place

The `NOTE` in `lib/gis/open_misc.c`, the modification history in `vector/v.perturb/main.c`, the port note in `scripts/r3.in.xyz/r3.in.xyz.py`, the attribution paragraph in `macos/build_grass_app.bash`, the third-party permission notice below the header in `raster/r.texture/main.c`, and the RMIT license text in `vector/v.delaunay/main.c` are all byte-identical to before.

## v.delaunay (8 files)

`(C) RMIT 1993` becomes `SPDX-FileCopyrightText: 1993 RMIT`, years first like every other line in the tree. The team clause keeps its own years on the collective line (`2008-2009 GRASS Development Team`), since it is a separate clause rather than one shared with the named holder.

## Checked

Each of the 31 files was changed by a single reviewed replacement applied by a small script that asserts the old text occurs exactly once, the trailing bytes are unchanged, no `COPYRIGHT:` field remains, and exactly one license identifier results. No emitted C line exceeds 78 columns, and `pre-commit run` on all 31 files passes with nothing reformatted. `lib/vector/rtree/docs/MAILS`, an archived 2002 email that quotes a header inside a permission request, remains excluded and untouched.

</details>


