### PR TITLE
r.geomorphon: check region rows against search radius before reading

### DIFF
--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -282,6 +282,15 @@ int main(int argc, char **argv)
         row_radius_size =
             meters ? ceil(search_radius / ns_resolution) : search_radius;
         row_buffer_size = row_radius_size * 2 + 1;
+        /* open_map fills the row buffer by reading row_buffer_size + 1 rows
+         * from the map, so a region with fewer rows than that would die
+         * partway through that read with a confusing low level error. */
+        if (nrows < row_buffer_size + 1)
+            G_fatal_error(
+                _("The current region has only %d rows but search=%s needs "
+                  "at least %d rows. Make the region taller with g.region "
+                  "or use a smaller search value."),
+                nrows, par_search_radius->answer, row_buffer_size + 1);
         search_distance =
             (meters) ? search_radius : ns_resolution * search_cells;
 

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -282,14 +282,12 @@ int main(int argc, char **argv)
         row_radius_size =
             meters ? ceil(search_radius / ns_resolution) : search_radius;
         row_buffer_size = row_radius_size * 2 + 1;
-        /* open_map fills the row buffer by reading row_buffer_size + 1 rows
-         * from the map, so a region with fewer rows than that would die
-         * partway through that read with a confusing low level error. */
+        // open_map fills the row buffer by reading row_buffer_size + 1 rows
         if (nrows < row_buffer_size + 1)
             G_fatal_error(
-                _("The outer search radius (search=%s) exceeds what the "
-                  "north-south extent of the current region (%d rows) can "
-                  "handle. At least %d rows are needed. Set the computational "
+                _("The outer search radius (search=%s) exceeds the "
+                  "north-south extent of the current region (%d rows). "
+                  "At least %d rows are needed. Set larger computational "
                   "region with g.region or use a smaller search value."),
                 par_search_radius->answer, nrows, row_buffer_size + 1);
         search_distance =

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -287,10 +287,11 @@ int main(int argc, char **argv)
          * partway through that read with a confusing low level error. */
         if (nrows < row_buffer_size + 1)
             G_fatal_error(
-                _("The current region has only %d rows but search=%s needs "
-                  "at least %d rows. Make the region taller with g.region "
-                  "or use a smaller search value."),
-                nrows, par_search_radius->answer, row_buffer_size + 1);
+                _("The outer search radius (search=%s) exceeds what the "
+                  "north-south extent of the current region (%d rows) can "
+                  "handle. At least %d rows are needed. Set the computational "
+                  "region with g.region or use a smaller search value."),
+                par_search_radius->answer, nrows, row_buffer_size + 1);
         search_distance =
             (meters) ? search_radius : ns_resolution * search_cells;
 


### PR DESCRIPTION
While working on parallelizing r.geomorphon, I found a small bug in the serial code. 

When the region has fewer rows than the search radius needs, the module fails without saying why. It just gives a confusing library message about the symptom, not the cause. 

This small PR adds an early check with an error message that tells the user their search value needs more rows than the region has, and what the minimum is.