### PR TITLE
docs: noindex development manuals so they defer to grass-stable

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -230,6 +230,13 @@ jobs:
           cd ..
           export SITE_NAME="GRASS ${MAJOR}.${MINOR} Documentation"
           export COPYRIGHT="&copy; 2003-$YEAR GRASS Development Team, GRASS $VERSION Documentation"
+          # Development builds (micro ends in "dev") are marked noindex so the dev
+          # manuals do not compete with the grass-stable canonical (see #5935).
+          if [[ "${MICRO}" == *dev ]]; then
+            export GRASS_DOCS_NOINDEX="true"
+          else
+            export GRASS_DOCS_NOINDEX="false"
+          fi
           cd "${MKDOCS_DIR}" || exit
           mkdocs build
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -33,6 +33,7 @@ DSTFILES := \
 	$(MDDIR)/source/grassdocs.css \
 	$(MDDIR)/scripts/hook_list_scripts.py \
 	$(MDDIR)/source/index.md \
+	$(MDDIR)/overrides/main.html \
 	$(MDDIR)/overrides/partials/copyright.html \
 	$(MDDIR)/overrides/partials/footer.html \
 	$(MDDIR)/overrides/partials/actions.html \
@@ -286,6 +287,12 @@ $(MDDIR)/scripts/hook_list_scripts.py: mkdocs/scripts/hook_list_scripts.py | $(M
 	$(INSTALL_DATA) $< $@
 
 $(MDDIR)/scripts:
+	$(MKDIR) $@
+
+$(MDDIR)/overrides/main.html: mkdocs/overrides/main.html | $(MDDIR)/overrides
+	$(INSTALL_DATA) $< $@
+
+$(MDDIR)/overrides:
 	$(MKDIR) $@
 
 $(MDDIR)/overrides/partials/copyright.html: mkdocs/overrides/partials/copyright.html | $(MDDIR)/overrides/partials

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -50,6 +50,9 @@ theme:
 # Customization
 extra:
   homepage: index.html
+  # Development builds set GRASS_DOCS_NOINDEX=true so dev pages emit
+  # robots noindex and do not compete with grass-stable in search (see #5935).
+  noindex: !ENV [GRASS_DOCS_NOINDEX, "false"]
   social:
     - icon: simple/opencollective
       link: https://opencollective.com/grass

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -50,9 +50,11 @@ theme:
 # Customization
 extra:
   homepage: index.html
-  # Development builds set GRASS_DOCS_NOINDEX=true so dev pages emit
-  # robots noindex and do not compete with grass-stable in search (see #5935).
-  noindex: !ENV [GRASS_DOCS_NOINDEX, "false"]
+  # Development builds set GRASS_DOCS_NOINDEX=true so dev pages emit robots
+  # noindex and do not compete with grass-stable in search (see #5935). !ENV
+  # YAML-parses the value, so "true"/"false" become booleans; keep the default
+  # an unquoted boolean and test it as truthy in overrides/main.html.
+  noindex: !ENV [GRASS_DOCS_NOINDEX, false]
   social:
     - icon: simple/opencollective
       link: https://opencollective.com/grass

--- a/man/mkdocs/overrides/main.html
+++ b/man/mkdocs/overrides/main.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{#
+  Development builds (GRASS_DOCS_NOINDEX=true, set in documentation.yml when the
+  VERSION micro ends in "dev") emit robots noindex so the dev manuals do not
+  compete with the grass-stable canonical in search. Stable and release builds
+  leave the flag "false" and stay indexable. See OSGeo/grass#5935.
+#}
+{% block extrahead %}
+  {{ super() }}
+  {% if config.extra.noindex == "true" %}
+  <meta name="robots" content="noindex, follow">
+  {% endif %}
+{% endblock %}

--- a/man/mkdocs/overrides/main.html
+++ b/man/mkdocs/overrides/main.html
@@ -8,7 +8,7 @@
 #}
 {% block extrahead %}
   {{ super() }}
-  {% if config.extra.noindex == "true" %}
+  {% if config.extra.noindex %}
   <meta name="robots" content="noindex, follow">
   {% endif %}
 {% endblock %}

--- a/python/grass/docs/_templates/layout.html.template
+++ b/python/grass/docs/_templates/layout.html.template
@@ -1,5 +1,6 @@
 {% extends "!layout.html" %}
 {% block extrahead %}
 <link rel="stylesheet" href="{{ pathto('_static/pygrass.css', 1) }}" type="text/css" />
+{% if grass_noindex %}<meta name="robots" content="noindex, follow" />{% endif %}
 {{ super() }}
 {% endblock %}

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -36,6 +36,10 @@ GRASS Development Team</a>, GRASS ${grass_version} Documentation</p>
 )
 
 grass_version = core.version()["version"]
+# Development builds (e.g. 8.6.0dev) are marked noindex so the dev libpython docs
+# do not compete with the grass-stable canonical in search; stable and release
+# builds stay indexable. Consumed by _templates/layout.html.template (see #5935).
+grass_noindex = grass_version.endswith("dev")
 # Canonical doc URLs point to the stable manuals tree, matching the MkDocs core
 # manuals (man/mkdocs/mkdocs.yml site_url = .../grass-stable/manuals/). Keeping an
 # absolute stable base here keeps every libpython canonical + sitemap <loc> on the
@@ -235,6 +239,9 @@ html_favicon = "_static/favicon.ico"
 # to indicate the location of document using the Canonical Link Relation, and
 # also as the base for the sphinx-sitemap URLs below (they must stay in sync).
 html_baseurl = grass_docs_baseurl
+
+# Expose the noindex flag to layout.html (dev builds emit robots noindex).
+html_context = {"grass_noindex": grass_noindex}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Followup to (PR #5935) to emit 'noindex, follow' on dev builds for both MkDocs and Sphinx. The stable and release builds leave the flag off and stay indexable.