### PR TITLE
CMake: Copy proj tables to build output tree

### DIFF
--- a/lib/proj/CMakeLists.txt
+++ b/lib/proj/CMakeLists.txt
@@ -21,6 +21,19 @@ build_module(
     INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/../driver"
 )
 
+add_custom_command(
+    TARGET grass_gproj
+    POST_BUILD
+    COMMAND
+        ${CMAKE_COMMAND} -E make_directory
+        ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/proj
+    COMMAND
+        ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/desc.table
+        ${CMAKE_CURRENT_SOURCE_DIR}/parms.table
+        ${CMAKE_CURRENT_SOURCE_DIR}/units.table
+        ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/proj
+)
+
 target_include_directories(
     grass_gproj
     INTERFACE


### PR DESCRIPTION
When testing data catalog with cmake build, this came up.
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/akratoc/dev/grass/grass_main/build/output/lib/grass86/etc/proj/parms.table'
```
The problem is only when running GRASS from the cmake build tree, installed GRASS should be fine.