### PR TITLE
contributing: Use SPDX copyright tags in individually resolved file headers

### DIFF
--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -4,10 +4,9 @@
  * background. With do_bg=0 compute position of all legend graphic item and draw
  * all.
  *
- * Copyright (C) 2016 by Adam Laza, GSoC 2016, and the GRASS Development Team
- *
- * This program is free software under the GPL (>=v2) Read the COPYING
- * file that comes with GRASS for details.
+ * SPDX-FileCopyrightText: 2016 Adam Laza, GSoC 2016
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <string.h>

--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -4,10 +4,9 @@
  * background. With do_bg=0 compute position of all legend graphic item and draw
  * all.
  *
- * Copyright (C) 2016 by Adam Laza, GSoC 2016, and the GRASS Development Team
- *
- * This program is free software under the GPL (>=v2) Read the COPYING
- * file that comes with GRASS for details.
+ * SPDX-FileCopyrightText: 2016 Adam Laza, GSoC 2016
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <string.h>

--- a/display/d.legend/draw.c
+++ b/display/d.legend/draw.c
@@ -3,9 +3,9 @@
  *    Extracted from original d.legend/main.c for background purpose
  *    Moving to separate file: Adam Laza, GSoC 2016
  *
- *    Copyright (C) 2014 by Hamish Bowman, and the GRASS Development Team*
- *    This program is free software under the GPL (>=v2)
- *    Read the COPYING file that comes with GRASS for details.
+ *    SPDX-FileCopyrightText: 2014 Hamish Bowman
+ *    SPDX-FileCopyrightText: Other GRASS authors
+ *    SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdlib.h>

--- a/display/d.legend/draw.c
+++ b/display/d.legend/draw.c
@@ -3,9 +3,9 @@
  *    Extracted from original d.legend/main.c for background purpose
  *    Moving to separate file: Adam Laza, GSoC 2016
  *
- *    Copyright (C) 2014 by Hamish Bowman, and the GRASS Development Team*
- *    This program is free software under the GPL (>=v2)
- *    Read the COPYING file that comes with GRASS for details.
+ *    SPDX-FileCopyrightText: 2014 Hamish Bowman
+ *    SPDX-FileCopyrightText: GRASS Development Team
+ *    SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdlib.h>

--- a/display/d.legend/histogram.c
+++ b/display/d.legend/histogram.c
@@ -2,9 +2,9 @@
  *    Draws a histogram along the left side of a smooth gradient legend
  *    (stats fetching code adapted from d.histogram)
  *
- *    Copyright (C) 2014 by Hamish Bowman, and the GRASS Development Team*
- *    This program is free software under the GPL (>=v2)
- *    Read the COPYING file that comes with GRASS for details.
+ *    SPDX-FileCopyrightText: 2014 Hamish Bowman
+ *    SPDX-FileCopyrightText: Other GRASS authors
+ *    SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <grass/gis.h>

--- a/display/d.legend/histogram.c
+++ b/display/d.legend/histogram.c
@@ -2,9 +2,9 @@
  *    Draws a histogram along the left side of a smooth gradient legend
  *    (stats fetching code adapted from d.histogram)
  *
- *    Copyright (C) 2014 by Hamish Bowman, and the GRASS Development Team*
- *    This program is free software under the GPL (>=v2)
- *    Read the COPYING file that comes with GRASS for details.
+ *    SPDX-FileCopyrightText: 2014 Hamish Bowman
+ *    SPDX-FileCopyrightText: GRASS Development Team
+ *    SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <grass/gis.h>

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -32,10 +32,8 @@ pythonw on a Mac.
 .. todo::
     verify option value types
 
-Copyright(C) 2000-2015 by the GRASS Development Team
-
-This program is free software under the GPL(>=v2) Read the file
-COPYING coming with GRASS for details.
+SPDX-FileCopyrightText: 2000-2015 Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 
 @author Jan-Oliver Wagner <jan@intevation.de>
 @author Bernhard Reiter <bernhard@intevation.de>

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -32,10 +32,8 @@ pythonw on a Mac.
 .. todo::
     verify option value types
 
-Copyright(C) 2000-2015 by the GRASS Development Team
-
-This program is free software under the GPL(>=v2) Read the file
-COPYING coming with GRASS for details.
+SPDX-FileCopyrightText: 2000-2015 GRASS Development Team
+SPDX-License-Identifier: GPL-2.0-or-later
 
 @author Jan-Oliver Wagner <jan@intevation.de>
 @author Bernhard Reiter <bernhard@intevation.de>

--- a/gui/wxpython/xml/grass-gxm.dtd
+++ b/gui/wxpython/xml/grass-gxm.dtd
@@ -1,10 +1,8 @@
 <!--	grass-gxm.dtd
 
-	Copyright (C) 2010 by the GRASS Development Team
+	SPDX-FileCopyrightText: 2010 Other GRASS authors
+	SPDX-License-Identifier: GPL-2.0-or-later
 	Author: Martin Landa <landa.martin gmail.com>
-
-	This program is free software under the GPL (>=v2)
-	Read the file COPYING coming with GRASS for details.
 -->
 
 

--- a/gui/wxpython/xml/grass-gxm.dtd
+++ b/gui/wxpython/xml/grass-gxm.dtd
@@ -1,10 +1,8 @@
 <!--	grass-gxm.dtd
 
-	Copyright (C) 2010 by the GRASS Development Team
+	SPDX-FileCopyrightText: 2010 GRASS Development Team
+	SPDX-License-Identifier: GPL-2.0-or-later
 	Author: Martin Landa <landa.martin gmail.com>
-
-	This program is free software under the GPL (>=v2)
-	Read the file COPYING coming with GRASS for details.
 -->
 
 

--- a/gui/wxpython/xml/grass-gxw.dtd
+++ b/gui/wxpython/xml/grass-gxw.dtd
@@ -1,10 +1,8 @@
 <!--	grass-gxw.dtd
 
