### PR TITLE
docs: fix logic for applying noindex to manuals

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,11 @@ jobs:
       PYTHONWARNINGS: always
       # renovate: datasource=python-version depName=python
       PYTHON_VERSION: "3.14"
+      # Only release-branch builds deploy to the indexable stable trees
+      # (grass-stable / grassNN); everything else (the grass-devel mainline, PRs,
+      # dispatch builds) is noindexed so it never competes with stable in search.
+      # Replaces the fragile version-micro check (see #5935, #7772).
+      GRASS_DOCS_NOINDEX: ${{ !startsWith(github.ref_name, 'releasebranch_') }}
 
     steps:
       - name: Checkout core
@@ -230,13 +235,6 @@ jobs:
           cd ..
           export SITE_NAME="GRASS ${MAJOR}.${MINOR} Documentation"
           export COPYRIGHT="&copy; 2003-$YEAR GRASS Development Team, GRASS $VERSION Documentation"
-          # Development builds (micro ends in "dev") are marked noindex so the dev
-          # manuals do not compete with the grass-stable canonical (see #5935).
-          if [[ "${MICRO}" == *dev ]]; then
-            export GRASS_DOCS_NOINDEX="true"
-          else
-            export GRASS_DOCS_NOINDEX="false"
-          fi
           cd "${MKDOCS_DIR}" || exit
           mkdocs build
 

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -36,10 +36,11 @@ GRASS Development Team</a>, GRASS ${grass_version} Documentation</p>
 )
 
 grass_version = core.version()["version"]
-# Development builds (e.g. 8.6.0dev) are marked noindex so the dev libpython docs
-# do not compete with the grass-stable canonical in search; stable and release
-# builds stay indexable. Consumed by _templates/layout.html.template (see #5935).
-grass_noindex = grass_version.endswith("dev")
+# Development builds on  the main branch are marked noindex so the dev
+# libpython docs do not compete with the grass-stable canonical in search;
+# stable and release builds stay indexable.
+# Consumed by _templates/layout.html.template (see #5935).
+grass_noindex = os.environ.get("GRASS_DOCS_NOINDEX", "false") == "true"
 # Canonical doc URLs point to the stable manuals tree, matching the MkDocs core
 # manuals (man/mkdocs/mkdocs.yml site_url = .../grass-stable/manuals/). Keeping an
 # absolute stable base here keeps every libpython canonical + sitemap <loc> on the


### PR DESCRIPTION
Fixing issue found in PR #7772 that would set the releasebranch_* manuals to noindex because of how the MINOR version was used to check for a development version version release. The check now using the same check as the CI, main or releasebranch_* to determine if the documentation is a development build or a release build. 