### PR TITLE
CMake: Rebuild g.gui.* modules when their sources change

### DIFF
--- a/cmake/modules/build_gui_in_subdir.cmake
+++ b/cmake/modules/build_gui_in_subdir.cmake
@@ -47,6 +47,7 @@ function(build_gui_in_subdir dir_name)
             ${CMAKE_COMMAND} -E copy_if_different ${PYTHON_FILES}
             "${OUTDIR}/${GRASS_INSTALL_GUIDIR}/wxpython/${G_NAME}"
         COMMAND ${CMAKE_COMMAND} -E touch ${GUI_STAMP_FILE}
+        DEPENDS ${PYTHON_FILES}
     )
 
     set(OUT_SCRIPT_FILE


### PR DESCRIPTION
Editing a `g.gui.*` module's source (e.g. `gui/wxpython/tplot/frame.py`) and   rebuilding did not update the copy in the output tree. The custom command that  copies a module's Python files produces only a stamp file and declared no  inputs, so once the stamp existed the build system treated it as permanently up  to date. The only workaround was deleting the stamp by hand.