-	Copyright (C) 2007-2008 by the GRASS Development Team
+	SPDX-FileCopyrightText: 2007-2008 Other GRASS authors
+	SPDX-License-Identifier: GPL-2.0-or-later
 	Author: Martin Landa <landa.martin gmail.com>
-
-	This program is free software under the GPL (>=v2)
-	Read the file COPYING coming with GRASS for details.
 -->
 
 

--- a/gui/wxpython/xml/grass-gxw.dtd
+++ b/gui/wxpython/xml/grass-gxw.dtd
@@ -1,10 +1,8 @@
 <!--	grass-gxw.dtd
 
-	Copyright (C) 2007-2008 by the GRASS Development Team
+	SPDX-FileCopyrightText: 2007-2008 GRASS Development Team
+	SPDX-License-Identifier: GPL-2.0-or-later
 	Author: Martin Landa <landa.martin gmail.com>
-
-	This program is free software under the GPL (>=v2)
-	Read the file COPYING coming with GRASS for details.
 -->
 
 

--- a/imagery/i.svm.train/fill.c
+++ b/imagery/i.svm.train/fill.c
@@ -1,11 +1,10 @@
 /*
  * i.svm.train Functions filling svm_problem struct
  *
- *   Copyright 2023 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2023 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <grass/raster.h>

--- a/imagery/i.svm.train/fill.c
+++ b/imagery/i.svm.train/fill.c
@@ -1,11 +1,10 @@
 /*
  * i.svm.train Functions filling svm_problem struct
  *
- *   Copyright 2023 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2023 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <grass/raster.h>

--- a/imagery/i.svm.train/fill.h
+++ b/imagery/i.svm.train/fill.h
@@ -1,11 +1,10 @@
 /*
  * i.svm.train Functions filling svm_problem struct
  *
- *   Copyright 2023 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2023 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/imagery/i.svm.train/fill.h
+++ b/imagery/i.svm.train/fill.h
@@ -1,11 +1,10 @@
 /*
  * i.svm.train Functions filling svm_problem struct
  *
- *   Copyright 2023 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2023 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/lib/cairodriver/draw.c
+++ b/lib/cairodriver/draw.c
@@ -3,10 +3,10 @@
 
    \brief GRASS cairo display driver
 
-   (C) 2007-2008 by Lars Ahlzen, Glynn Clements and the GRASS Development Team
-
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2007-2008 Lars Ahlzen
+   SPDX-FileCopyrightText: 2007-2008 Glynn Clements
+   SPDX-FileCopyrightText: Other GRASS authors
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements

--- a/lib/cairodriver/draw.c
+++ b/lib/cairodriver/draw.c
@@ -3,10 +3,10 @@
 
    \brief GRASS cairo display driver
 
-   (C) 2007-2008 by Lars Ahlzen, Glynn Clements and the GRASS Development Team
-
-   This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2007-2008 Lars Ahlzen
+   SPDX-FileCopyrightText: 2007-2008 Glynn Clements
+   SPDX-FileCopyrightText: GRASS Development Team
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Lars Ahlzen <lars ahlzen.com> (original contributor)
    \author Glynn Clements

--- a/lib/datetime/between.c
+++ b/lib/datetime/between.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 int datetime_is_between(int x, int a, int b)
 {

--- a/lib/datetime/between.c
+++ b/lib/datetime/between.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 int datetime_is_between(int x, int a, int b)
 {

--- a/lib/datetime/change.c
+++ b/lib/datetime/change.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/change.c
+++ b/lib/datetime/change.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/copy.c
+++ b/lib/datetime/copy.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 #include <grass/datetime.h>

--- a/lib/datetime/copy.c
+++ b/lib/datetime/copy.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 #include <grass/datetime.h>

--- a/lib/datetime/diff.c
+++ b/lib/datetime/diff.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdlib.h>
 #include <grass/datetime.h>

--- a/lib/datetime/diff.c
+++ b/lib/datetime/diff.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdlib.h>
 #include <grass/datetime.h>

--- a/lib/datetime/error.c
+++ b/lib/datetime/error.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 

--- a/lib/datetime/error.c
+++ b/lib/datetime/error.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 

--- a/lib/datetime/format.c
+++ b/lib/datetime/format.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/datetime/format.c
+++ b/lib/datetime/format.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/datetime/incr1.c
+++ b/lib/datetime/incr1.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/incr1.c
+++ b/lib/datetime/incr1.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/incr2.c
+++ b/lib/datetime/incr2.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/incr2.c
+++ b/lib/datetime/incr2.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/incr3.c
+++ b/lib/datetime/incr3.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/incr3.c
+++ b/lib/datetime/incr3.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <time.h>
 #include <grass/datetime.h>

--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <time.h>
 #include <grass/datetime.h>

--- a/lib/datetime/misc.c
+++ b/lib/datetime/misc.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/misc.c
+++ b/lib/datetime/misc.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/same.c
+++ b/lib/datetime/same.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 #include <grass/datetime.h>

--- a/lib/datetime/same.c
+++ b/lib/datetime/same.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <string.h>
 #include <grass/datetime.h>

--- a/lib/datetime/scan.c
+++ b/lib/datetime/scan.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/datetime/scan.c
+++ b/lib/datetime/scan.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <stdio.h>
 #include <string.h>

--- a/lib/datetime/sign.c
+++ b/lib/datetime/sign.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/sign.c
+++ b/lib/datetime/sign.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/type.c
+++ b/lib/datetime/type.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/type.c
+++ b/lib/datetime/type.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/tz1.c
+++ b/lib/datetime/tz1.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/tz1.c
+++ b/lib/datetime/tz1.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/tz2.c
+++ b/lib/datetime/tz2.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/tz2.c
+++ b/lib/datetime/tz2.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/values.c
+++ b/lib/datetime/values.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/datetime/values.c
+++ b/lib/datetime/values.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) 1995.  Bill Brown <brown@gis.uiuc.edu> & Michael Shapiro
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1995 Bill Brown <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: 1995 Michael Shapiro
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 #include <grass/datetime.h>
 

--- a/lib/db/README.md
+++ b/lib/db/README.md
@@ -29,13 +29,10 @@ Further authors:
 
 ### Copyright
 
-(C) 2003-2024 by the GRASS Development Team
+SPDX-FileCopyrightText: 2003-2024 Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 
 ### License
-
-This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS
-for details.
 
 ### Directory contents
 

--- a/lib/db/README.md
+++ b/lib/db/README.md
@@ -29,13 +29,11 @@ Further authors:
 
 ### Copyright
 
-(C) 2003-2024 by the GRASS Development Team
+SPDX-FileCopyrightText: 2003-2024 GRASS Development Team
 
 ### License
 
-This program is free software under the GNU General Public
-License (>=v2). Read the file COPYING that comes with GRASS
-for details.
+SPDX-License-Identifier: GPL-2.0-or-later
 
 ### Directory contents
 

--- a/lib/gis/asprintf.c
+++ b/lib/gis/asprintf.c
@@ -8,11 +8,9 @@
  * Rewritten by Glynn Clements, Sat, 6 Feb 2010
  * Assumes that vsnprintf() is available
  *
- * (C) 2002-2014 by the GRASS Development Team
- * (C) 2010 by Glynn Clements
- *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
+ * SPDX-FileCopyrightText: 2010 Glynn Clements
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #define _GNU_SOURCE /* enable asprintf */

