### PR TITLE
contributing: Use SPDX copyright tags in the most complicated file headers

### DIFF
--- a/lib/rst/interp_float/distance.c
+++ b/lib/rst/interp_float/distance.c
@@ -1,8 +1,11 @@
 /*-
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Fall 1993
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/distance.c
+++ b/lib/rst/interp_float/distance.c
@@ -1,8 +1,11 @@
 /*-
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Fall 1993
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/minmax.c
+++ b/lib/rst/interp_float/minmax.c
@@ -2,9 +2,11 @@
  * Written by H. Mitasova, L. Mitas, I. Kosinovsky, D. Gerdes Fall 1994
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1994, H. Mitasova (University of Illinois),
- * L. Mitas (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1994 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1994 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1994 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/minmax.c
+++ b/lib/rst/interp_float/minmax.c
@@ -2,9 +2,12 @@
  * Written by H. Mitasova, L. Mitas, I. Kosinovsky, D. Gerdes Fall 1994
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1994, H. Mitasova (University of Illinois),
- * L. Mitas (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1994 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1994 L. Mitas (University of Illinois)
+ * SPDX-FileCopyrightText: 1994 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1994 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/resout2d.c
+++ b/lib/rst/interp_float/resout2d.c
@@ -2,8 +2,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/resout2d.c
+++ b/lib/rst/interp_float/resout2d.c
@@ -2,8 +2,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -2,8 +2,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -2,8 +2,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
  * modified by Mitasova in August 1995

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -4,23 +4,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
- *
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *
  * modified by McCauley in August 1995

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -4,23 +4,11 @@
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Summer 1993
  * University of Illinois
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
- *
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  *
  * modified by McCauley in August 1995

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -4,29 +4,11 @@ r.sun: This program was written by Jaro Hofierka in Summer 1993 and
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,
-       suri@geomodel.sk Thomas.Huld@jrc.it
-(c) 2003-2013 by the GRASS Development Team
+SPDX-FileCopyrightText: 2002 Jaro Hofierka
+SPDX-FileCopyrightText: 2002 GeoModel, s.r.o.
+SPDX-FileCopyrightText: Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 ******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 /*v. 3.0 February 2006, several changes (shadowing algorithm, earth's curvature

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -4,29 +4,10 @@ r.sun: This program was written by Jaro Hofierka in Summer 1993 and
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,
-       suri@geomodel.sk Thomas.Huld@jrc.it
-(c) 2003-2013 by the GRASS Development Team
+SPDX-FileCopyrightText: 2002 Jaro Hofierka, GeoModel, s.r.o.
+SPDX-FileCopyrightText: 2003-2013 GRASS Development Team
+SPDX-License-Identifier: GPL-2.0-or-later
 ******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 /*v. 3.0 February 2006, several changes (shadowing algorithm, earth's curvature

--- a/raster/r.sun/rsunglobals.h
+++ b/raster/r.sun/rsunglobals.h
@@ -4,27 +4,11 @@ r.sun: rsunglobals.h. This program was written by Jaro Hofierka in Summer 1993
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,suri@geomodel.sk
+SPDX-FileCopyrightText: 2002 Jaro Hofierka
+SPDX-FileCopyrightText: 2002 GeoModel, s.r.o.
+SPDX-FileCopyrightText: Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 ******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.sun/rsunglobals.h
+++ b/raster/r.sun/rsunglobals.h
@@ -4,27 +4,10 @@ r.sun: rsunglobals.h. This program was written by Jaro Hofierka in Summer 1993
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,suri@geomodel.sk
+SPDX-FileCopyrightText: 2002 Jaro Hofierka, GeoModel, s.r.o.
+SPDX-FileCopyrightText: GRASS Development Team
+SPDX-License-Identifier: GPL-2.0-or-later
 ******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.sun/rsunlib.c
+++ b/raster/r.sun/rsunlib.c
@@ -4,29 +4,14 @@
    Thomas Huld from JRC in Ispra a new version of r.sun was prepared using
    ESRA solar radiation formulas.  See the manual page for details.
 
-  (C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-               and GeoModel, s.r.o., Bratislava, Slovakia
-  email: hofierka at geomodel.sk, marcel.suri at jrc.it, suri at geomodel.sk
+  SPDX-FileCopyrightText: 2002 Jaro Hofierka
+  SPDX-FileCopyrightText: 2002 GeoModel, s.r.o.
+  SPDX-FileCopyrightText: 2011 Hamish Bowman
+  SPDX-FileCopyrightText: Other GRASS authors
+  SPDX-License-Identifier: GPL-2.0-or-later
 
   (C) 2011 by Hamish Bowman, and the GRASS Development Team
 ****************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.sun/rsunlib.c
+++ b/raster/r.sun/rsunlib.c
@@ -4,29 +4,12 @@
    Thomas Huld from JRC in Ispra a new version of r.sun was prepared using
    ESRA solar radiation formulas.  See the manual page for details.
 
-  (C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-               and GeoModel, s.r.o., Bratislava, Slovakia
-  email: hofierka at geomodel.sk, marcel.suri at jrc.it, suri at geomodel.sk
+  SPDX-FileCopyrightText: 2002 Jaro Hofierka, GeoModel, s.r.o.
+  SPDX-FileCopyrightText: 2011 Hamish Bowman
+  SPDX-FileCopyrightText: GRASS Development Team
+  SPDX-License-Identifier: GPL-2.0-or-later
 
-  (C) 2011 by Hamish Bowman, and the GRASS Development Team
 ****************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.sun/sunradstruct.h
+++ b/raster/r.sun/sunradstruct.h
@@ -4,27 +4,11 @@ r.sun: sunradstruct.h. This program was written by Jaro Hofierka in Summer 1993
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,suri@geomodel.sk
+SPDX-FileCopyrightText: 2002 Jaro Hofierka
+SPDX-FileCopyrightText: 2002 GeoModel, s.r.o.
+SPDX-FileCopyrightText: Other GRASS authors
+SPDX-License-Identifier: GPL-2.0-or-later
 *******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.sun/sunradstruct.h
+++ b/raster/r.sun/sunradstruct.h
@@ -4,27 +4,10 @@ r.sun: sunradstruct.h. This program was written by Jaro Hofierka in Summer 1993
  from JRC in Ispra a new version of r.sun was prepared using ESRA solar
  radiation formulas.
 See manual pages for details.
-(C) 2002 Copyright Jaro Hofierka, Gresaka 22, 085 01 Bardejov, Slovakia,
-              and GeoModel, s.r.o., Bratislava, Slovakia
-email: hofierka@geomodel.sk,marcel.suri@jrc.it,suri@geomodel.sk
+SPDX-FileCopyrightText: 2002 Jaro Hofierka, GeoModel, s.r.o.
+SPDX-FileCopyrightText: GRASS Development Team
+SPDX-License-Identifier: GPL-2.0-or-later
 *******************************************************************************/
