### PR TITLE
r.reclass.area: preserve backwards compatibility

### DIFF
--- a/scripts/r.reclass.area/r.reclass.area.html
+++ b/scripts/r.reclass.area/r.reclass.area.html
@@ -27,9 +27,9 @@ the <strong>-v</strong> flag the <strong>output</strong> is the filtered
 vector map instead of a raster.
 
 An important difference between the two methods with regard to
-the<strong>lower</strong>strong> area size threshold is that
-<strong>method=reclass</strong>strong> deletes these areas, whereas
-<strong>method=rmarea</strong>strong> tries to merge these small areas
+the <strong>lower</strong> area size threshold is that
+<strong>method=reclass</strong> deletes these areas, whereas
+<strong>method=rmarea</strong> tries to merge these small areas
 with a neighbouring larger area if existing. Details are explained in
 <a href="v.clean.md">v.clean</a> describing the behaviour of
 <strong>tool=rmarea</strong>.

--- a/scripts/r.reclass.area/r.reclass.area.html
+++ b/scripts/r.reclass.area/r.reclass.area.html
@@ -26,6 +26,14 @@ href="v.clean.md">v.clean</a> and <a href="v.edit.md">v.edit</a>. With
 the <strong>-v</strong> flag the <strong>output</strong> is the filtered
 vector map instead of a raster.
 
+An important difference between the two methods with regard to
+the<strong>lower</strong>strong> area size threshold is that
+<strong>method=reclass</strong>strong> deletes these areas, whereas
+<strong>method=rmarea</strong>strong> tries to merge these small areas
+with a neighbouring larger area if existing. Details are explained in
+<a href="v.clean.md">v.clean</a> describing the behaviour of
+<strong>tool=rmarea</strong>.
+
 <h2>EXAMPLES</h2>
 
 In this example, the ZIP code map in the North Carolina sample dataset

--- a/scripts/r.reclass.area/r.reclass.area.md
+++ b/scripts/r.reclass.area/r.reclass.area.md
@@ -21,6 +21,13 @@ areas outside the given thresholds using [v.clean](v.clean.md) and
 [v.edit](v.edit.md). With the **-v** flag the **output** is the
 filtered vector map instead of a raster.
 
+An important difference between the two methods with regard to the
+**lower** area size threshold is that **method=reclass** deletes
+these areas, whereas **method=rmarea** tries to merge these small
+areas with a neighbouring larger area if existing. Details are
+explained in [v.clean](v.clean.md) describing the behaviour of
+**tool=rmarea**.
+
 ## EXAMPLES
 
 In this example, the ZIP code map in the North Carolina sample dataset

--- a/scripts/r.reclass.area/r.reclass.area.py
+++ b/scripts/r.reclass.area/r.reclass.area.py
@@ -304,6 +304,8 @@ def rmarea(
         edit_vector = cleanfile
 
     # Apply upper threshold
+    # contrary to the lower threshold, areas larger than threshold are
+    # not merged with a neighbour, but deleted
     if upper:
         tools.v_to_db(
             map=edit_vector,
@@ -355,7 +357,16 @@ def main() -> None:
                 "Use 'lower' and/or 'upper'.",
             ),
         )
-        options["lower" if options["mode"] == "greater" else "upper"] = options["value"]
+        # backwards compatibility for mixed-up logic in previous version
+        # of r.reclass.area
+        if options["method"] == "rmarea":
+            options["lower" if options["mode"] == "lesser" else "upper"] = options[
+                "value"
+            ]
+        else:
+            options["lower" if options["mode"] == "greater" else "upper"] = options[
+                "value"
+            ]
 
     # Define filter thresholds
     lower = float(options["lower"]) if options["lower"] else None


### PR DESCRIPTION
Up to G85, there was a inconsistency in the behaviour of `r.reclass.area`: `mode=lesser method=rmarea` removed areas smaller than `value`, whereas `mode=lesser method=reclass` removed areas larger than `value`.

PR #7337 fixed this inconsistend behaviour with the introduction of the new options `lower` and `upper`, replacing the `mode` and `value` options up to G85. This is great! But handling of backwards compatibility did not take into account the inconsistency in the behaviour up to G85. This PR fixes the backwards compatibility of PR #7337.