### PR TITLE
r.coin: Fail when r.stats returns no data

### DIFF
--- a/raster/r.coin/make_coin.c
+++ b/raster/r.coin/make_coin.c
@@ -74,6 +74,12 @@ int make_coin(void)
 
     G_popen_close(&child);
 
+    /* Without this, an empty result reaches collapse(), which counts from one
+       and reports a single category, and that category is then read from a
+       zero length allocation. */
+    if (count == 0)
+        G_fatal_error(_("No data returned from r.stats"));
+
     fclose(stat_fp);
 
     stat_fp = fopen(statname, "r");

--- a/raster/r.coin/tests/test_coin.py
+++ b/raster/r.coin/tests/test_coin.py
@@ -1,4 +1,7 @@
+import pytest
+
 import grass.script as gs
+from grass.exceptions import CalledModuleError
 
 
 def validate_r_coin_output(actual_results, expected_results):
@@ -61,3 +64,21 @@ def test_r_coin(setup_maps):
 
     # Validate results
     validate_r_coin_output(actual_results, expected_results)
+
+
+def test_r_coin_errors_without_data(setup_maps):
+    """r.coin reports an error when r.stats returns no data
+
+    Two maps holding only NULL cells make r.stats produce no output, since
+    r.coin runs it with the flag that skips the no data value. r.coin used to
+    print a normal looking report for a single category 0, whose value came
+    from a zero length allocation, and exit successfully.
+    """
+    session = setup_maps
+    gs.mapcalc("empty1 = null()", overwrite=True, env=session.env)
+    gs.mapcalc("empty2 = null()", overwrite=True, env=session.env)
+
+    with pytest.raises(CalledModuleError):
+        gs.run_command(
+            "r.coin", first="empty1", second="empty2", units="c", env=session.env
+        )


### PR DESCRIPTION
Fixes #7734.

When `r.stats` produces no output, `make_coin()` parsed zero records and nothing noticed:

- the read loop ends without entering the "Unexpected output from r.stats" branch, which only catches malformed lines
- the category lists are then allocated with `G_calloc(0, ...)`
- `collapse()` starts its counter at 1, so an empty list still reports one category
- that category's value is read from the zero length allocation, which is undefined behaviour and in practice reads as 0

The result was a normal looking coincidence report for a single category 0, with `EXIT_SUCCESS`. A failure of `r.stats` was indistinguishable from a valid result, which is how it went unnoticed in the OSGeo4W CI in #7732.

Treating zero records as an error also removes the read from the zero length allocation.

I have not done the second improvement suggested in the issue, checking the child's exit status, because `G_popen_close()` discards it and that is a `lib/gis` change.

## Reproducing it

Two maps of only NULL cells are enough, since `r.coin` runs `r.stats` with the flag that skips the no data value, so nothing is printed:

```
r.mapcalc "empty1 = null()"
r.mapcalc "empty2 = null()"
r.coin first=empty1 second=empty2 units=c
```

Before, that prints a full report with `cat# 0` and all zeros, and exits 0. After, it exits 1 with `ERROR: No data returned from r.stats`.

## Tests

`test_r_coin_errors_without_data` in the existing `raster/r.coin/tests/test_coin.py` does exactly the above and expects the module to fail. Checked against the unfixed build, where it fails with `DID NOT RAISE CalledModuleError`; the existing `test_r_coin` passes either way. `clang-format` and `ruff` report no changes.

I used an AI assistant while preparing this. I understand the change and can explain it.