--- a/lib/gis/asprintf.c
+++ b/lib/gis/asprintf.c
@@ -8,11 +8,9 @@
  * Rewritten by Glynn Clements, Sat, 6 Feb 2010
  * Assumes that vsnprintf() is available
  *
- * (C) 2002-2014 by the GRASS Development Team
- * (C) 2010 by Glynn Clements
- *
- * This program is free software under the GNU General Public License
- * (>=v2). Read the file COPYING that comes with GRASS for details.
+ * SPDX-FileCopyrightText: 2010 Glynn Clements
+ * SPDX-FileCopyrightText: 2002-2014 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #define _GNU_SOURCE /* enable asprintf */

--- a/lib/gis/find_rast3d.c
+++ b/lib/gis/find_rast3d.c
@@ -3,10 +3,8 @@
 
    \brief GIS library - Find a 3D raster map
 
-   (C) 2001-2009, 2011 by the GRASS Development Team
-
-   `  This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2001-2009, 2011 Other GRASS authors
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Original author CERL
  */

--- a/lib/gis/find_rast3d.c
+++ b/lib/gis/find_rast3d.c
@@ -3,10 +3,8 @@
 
    \brief GIS library - Find a 3D raster map
 
-   (C) 2001-2009, 2011 by the GRASS Development Team
-
-   `  This program is free software under the GNU General Public License
-   (>=v2). Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2001-2009, 2011 GRASS Development Team
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Original author CERL
  */

--- a/lib/linkm/README
+++ b/lib/linkm/README
@@ -1,7 +1,9 @@
 /*
 **  Written by David Gerdes  US Army Construction Engineering Research Lab
 **  	April 1992
-**  Copyright 1992 USA-CERL   All rights reserved.
+**  SPDX-FileCopyrightText: 1992 USA-CERL
+**  SPDX-FileCopyrightText: Other GRASS authors
+**  SPDX-License-Identifier: GPL-2.0-or-later
 **
 */
 

--- a/lib/linkm/README
+++ b/lib/linkm/README
@@ -1,7 +1,9 @@
 /*
 **  Written by David Gerdes  US Army Construction Engineering Research Lab
 **  	April 1992
-**  Copyright 1992 USA-CERL   All rights reserved.
+**  SPDX-FileCopyrightText: 1992 USA-CERL
+**  SPDX-FileCopyrightText: GRASS Development Team
+**  SPDX-License-Identifier: GPL-2.0-or-later
 **
 */
 

--- a/lib/linkm/dispose.c
+++ b/lib/linkm/dispose.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/dispose.c
+++ b/lib/linkm/dispose.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/new.c
+++ b/lib/linkm/new.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/new.c
+++ b/lib/linkm/new.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/next.c
+++ b/lib/linkm/next.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/next.c
+++ b/lib/linkm/next.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/linkm.c
+++ b/lib/linkm/test/linkm.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/linkm.c
+++ b/lib/linkm/test/linkm.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/malloc.c
+++ b/lib/linkm/test/malloc.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/malloc.c
+++ b/lib/linkm/test/malloc.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed.c
+++ b/lib/linkm/test/speed.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed.c
+++ b/lib/linkm/test/speed.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed2.c
+++ b/lib/linkm/test/speed2.c
@@ -2,7 +2,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed2.c
+++ b/lib/linkm/test/speed2.c
@@ -2,7 +2,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed3.c
+++ b/lib/linkm/test/speed3.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/speed3.c
+++ b/lib/linkm/test/speed3.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/try.c
+++ b/lib/linkm/test/try.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/try.c
+++ b/lib/linkm/test/try.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/try2.c
+++ b/lib/linkm/test/try2.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: Other GRASS authors
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/linkm/test/try2.c
+++ b/lib/linkm/test/try2.c
@@ -1,7 +1,9 @@
 /*
  **  Written by David Gerdes  US Army Construction Engineering Research Lab
  **     April 1992
- **  Copyright 1992 USA-CERL   All rights reserved.
+ **  SPDX-FileCopyrightText: 1992 USA-CERL
+ **  SPDX-FileCopyrightText: GRASS Development Team
+ **  SPDX-License-Identifier: GPL-2.0-or-later
  **
  */
 

--- a/lib/ogsf/gsd_img_ppm.c
+++ b/lib/ogsf/gsd_img_ppm.c
@@ -5,17 +5,13 @@
 
    GRASS OpenGL gsurf OGSF Library
 
-   (C) 1999-2008 by the GRASS Development Team
+   SPDX-FileCopyrightText: 1999-2008 Other GRASS authors
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    - added little/big endian test Markus Neteler
    - modified to PPM by Bob Covill <bcovill@tekmap.ns.ca>
    - changed 10/99 Jaro
    - Created new function GS_write_ppm based on RGB dump