-/*
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the
- *   Free Software Foundation, Inc.,
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 

--- a/raster/r.surf.area/main.c
+++ b/raster/r.surf.area/main.c
@@ -1,24 +1,10 @@
 /* main.c - r.surf.area */
 
-/* Copyright Notice
- * ----------------
- * Written by Bill Brown, USACERL December 21, 1994
- * Copyright 1994, Bill Brown, USACERL
- * brown@gis.uiuc.edu
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*Written by Bill Brown, USACERL December 21,
+    1994
+/* SPDX-FileCopyrightText: 1994 Bill Brown, USACERL <brown@gis.uiuc.edu>
+/* SPDX-FileCopyrightText: Other GRASS authors
+/* SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /* Calculates area of regular 3D triangulated points
@@ -57,7 +43,7 @@
 
 #include "local_proto.h"
 
-int main(int argc, char *argv[])
+    int main(int argc, char *argv[])
 {
     struct GModule *module;
     struct {

--- a/raster/r.surf.area/main.c
+++ b/raster/r.surf.area/main.c
@@ -1,24 +1,10 @@
 /* main.c - r.surf.area */
 
-/* Copyright Notice
- * ----------------
+/*
  * Written by Bill Brown, USACERL December 21, 1994
- * Copyright 1994, Bill Brown, USACERL
- * brown@gis.uiuc.edu
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-FileCopyrightText: 1994 Bill Brown, USACERL <brown@gis.uiuc.edu>
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /* Calculates area of regular 3D triangulated points

--- a/vector/v.lrs/v.lrs.segment/main.c
+++ b/vector/v.lrs/v.lrs.segment/main.c
@@ -4,26 +4,10 @@
  */
 
 /******************************************************************************
- * Copyright (c) 2004-2007, Radim Blazek (blazek@itc.it),
- *                          Hamish Bowman (side_offset bits)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2004-2007 Radim Blazek <blazek@itc.it>
+ * SPDX-FileCopyrightText: 2004-2007 Hamish Bowman (side_offset bits)
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: MIT
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/vector/v.lrs/v.lrs.segment/main.c
+++ b/vector/v.lrs/v.lrs.segment/main.c
@@ -4,26 +4,10 @@
  */
 
 /******************************************************************************
- * Copyright (c) 2004-2007, Radim Blazek (blazek@itc.it),
- *                          Hamish Bowman (side_offset bits)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2004-2007 Radim Blazek <blazek@itc.it>
+ * SPDX-FileCopyrightText: 2004-2007 Hamish Bowman (side_offset bits)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: MIT
  *****************************************************************************/
 
 #include <stdlib.h>

