### PR TITLE
docs: add lastmod to libpython sitemap entries

### DIFF
--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -15,6 +15,7 @@ import os
 from datetime import date
 import string
 from shutil import copy
+import pathlib
 
 # The grass package is imported from GISBASE, which the build puts on PYTHONPATH.
 if not os.getenv("GISBASE"):
@@ -85,8 +86,47 @@ def skip_member(app, what, name, obj, skip, options):
     return None
 
 
+def _apidoc_lastmod_from_source(app, env):
+    """Stamp sitemap lastmod on generated grass.* API pages.
+
+    autodoc records their dependency against the GISBASE-installed modules
+    (untracked), so sphinx_last_updated_by_git leaves them undated. Fill the gap
+    from the newest git commit in the matching python/grass source directory.
+    """
+    import subprocess
+
+    git_last_updated = getattr(env, "git_last_updated", None)
+    if git_last_updated is None:
+        return
+    confdir = os.path.dirname(os.path.abspath(__file__))
+    for docname in env.found_docs:
+        if docname != "grass" and not docname.startswith("grass."):
+            continue
+        current = git_last_updated.get(docname)
+        if current and current[0]:
+            continue  # keep real dates from the git extension
+        src = os.path.join(confdir, "..", *docname.split(".")[1:])
+        if not pathlib.Path(src).exists():
+            continue
+        try:
+            ts = subprocess.run(
+                ["git", "log", "-1", "--format=%ct", "--", src],
+                cwd=confdir,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        if ts:
+            git_last_updated[docname] = (int(ts), True)
+
+
 def setup(app):
     app.connect("autodoc-skip-member", skip_member)
+    # Run after sphinx_last_updated_by_git (default priority 500) so we only fill
+    # the gaps it leaves for generated apidoc pages, never clobber real dates.
+    app.connect("env-updated", _apidoc_lastmod_from_source, priority=900)
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -480,6 +480,11 @@ todo_include_todos = True
 # URLs exactly; the grass-stable base is already part of html_baseurl (see #5935).
 sitemap_filename = "sitemap.xml"
 sitemap_url_scheme = "{link}"
+# Emit <lastmod> for each page, taken from the git commit date via the
+# sphinx_last_updated_by_git extension (sphinx-sitemap sets it up when this is
+# True). Without it sphinx-sitemap defaults to no lastmod, so libpython entries
+# in the merged manuals sitemap had none while the MkDocs entries did.
+sitemap_show_lastmod = True
 
 sitemap_excludes = [
     "search.html",

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -489,6 +489,10 @@ sitemap_show_lastmod = True
 sitemap_excludes = [
     "search.html",
     "genindex.html",
+    "py-modindex.html",
+    # viewcode source-view pages: low search value and no datable source, so keep
+    # them off the sitemap (they remain reachable from the API pages' [source] links)
+    "_modules/*",
 ]
 
 # Intersphinx config

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -93,11 +93,17 @@ def _apidoc_lastmod_from_source(app, env):
     (untracked), so sphinx_last_updated_by_git leaves them undated. Fill the gap
     from the newest git commit in the matching python/grass source directory.
     """
+    import shutil
     import subprocess
 
     git_last_updated = getattr(env, "git_last_updated", None)
     if git_last_updated is None:
         return
+
+    git = shutil.which("git")
+    if git is None:
+        return
+
     confdir = os.path.dirname(os.path.abspath(__file__))
     for docname in env.found_docs:
         if docname != "grass" and not docname.startswith("grass."):
@@ -110,7 +116,7 @@ def _apidoc_lastmod_from_source(app, env):
             continue
         try:
             ts = subprocess.run(
-                ["git", "log", "-1", "--format=%ct", "--", src],
+                [git, "log", "-1", "--format=%ct", "--", src],
                 cwd=confdir,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION

The libpython (Sphinx) entries in the merged manuals sitemap have no `<lastmod>`, we need to set

`sitemap_show_lastmod = True`

to include the tag.
