### PR TITLE
r.resamp.stats: Fix quantile option being truncated to an integer

### DIFF
--- a/raster/r.resamp.stats/main.c
+++ b/raster/r.resamp.stats/main.c
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
         G_fatal_error(_("Unknown method <%s>"), parm.method->answer);
 
     if (menu[method].method == c_quant) {
-        quantile = atoi(parm.quantile->answer);
+        quantile = atof(parm.quantile->answer);
         closure = &quantile;
     }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p></p><h2>Summary</h2><p><code inline="">quantile</code> is stored as a <code inline="">double</code>, but its value was parsed using <code inline="">atoi()</code>, causing any value less than <code inline="">1.0</code> to be truncated to <code inline="">0</code>. As a result, <code inline="">c_quant()</code> always received <code inline="">0</code> as the requested quantile, returning the minimum value. This meant that <code inline="">method=quantile</code> effectively behaved as <code inline="">method=minimum</code>, and the <code inline="">quantile</code> option had no effect.</p><h2>Verification</h2><p>Verified on the <code inline="">nc_spm_08_grass7</code> dataset with <code inline="">res=100</code>:</p>
Comparison | Difference
-- | --
quantile=0.5 vs. minimum | 0 ... 0 (identical)
quantile=0.9 vs. minimum | 0 ... 0 (identical)
quantile=0.5 vs. median | -21.67 ... 0 (expected to be 0)

<h2>Fix</h2><p>Replace <code inline="">atoi()</code> with <code inline="">atof()</code> so fractional quantile values are parsed correctly.</p><p>This matches the implementation used by other GRASS modules exposing the same option, including:</p><ul><li><p><code inline="">r.neighbors</code></p></li><li><p><code inline="">r.series</code></p></li><li><p><code inline="">r3.neighbors</code></p></li></ul><h2>Notes</h2><p>Found while reviewing #7044 and submitted as a separate PR, as requested, to keep the fix independent.</p></body></html><!--EndFragment-->
</body>
</html>