--- a/vector/v.normal/scancats.c
+++ b/vector/v.normal/scancats.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.normal/scancats.c
+++ b/vector/v.normal/scancats.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/fische.c
+++ b/vector/v.perturb/fische.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/fische.c
+++ b/vector/v.perturb/fische.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/myrng.c
+++ b/vector/v.perturb/myrng.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/myrng.c
+++ b/vector/v.perturb/myrng.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normal00.c
+++ b/vector/v.perturb/normal00.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normal00.c
+++ b/vector/v.perturb/normal00.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalen.c
+++ b/vector/v.perturb/normalen.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalen.c
+++ b/vector/v.perturb/normalen.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalrs.c
+++ b/vector/v.perturb/normalrs.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalrs.c
+++ b/vector/v.perturb/normalrs.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalsv.c
+++ b/vector/v.perturb/normalsv.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/normalsv.c
+++ b/vector/v.perturb/normalsv.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.perturb/zufall.h
+++ b/vector/v.perturb/zufall.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #define min(a, b) ((a) <= (b) ? (a) : (b))

--- a/vector/v.perturb/zufall.h
+++ b/vector/v.perturb/zufall.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994. James Darrell McCauley.  (darrell@mccauley-usa.com)
- *                                              http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #define min(a, b) ((a) <= (b) ? (a) : (b))

--- a/vector/v.qcount/count.c
+++ b/vector/v.qcount/count.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.qcount/count.c
+++ b/vector/v.qcount/count.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdio.h>

--- a/vector/v.qcount/findquads.c
+++ b/vector/v.qcount/findquads.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdlib.h>

--- a/vector/v.qcount/findquads.c
+++ b/vector/v.qcount/findquads.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <stdlib.h>

--- a/vector/v.qcount/indices.c
+++ b/vector/v.qcount/indices.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <grass/gis.h>

--- a/vector/v.qcount/indices.c
+++ b/vector/v.qcount/indices.c
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <grass/gis.h>

