### PR TITLE
grass.pygrass: Fix resource_tracker semaphore warning at exit

### DIFF
--- a/python/grass/pygrass/rpc/base.py
+++ b/python/grass/pygrass/rpc/base.py
@@ -206,8 +206,13 @@ class RPCServerBase:
                     ]
                 )
             self.server.terminate()
+            # A process still starting up reopens the lock semaphore by name,
+            # so it must be gone before the reference is dropped below.
+            self.server.join(timeout=5)
         if self.client_conn is not None:
             self.client_conn.close()
+        # Dropping the reference unlinks the semaphore now, not at exit.
+        self.lock = None
         self.stopped = True
 
 


### PR DESCRIPTION
Closes #7832 

Unlink the RPC server lock semaphore when the server is stopped, so temporal tools no longer emit a resource_tracker warning at exit.

**Note** :- `Messenger` holds the same kind of lock, but bisecting showed only the CLibrariesInterface lock survives to shutdown, so changing its `stop()` would fix nothing.

@petrasovaa 