### PR TITLE
lib/proj: fix data race on METERS_in/METERS_out in coordinate transform functions

### DIFF
--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -39,8 +39,6 @@
         }                         \
     } while (0)
 
-static double METERS_in = 1.0, METERS_out = 1.0;
-
 int get_pj_area(const struct pj_info *iproj, double *xmin, double *xmax,
                 double *ymin, double *ymax)
 {
@@ -878,6 +876,7 @@ int GPJ_transform(const struct pj_info *info_in, const struct pj_info *info_out,
 
     int in_is_ll, out_is_ll, in_deg2rad, out_rad2deg;
     PJ_COORD c;
+    double METERS_in = 1.0, METERS_out = 1.0;
 
     if (info_in->pj == NULL)
         G_fatal_error(_("No input projection"));
@@ -1040,6 +1039,7 @@ int GPJ_transform_array(const struct pj_info *info_in,
     /* PROJ 5+ variant */
     int in_is_ll, out_is_ll, in_deg2rad, out_rad2deg;
     PJ_COORD c;
+    double METERS_in = 1.0, METERS_out = 1.0;
 
     if (info_trans->pj == NULL)
         G_fatal_error(_("No transformation object"));
@@ -1236,6 +1236,7 @@ int pj_do_proj(double *x, double *y, const struct pj_info *info_in,
 
     struct pj_info info_trans;
     PJ_COORD c;
+    double METERS_in = 1.0, METERS_out = 1.0;
 
     if (GPJ_init_transform(info_in, info_out, &info_trans) < 0) {
         return -1;
@@ -1325,6 +1326,7 @@ int pj_do_transform(int count, double *x, double *y, double *h,
 
     struct pj_info info_trans;
     PJ_COORD c;
+    double METERS_in = 1.0, METERS_out = 1.0;
 
     if (GPJ_init_transform(info_in, info_out, &info_trans) < 0) {
         return -1;


### PR DESCRIPTION
This is the small separate PR for the globals fix suggested in the review of #7627.

GPJ_transform and three other functions in do_proj.c share two variables, METERS_in and METERS_out, that live at file scope. Every call writes into them. So if two threads call these functions at the same time, they both write into the same shared variables. This could cause a data race. It doesn't matter that each thread has its own cloned PJ object, because the race is on these shared variables and not on the PJ. In practice the output still came out correct since every thread happened to write the same values, but it is still undefined behavior and thread sanitizer found it.

The fix itself was pretty simple. Each of the four functions now has its own local copy of the two variables instead of sharing one pair at file scope. Each function already sets both values before using them, on every path through the code, so nothing about the output changes.

How I verified it:
I wrote a small test program where 8 threads call GPJ_transform at the same time, each thread with its own cloned PJ. On the old code, thread sanitizer reports data races on METERS_in and METERS_out in both transform directions. With this change, the same test runs clean in both directions. I also built r.proj with the change and its output is bit for bit identical to the unmodified module. I tested this with the nearest and bilinear methods.
