### PR TITLE
CI: drop redundant libpython sitemap after the manuals merge

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -249,6 +249,9 @@ jobs:
             --sphinx-sitemap "${MKDOCS_DIR}/site/libpython/sitemap.xml" \
             --output "${MKDOCS_DIR}/site/sitemap.xml" \
             -o
+          # The libpython URLs are now in the merged manuals sitemap; drop the
+          # standalone libpython sitemap so each URL is listed only once (#5935).
+          rm -f "${MKDOCS_DIR}/site/libpython/sitemap.xml"
 
       - name: Make logs available
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Delete `site/libpython/sitemap.xml` right after the merge, so each URL is listed in exactly one sitemap.