-
-   This program is free software under the
-   GNU General Public License (>=v2).
-   Read the file COPYING that comes with GRASS
-   for details.
 
    \author Bill Brown USACERL, GMSL/University of Illinois
    \author Markus Neteler

--- a/lib/ogsf/gsd_img_ppm.c
+++ b/lib/ogsf/gsd_img_ppm.c
@@ -5,17 +5,13 @@
 
    GRASS OpenGL gsurf OGSF Library
 
-   (C) 1999-2008 by the GRASS Development Team
+   SPDX-FileCopyrightText: 1999-2008 GRASS Development Team
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    - added little/big endian test Markus Neteler
    - modified to PPM by Bob Covill <bcovill@tekmap.ns.ca>
    - changed 10/99 Jaro
    - Created new function GS_write_ppm based on RGB dump
-
-   This program is free software under the
-   GNU General Public License (>=v2).
-   Read the file COPYING that comes with GRASS
-   for details.
 
    \author Bill Brown USACERL, GMSL/University of Illinois
    \author Markus Neteler

--- a/lib/ogsf/gsd_img_tif.c
+++ b/lib/ogsf/gsd_img_tif.c
@@ -5,17 +5,13 @@
 
    GRASS OpenGL gsurf OGSF Library
 
-   (C) 1999-2008 by the GRASS Development Team
+   SPDX-FileCopyrightText: 1999-2008 Other GRASS authors
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    - added little/big endian test Markus Neteler
    - modified to PPM by Bob Covill <bcovill@tekmap.ns.ca>
    - changed 10/99 Jaro
    - Created new function GS_write_tif based on RGB dump
-
-   This program is free software under the
-   GNU General Public License (>=v2).
-   Read the file COPYING that comes with GRASS
-   for details.
 
    \author Bill Brown USACERL, GMSL/University of Illinois
    \author Markus Neteler

--- a/lib/ogsf/gsd_img_tif.c
+++ b/lib/ogsf/gsd_img_tif.c
@@ -5,17 +5,13 @@
 
    GRASS OpenGL gsurf OGSF Library
 
-   (C) 1999-2008 by the GRASS Development Team
+   SPDX-FileCopyrightText: 1999-2008 GRASS Development Team
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    - added little/big endian test Markus Neteler
    - modified to PPM by Bob Covill <bcovill@tekmap.ns.ca>
    - changed 10/99 Jaro
    - Created new function GS_write_tif based on RGB dump
-
-   This program is free software under the
-   GNU General Public License (>=v2).
-   Read the file COPYING that comes with GRASS
-   for details.
 
    \author Bill Brown USACERL, GMSL/University of Illinois
    \author Markus Neteler

--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -4,11 +4,10 @@
    \brief Raster library - Functions to read and write raster "units",
    "semantic label" and "vertical datum" meta-data info
 
-   (C) 2007-2009, 2021 by Hamish Bowman, Maris Nartiss,
-   and the GRASS Development Team
-
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2007-2009, 2021 Hamish Bowman
+   SPDX-FileCopyrightText: 2007-2009, 2021 Maris Nartiss
+   SPDX-FileCopyrightText: Other GRASS authors
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Hamish Bowman
  */

--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -4,11 +4,10 @@
    \brief Raster library - Functions to read and write raster "units",
    "semantic label" and "vertical datum" meta-data info
 
-   (C) 2007-2009, 2021 by Hamish Bowman, Maris Nartiss,
-   and the GRASS Development Team
-
-   This program is free software under the GNU General Public License
-   (>=v2).  Read the file COPYING that comes with GRASS for details.
+   SPDX-FileCopyrightText: 2007-2009, 2021 Hamish Bowman
+   SPDX-FileCopyrightText: 2007-2009, 2021 Maris Nartiss
+   SPDX-FileCopyrightText: GRASS Development Team
+   SPDX-License-Identifier: GPL-2.0-or-later
 
    \author Hamish Bowman
  */

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 # checks for HTML files missing DESCRIPTION section
-# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# SPDX-FileCopyrightText: 2003-2009 Markus Neteler
+# SPDX-FileCopyrightText: Other GRASS authors
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Authors:
 #   Markus Neteler
 #   Glynn Clements

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 # checks for HTML files missing DESCRIPTION section
-# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# SPDX-FileCopyrightText: 2003-2009 Markus Neteler
+# SPDX-FileCopyrightText: GRASS Development Team
+# SPDX-License-Identifier: GPL-2.0-or-later
 # Authors:
 #   Markus Neteler
 #   Glynn Clements

--- a/raster/r.geomorphon/testsuite/test_r_geom.py
+++ b/raster/r.geomorphon/testsuite/test_r_geom.py
@@ -4,10 +4,10 @@ Purpose:    Tests r.geomorphon input parsing.
             Uses NC Basic data set.
 
 Author:     Luca Delucchi, Markus Neteler
