### PR TITLE
docker: update grass-session test to use tools

### DIFF
--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -1,21 +1,26 @@
 # Import GRASS Python bindings (requires 8.4+) and test r.in.pdal
 
 # PYTHONPATH=$(grass --config python-path) python
+#  or
+# export PYTHONPATH=$(grass --config python-path)
 
 import grass.script as gs
+from grass.tools import Tools
 
-# full path to new project
-project = "/tmp/grasstest_epsg_25832"
-gs.create_project(project, epsg="25832")
-
+# Create a new project (formerly "location")
 # hint: do not use ~ as an alias for HOME
-with gs.setup.init(project):
+project = "/tmp/my_project_3358"
+gs.create_project(project, epsg="3358")
+
+# Initialize the GRASS session
+with gs.setup.init(project) as session:
     print("GRASS session: tests for PROJ, GDAL, PDAL, GRASS")
     print(gs.parse_command("g.gisenv", flags="s"))
+    tools = Tools(session=session)
 
     # simple test: just scan the LAZ file
-    gs.run_command(
-        "r.in.pdal",
+    tools.g_region(n=853535.43, w=635619.85, e=638982.55, s=848899.7)
+    tools.r_in_pdal(
         input="/tmp/simple.laz",
         output="count_1",
         method="n",


### PR DESCRIPTION
Replace old python interface (`gs.run_command()` with new tools interface.