--- a/vector/v.qcount/quaddefs.h
+++ b/vector/v.qcount/quaddefs.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: Other GRASS authors
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 typedef struct {

--- a/vector/v.qcount/quaddefs.h
+++ b/vector/v.qcount/quaddefs.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 1994-1995. James Darrell McCauley. (darrell@mccauley-usa.com)
- *                                http://mccauley-usa.com/
- *
- * This program is free software under the GPL (>=v2)
- * Read the file GPL.TXT coming with GRASS for details.
+ * SPDX-FileCopyrightText: 1994-1995 James Darrell McCauley
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 typedef struct {


### PR DESCRIPTION
Converts 23 files whose headers needed reading in full: r.sun, the RST interpolation library, the McCauley tools, and the MIT-licensed v.lrs.segment.

* r.sun: `2002 Jaro Hofierka, GeoModel, s.r.o.`; postal addresses and email lists stay out of holder lines.
* lib/rst/interp_float converts with the identifier by maintainer decision; r.resamp.rst in the same code family states the GPL explicitly.
* The McCauley files use the name alone; with the email the line passes the 80-column limit where clang-format breaks the tag.
* v.lrs.segment converts to `SPDX-License-Identifier: MIT` with its two holders on their own lines.
* Four third-party files are deferred: Oracle's `mysql_config`, `gitlog2changelog.py` from NUT, and two vendored web assets under `man`.

```diff
 /*-
  * Written by H. Mitasova, I. Kosinovsky, D. Gerdes Fall 1993
  * US Army Construction Engineering Research Lab
- * Copyright 1993, H. Mitasova (University of Illinois),
- * I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 H. Mitasova (University of Illinois)
+ * SPDX-FileCopyrightText: 1993 I. Kosinovsky (USA-CERL)
+ * SPDX-FileCopyrightText: 1993 D.Gerdes (USA-CERL)
+ * SPDX-FileCopyrightText: GRASS Development Team
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * modified by McCauley in August 1995
```

The policy decisions were made during GRASS Community Meeting 2026 in San Michele all'Adige.

Like the other conversion PRs, this should technically merge after #7749, which defines the "GRASS Development Team" line, but it does not have to.

The edits were applied by a per-file replacement script that asserts each old text occurs exactly once and that trailing bytes never change. The script was written and this conversion prepared with AI assistance (Claude Code with Opus 4.8 and Fable 5); the decisions are the author's.

<details>
<summary>Details: decisions, deferred files, and how it was checked (AI generated)</summary>

## Decisions

* **r.sun** (4 files): holder `2002 Jaro Hofierka, GeoModel, s.r.o.` (GeoModel is his affiliation, kept on the same line), plus `2011 Hamish Bowman` on his own line in rsunlib.c. Contact information goes with the notice. The separate team clause in main.c keeps its years on the collective line (`2003-2013 GRASS Development Team`); rsunlib.c shares its clause with Hamish Bowman, so its collective line is bare. The FSF license block each file carried in a separate comment is replaced by the identifier.
* **lib/rst/interp_float** (4 files): `Copyright 1993, H. Mitasova (University of Illinois), I. Kosinovsky, (USA-CERL), and D.Gerdes (USA-CERL)` with no license text. One holder per line, affiliations kept; the `Written by` and `modified by` lines are untouched.
* **McCauley** (12 files): `1994 James Darrell McCauley` (or `1994-1995`), name only. With the email the line is 81 to 86 columns; clang-format wraps comments at 80 and would break the tag. Bill Brown's `1994 Bill Brown, USACERL <brown@gis.uiuc.edu>` fits at 77 columns and keeps the email in r.surf.area.
* **v.lrs.segment**: `2004-2007 Radim Blazek <blazek@itc.it>` and `2004-2007 Hamish Bowman (side_offset bits)`, then `SPDX-License-Identifier: MIT` replacing the license text, the same operation as for the GPL files. This is the one file in the series with a license other than GPL-2.0-or-later.
* **r.surf.area** and **r.resamp.rst**: the full three-paragraph FSF text is replaced by the identifier; attribution lines stay.

## Deferred as third party (4 files)

* `mswindows/osgeo4w/mysql_config`: Oracle's script, GPL version 2 only.
* `utils/gitlog2changelog.py`: Marcus D. Hanwell's, via the NUT project.
* `man/jquery.fixedheadertable.min.js`, `man/parser_standard_options.css`: vendored web assets.

## Checked

Each replacement asserts the old text occurs exactly once and trailing bytes never change. Across the 23 files: no license prose remains, no emitted line exceeds 80 columns, and `pre-commit` passes with nothing reformatted, verified with hooks actually running. clang-format adjusted whitespace in the four interp_float headers after the initial edit; the committed text is the hook-stable form, re-verified as a byte-level no-op. The script (`resolve_final.py.txt`) is attached.

[resolve_final.py.txt](https://github.com/user-attachments/files/30157679/resolve_final.py.txt)


</details>