-Copyright:  (C) 2017 by Luca Delucchi, Markus Neteler and the GRASS Development Team
-Licence:    This program is free software under the GNU General Public
-            License (>=v2). Read the file COPYING that comes with GRASS
-            for details.
+SPDX-FileCopyrightText: 2017 Luca Delucchi
+SPDX-FileCopyrightText: 2017 Markus Neteler
+SPDX-FileCopyrightText: Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 """
 
 import json

--- a/raster/r.in.gridatb/main.c
+++ b/raster/r.in.gridatb/main.c
@@ -3,13 +3,11 @@
  *
  * GRIDATB.FOR Author: Keith Beven <k.beven@lancaster.ac.uk>
  *
- *      Copyright (C) 2000 by the GRASS Development Team
+ *      SPDX-FileCopyrightText: 2000 Other GRASS authors
+ *      SPDX-License-Identifier: GPL-2.0-or-later
  *      Author: Huidae Cho <grass4u@gmail.com>
  *              Hydro Laboratory, Kyungpook National University
  *              South Korea
- *
- *      This program is free software under the GPL (>=v2)
- *      Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.in.gridatb/main.c
+++ b/raster/r.in.gridatb/main.c
@@ -3,13 +3,11 @@
  *
  * GRIDATB.FOR Author: Keith Beven <k.beven@lancaster.ac.uk>
  *
- *      Copyright (C) 2000 by the GRASS Development Team
+ *      SPDX-FileCopyrightText: 2000 GRASS Development Team
+ *      SPDX-License-Identifier: GPL-2.0-or-later
  *      Author: Huidae Cho <grass4u@gmail.com>
  *              Hydro Laboratory, Kyungpook National University
  *              South Korea
- *
- *      This program is free software under the GPL (>=v2)
- *      Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/filters.c
+++ b/raster/r.in.lidar/filters.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/filters.c
+++ b/raster/r.in.lidar/filters.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/filters.h
+++ b/raster/r.in.lidar/filters.h
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/filters.h
+++ b/raster/r.in.lidar/filters.h
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/info.c
+++ b/raster/r.in.lidar/info.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move functions to a file)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/info.c
+++ b/raster/r.in.lidar/info.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move functions to a file)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/point_binning.c
+++ b/raster/r.in.lidar/point_binning.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/point_binning.c
+++ b/raster/r.in.lidar/point_binning.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/point_binning.h
+++ b/raster/r.in.lidar/point_binning.h
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/point_binning.h
+++ b/raster/r.in.lidar/point_binning.h
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/projection.c
+++ b/raster/r.in.lidar/projection.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar metadata-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/projection.c
+++ b/raster/r.in.lidar/projection.c
@@ -1,13 +1,12 @@
 /*
  * r.in.lidar metadata-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/support.c
+++ b/raster/r.in.lidar/support.c
@@ -1,10 +1,9 @@
 /*
  * r.in.lidar support fns, from r.in.xyz.
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.lidar/support.c
+++ b/raster/r.in.lidar/support.c
@@ -1,10 +1,9 @@
 /*
  * r.in.lidar support fns, from r.in.xyz.
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.mat/main.c
+++ b/raster/r.in.mat/main.c
@@ -2,11 +2,9 @@
  *
  * Input a GRASS raster file from a MAT-File (version 4).
  *
- *   Copyright (C) 2004 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Hamish Bowman, University of Otago, New Zealand
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   Code follows r.out.mat, which follows r.out.bin to a certain
  *   extent, which in turn follows r.out.ascii, which is really old.

--- a/raster/r.in.mat/main.c
+++ b/raster/r.in.mat/main.c
@@ -2,11 +2,9 @@
  *
  * Input a GRASS raster file from a MAT-File (version 4).
  *
- *   Copyright (C) 2004 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Hamish Bowman, University of Otago, New Zealand
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   Code follows r.out.mat, which follows r.out.bin to a certain
  *   extent, which in turn follows r.out.ascii, which is really old.

--- a/raster/r.in.pdal/bin_update.c
+++ b/raster/r.in.pdal/bin_update.c
@@ -1,12 +1,11 @@
 /*
  * r.in.pdal Functions performing value updates on each incoming point
  *            during point binning process
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
  *     Maris Nartiss code refactoring for r.in.pdal
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/bin_update.c
+++ b/raster/r.in.pdal/bin_update.c
@@ -1,12 +1,11 @@
 /*
  * r.in.pdal Functions performing value updates on each incoming point
  *            during point binning process
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
  *     Maris Nartiss code refactoring for r.in.pdal
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/bin_write.c
+++ b/raster/r.in.pdal/bin_write.c
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning output value calculation
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/bin_write.c
+++ b/raster/r.in.pdal/bin_write.c
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning output value calculation
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/bin_write.h
+++ b/raster/r.in.pdal/bin_write.h
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning output value calculation
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/bin_write.h
+++ b/raster/r.in.pdal/bin_write.h
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning output value calculation
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/filters.c
+++ b/raster/r.in.pdal/filters.c
@@ -2,13 +2,12 @@
  * r.in.pdal filtering functions
  * adapted from v.in.lidar
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/filters.c
+++ b/raster/r.in.pdal/filters.c
@@ -2,13 +2,12 @@
  * r.in.pdal filtering functions
  * adapted from v.in.lidar
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/filters.h
+++ b/raster/r.in.pdal/filters.h
@@ -2,13 +2,12 @@
  * r.in.pdal filtering functions
  * adapded from v.in.lidar
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/filters.h
+++ b/raster/r.in.pdal/filters.h
@@ -2,13 +2,12 @@
  * r.in.pdal filtering functions
  * adapded from v.in.lidar
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/info.cpp
+++ b/raster/r.in.pdal/info.cpp
@@ -1,11 +1,10 @@
 /*
  * r.in.pdal Functions printing out various information on input LAS files
  *
- *   Copyright 2021-2024 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2021-2024 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/info.cpp
+++ b/raster/r.in.pdal/info.cpp
@@ -1,11 +1,10 @@
 /*
  * r.in.pdal Functions printing out various information on input LAS files
  *
- *   Copyright 2021-2024 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2021-2024 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/info.h
+++ b/raster/r.in.pdal/info.h
@@ -1,11 +1,10 @@
 /*
  * r.in.pdal Functions printing out various information on input LAS files
  *
- *   Copyright 2021 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2021 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/info.h
+++ b/raster/r.in.pdal/info.h
@@ -1,11 +1,10 @@
 /*
  * r.in.pdal Functions printing out various information on input LAS files
  *
- *   Copyright 2021 by Maris Nartiss, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2021 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/point_binning.c
+++ b/raster/r.in.pdal/point_binning.c
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning logic
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/point_binning.c
+++ b/raster/r.in.pdal/point_binning.c
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning logic
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/point_binning.h
+++ b/raster/r.in.pdal/point_binning.h
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning logic
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/point_binning.h
+++ b/raster/r.in.pdal/point_binning.h
@@ -1,14 +1,13 @@
 /*
  * r.in.pdal point binning logic
  *
- * Copyright 2011-2015, 2020 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015, 2020 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to separate functions)
  *  Maris Nartiss (refactoring for r.in.pdal)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/projection.c
+++ b/raster/r.in.pdal/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.pdal/projection.c
+++ b/raster/r.in.pdal/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.xyz/local_proto.h
+++ b/raster/r.in.xyz/local_proto.h
@@ -4,11 +4,10 @@
  *   Calculates univariate statistics from the non-null cells of a GRASS
  *   raster map
  *
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   This program is intended as a replacement for the GRASS 5
  *   s.cellstats module.

--- a/raster/r.in.xyz/local_proto.h
+++ b/raster/r.in.xyz/local_proto.h
@@ -4,11 +4,10 @@
  *   Calculates univariate statistics from the non-null cells of a GRASS
  *   raster map
  *
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   This program is intended as a replacement for the GRASS 5
  *   s.cellstats module.

--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -4,14 +4,13 @@
  *   Calculates univariate statistics from the non-null cells of a GRASS
  *   raster map
  *
- *   Copyright 2006-2014 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006-2014 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
  *
  *   Extended 2007 by Volker Wichmann to support the aggregate functions
  *   median, percentile, skewness and trimmed mean
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   This program is intended as a replacement for the GRASS 5 s.cellstats
  *   module.

--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -4,14 +4,13 @@
  *   Calculates univariate statistics from the non-null cells of a GRASS
  *   raster map
  *
- *   Copyright 2006-2014 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006-2014 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
  *
  *   Extended 2007 by Volker Wichmann to support the aggregate functions
  *   median, percentile, skewness and trimmed mean
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   This program is intended as a replacement for the GRASS 5 s.cellstats
  *   module.

--- a/raster/r.in.xyz/support.c
+++ b/raster/r.in.xyz/support.c
@@ -1,10 +1,9 @@
 /*
  * r.in.xyz support fns.
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.in.xyz/support.c
+++ b/raster/r.in.xyz/support.c
@@ -1,10 +1,9 @@
 /*
  * r.in.xyz support fns.
- *   Copyright 2006 by M. Hamish Bowman, and the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2006 M. Hamish Bowman
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: M. Hamish Bowman, University of Otago, Dunedin, New Zealand
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.out.bin/main.c
+++ b/raster/r.out.bin/main.c
@@ -1,12 +1,10 @@
 /*
  *   r.out.bin
  *
- *   Copyright (C) 2000,2010 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2000,2010 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Bob Covill <bcovill@tekmap.ns.ca>
  *   Modified by Glynn Clements, 2010-01-10
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.out.bin/main.c
+++ b/raster/r.out.bin/main.c
@@ -1,12 +1,10 @@
 /*
  *   r.out.bin
  *
- *   Copyright (C) 2000,2010 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2000,2010 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Bob Covill <bcovill@tekmap.ns.ca>
  *   Modified by Glynn Clements, 2010-01-10
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.out.gridatb/main.c
+++ b/raster/r.out.gridatb/main.c
@@ -3,13 +3,11 @@
  *
  * GRIDATB.FOR Author: Keith Beven <k.beven@lancaster.ac.uk>
  *
- *      Copyright (C) 2000 by the GRASS Development Team
+ *      SPDX-FileCopyrightText: 2000 Other GRASS authors
+ *      SPDX-License-Identifier: GPL-2.0-or-later
  *      Author: Huidae Cho <grass4u@gmail.com>
  *              Hydro Laboratory, Kyungpook National University
  *              South Korea
- *
- *      This program is free software under the GPL (>=v2)
- *      Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.out.gridatb/main.c
+++ b/raster/r.out.gridatb/main.c
@@ -3,13 +3,11 @@
  *
  * GRIDATB.FOR Author: Keith Beven <k.beven@lancaster.ac.uk>
  *
- *      Copyright (C) 2000 by the GRASS Development Team
+ *      SPDX-FileCopyrightText: 2000 GRASS Development Team
+ *      SPDX-License-Identifier: GPL-2.0-or-later
  *      Author: Huidae Cho <grass4u@gmail.com>
  *              Hydro Laboratory, Kyungpook National University
  *              South Korea
- *
- *      This program is free software under the GPL (>=v2)
- *      Read the file COPYING coming with GRASS for details.
  *
  */
 

--- a/raster/r.out.mat/main.c
+++ b/raster/r.out.mat/main.c
@@ -3,11 +3,9 @@
  *
  * Output a GRASS raster map to a MAT-File (version 4).
  *
- *   Copyright (C) 2004 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Hamish Bowman, University of Otago, New Zealand
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   Code follows r.out.bin to a certain extent, which in turn
  *   follows r.out.ascii.

--- a/raster/r.out.mat/main.c
+++ b/raster/r.out.mat/main.c
@@ -3,11 +3,9 @@
  *
  * Output a GRASS raster map to a MAT-File (version 4).
  *
- *   Copyright (C) 2004 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Hamish Bowman, University of Otago, New Zealand
- *
- *   This program is free software under the GPL (>=v2)
- *   Read the COPYING file that comes with GRASS for details.
  *
  *   Code follows r.out.bin to a certain extent, which in turn
  *   follows r.out.ascii.

--- a/raster/r.profile/main.c
+++ b/raster/r.profile/main.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2000 by the GRASS Development Team
+ * SPDX-FileCopyrightText: 2000 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Author: Bob Covill <bcovill@tekmap.ns.ca>
- *
- * This Program is free software under the GPL (>=v2)
- * Read the file COPYING coming with GRASS for details
  *
  */
 

--- a/raster/r.profile/main.c
+++ b/raster/r.profile/main.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2000 by the GRASS Development Team
+ * SPDX-FileCopyrightText: 2000 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Author: Bob Covill <bcovill@tekmap.ns.ca>
- *
- * This Program is free software under the GPL (>=v2)
- * Read the file COPYING coming with GRASS for details
  *
  */
 

--- a/raster/r.profile/read_rast.c
+++ b/raster/r.profile/read_rast.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2000 by the GRASS Development Team
+ * SPDX-FileCopyrightText: 2000 Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Author: Bob Covill <bcovill@tekmap.ns.ca>
- *
- * This Program is free software under the GPL (>=v2)
- * Read the file COPYING coming with GRASS for details
  *
  */
 

--- a/raster/r.profile/read_rast.c
+++ b/raster/r.profile/read_rast.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2000 by the GRASS Development Team
+ * SPDX-FileCopyrightText: 2000 GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Author: Bob Covill <bcovill@tekmap.ns.ca>
- *
- * This Program is free software under the GPL (>=v2)
- * Read the file COPYING coming with GRASS for details
  *
  */
 

--- a/raster/r.smooth.edgepreserve/local_proto.h
+++ b/raster/r.smooth.edgepreserve/local_proto.h
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.smooth.edgepreserve/local_proto.h
+++ b/raster/r.smooth.edgepreserve/local_proto.h
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/raster/r.smooth.edgepreserve/pm.c
+++ b/raster/r.smooth.edgepreserve/pm.c
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve Perona & Malik smoothing
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <string.h>

--- a/raster/r.smooth.edgepreserve/pm.c
+++ b/raster/r.smooth.edgepreserve/pm.c
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve Perona & Malik smoothing
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <string.h>

--- a/raster/r.smooth.edgepreserve/row_cache.c
+++ b/raster/r.smooth.edgepreserve/row_cache.c
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve row cache
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <stdio.h>

--- a/raster/r.smooth.edgepreserve/row_cache.c
+++ b/raster/r.smooth.edgepreserve/row_cache.c
@@ -1,11 +1,10 @@
 /*
  * r.smooth.edgepreserve row cache
  *
- *   Copyright 2025 by Maris Nartiss, and The GRASS Development Team
+ *   SPDX-FileCopyrightText: 2025 Maris Nartiss
+ *   SPDX-FileCopyrightText: GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author: Maris Nartiss
- *
- *   This program is free software licensed under the GPL (>=v2).
- *   Read the COPYING file that comes with GRASS for details.
  *
  */
 #include <stdio.h>

--- a/raster/r.univar/globals.h
+++ b/raster/r.univar/globals.h
@@ -1,14 +1,11 @@
 /*
  *  Calculates univariate statistics from the non-null cells
  *
- *   Copyright (C) 2004-2010 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2010 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *              Based on r.univar from Hamish Bowman, University of Otago, New
  *              Zealand and Martin Landa zonal loop by Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/globals.h
+++ b/raster/r.univar/globals.h
@@ -1,14 +1,11 @@
 /*
  *  Calculates univariate statistics from the non-null cells
  *
- *   Copyright (C) 2004-2010 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2010 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *              Based on r.univar from Hamish Bowman, University of Otago, New
  *              Zealand and Martin Landa zonal loop by Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -4,14 +4,11 @@
  *  Calculates univariate statistics from the non-null cells of a GRASS raster
  *  map
  *
- *   Copyright (C) 2004-2006, 2012 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2006, 2012 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Hamish Bowman, University of Otago, New Zealand
  *              Extended stats: Martin Landa
  *              Zonal stats: Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  *   This program is a replacement for the r.univar shell script
  */

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -4,14 +4,11 @@
  *  Calculates univariate statistics from the non-null cells of a GRASS raster
  *  map
  *
- *   Copyright (C) 2004-2006, 2012 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2006, 2012 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Hamish Bowman, University of Otago, New Zealand
  *              Extended stats: Martin Landa
  *              Zonal stats: Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  *   This program is a replacement for the r.univar shell script
  */

--- a/raster/r.univar/r3.univar_main.c
+++ b/raster/r.univar/r3.univar_main.c
@@ -4,15 +4,12 @@
  *  Calculates univariate statistics from the non-null 3d cells of a raster3d
  *  map
  *
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *              Based on r.univar from Hamish Bowman, University of Otago, New
  *              Zealand and Martin Landa heapsort code from
  *              http://de.wikipedia.org/wiki/Heapsort Zonal stats: Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/r3.univar_main.c
+++ b/raster/r.univar/r3.univar_main.c
@@ -4,15 +4,12 @@
  *  Calculates univariate statistics from the non-null 3d cells of a raster3d
  *  map
  *
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *              Based on r.univar from Hamish Bowman, University of Otago, New
  *              Zealand and Martin Landa heapsort code from
  *              http://de.wikipedia.org/wiki/Heapsort Zonal stats: Markus Metz
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/sort.c
+++ b/raster/r.univar/sort.c
@@ -1,11 +1,8 @@
 /*
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): 1998, 1999 Sebastian Cyris
  *              2007 modified by Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/sort.c
+++ b/raster/r.univar/sort.c
@@ -1,11 +1,8 @@
 /*
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): 1998, 1999 Sebastian Cyris
  *              2007 modified by Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -1,13 +1,10 @@
 /*
  *  Calculates univariate statistics from the non-null cells
  *
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Hamish Bowman, University of Otago, New Zealand
  *              Martin Landa and Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -1,13 +1,10 @@
 /*
  *  Calculates univariate statistics from the non-null cells
  *
- *   Copyright (C) 2004-2007 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2007 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Hamish Bowman, University of Otago, New Zealand
  *              Martin Landa and Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster3d/r3.stats/main.c
+++ b/raster3d/r3.stats/main.c
@@ -1,14 +1,11 @@
 /*
  *   r3.stats
  *
- *   Copyright (C) 2004-2017 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2017 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *
  *   Purpose: Generates volume statistics for raster3d maps.
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster3d/r3.stats/main.c
+++ b/raster3d/r3.stats/main.c
@@ -1,14 +1,11 @@
 /*
  *   r3.stats
  *
- *   Copyright (C) 2004-2017 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2017 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
  *
  *   Purpose: Generates volume statistics for raster3d maps.
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster3d/r3.stats/support.c
+++ b/raster3d/r3.stats/support.c
@@ -1,12 +1,9 @@
 /*
  *   r3.stats support functions
  *
- *   Copyright (C) 2004-2014 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2014 Other GRASS authors
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/raster3d/r3.stats/support.c
+++ b/raster3d/r3.stats/support.c
@@ -1,12 +1,9 @@
 /*
  *   r3.stats support functions
  *
- *   Copyright (C) 2004-2014 by the GRASS Development Team
+ *   SPDX-FileCopyrightText: 2004-2014 GRASS Development Team
+ *   SPDX-License-Identifier: GPL-2.0-or-later
  *   Author(s): Soeren Gebbert
- *
- *      This program is free software under the GNU General Public
- *      License (>=v2). Read the file COPYING that comes with GRASS
- *      for details.
  *
  */
 

--- a/vector/v.in.lidar/attributes.c
+++ b/vector/v.in.lidar/attributes.c
@@ -1,13 +1,12 @@
 /*
  * attribute handling
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/attributes.c
+++ b/vector/v.in.lidar/attributes.c
@@ -1,13 +1,12 @@
 /*
  * attribute handling
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/filters.c
+++ b/vector/v.in.lidar/filters.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/filters.c
+++ b/vector/v.in.lidar/filters.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/filters.h
+++ b/vector/v.in.lidar/filters.h
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/filters.h
+++ b/vector/v.in.lidar/filters.h
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/info.c
+++ b/vector/v.in.lidar/info.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move functions to a file)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/info.c
+++ b/vector/v.in.lidar/info.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar projection-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move functions to a file)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/projection.c
+++ b/vector/v.in.lidar/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.lidar/projection.c
+++ b/vector/v.in.lidar/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/filters.c
+++ b/vector/v.in.pdal/filters.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/filters.c
+++ b/vector/v.in.pdal/filters.c
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/filters.h
+++ b/vector/v.in.pdal/filters.h
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/filters.h
+++ b/vector/v.in.pdal/filters.h
@@ -1,13 +1,12 @@
 /*
  * v.in.lidar filtering functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to a separate files)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/projection.c
+++ b/vector/v.in.pdal/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 

--- a/vector/v.in.pdal/projection.c
+++ b/vector/v.in.pdal/projection.c
@@ -1,13 +1,12 @@
 /*
  * projection checking
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (v.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
- *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
  *
  */
 


### PR DESCRIPTION
Converts 90 files whose notices the bulk conversions (#7743, #7756) left for a person: notices naming several holders, notices whose license text is separated from them by an author list, and a handful of one-off shapes.

* One line per holder, a shared year range repeated on each line, email addresses and affiliations kept as written.
* Author lists and other text interleaved with the old notices stay in place.
* 27 files remain for another round, listed in the attached report.

A typical replacement:

```diff
 /*
  * r.in.lidar metadata-related functions
  *
- * Copyright 2011-2015 by Markus Metz, and the GRASS Development Team
+ * SPDX-FileCopyrightText: 2011-2015 Markus Metz
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Authors:
  *  Markus Metz (r.in.lidar)
  *  Vaclav Petras (move code to standalone functions)
  *
- * This program is free software licensed under the GPL (>=v2).
- * Read the COPYING file that comes with GRASS for details.
- *
  */
```

The policy decisions were made during GRASS Community Meeting 2026 in San Michele all'Adige.

Like the other conversion PRs, this should technically merge after #7749, which defines the "GRASS Development Team" line, but it does not have to.

The edits were generated as one reviewed replacement per file by a script that asserts each old text occurs exactly once and refuses anything it cannot resolve safely. The script was written and this conversion prepared with AI assistance (Claude Code with Opus 4.8 and Fable 5); the decisions are the author's.

<details>
<summary>Details: decisions, deferred files, and how it was checked (AI generated)</summary>

## Decisions

* The `lib/datetime` notices name two people joined by an ampersand; each gets a line with the shared year: `1995 Bill Brown <brown@gis.uiuc.edu>` and `1995 Michael Shapiro`.
* The `lib/linkm` notices, `Copyright 1992 USA-CERL All rights reserved.`, convert with the identifier under the CERL-era rule of #7756. The "All rights reserved" phrase is not carried over: it grants nothing and contradicts the license the code has shipped under.
* `lib/gis/asprintf.c` carries its own clause for the team next to a named one. Following the v.delaunay precedent of #7751, both the named holder and the collective line keep their years (`2010 Glynn Clements`, `2002-2014 GRASS Development Team`), since the team clause is separate rather than shared with the named holder.
* `Adam Laza, GSoC 2016` stays on one line as written, the same treatment as affiliations.
* A stray margin star glued to two `d.legend` notices (`...Development Team*`) is treated as formatting, not text.
* `man/build_check.py`, deferred by #7756 because the pinned ruff hook rewrote it on the unmodified base, converts cleanly here: with the new header the hook accepts the file as it is.

## Left for another round (27 files)

* Individual-held notices from 1993 on with no license text (`lib/rst/interp_float`, `v.lrs.segment`): adding an identifier would assert a license the file never stated, so they wait for their authors.
* Headers that need reading in full: the `r.sun` address block with several email addresses, the `v.perturb` and `v.normal` textbook-algorithm attributions, `r.resamp.rst`, `r.surf.area`, `mswindows/osgeo4w/mysql_config`, and `utils/gitlog2changelog.py`.
* Two vendored web assets (`man/jquery.fixedheadertable.min.js`, `man/parser_standard_options.css`) that belong with the third-party exclusions.

Each is listed with its verbatim notice in the attached `hand-deferred.md`.

## Checked

The generating script asserts for every file that the old text occurs exactly once and that the trailing bytes do not change, and it refuses notices it cannot resolve safely; everything it refused is in the deferred list rather than half-converted. Across the 91 files: no license prose remains, the set of years on notice lines is unchanged everywhere, no emitted C line exceeds 78 columns, and `pre-commit` over all files passes with nothing reformatted. The script (`resolve_bare.py.txt`), the conversion library it builds on from the earlier PRs (`spdx_headers.py.txt`), and the deferred report (`hand-deferred.md`) are attached.

[hand-deferred.md](https://github.com/user-attachments/files/30157830/hand-deferred.md)
[resolve_bare.py.txt](https://github.com/user-attachments/files/30157831/resolve_bare.py.txt)
[spdx_headers.py.txt](https://github.com/user-attachments/files/30157832/spdx_headers.py.txt)


</details>



