### PR TITLE
init: do not fail if no shell and no GUI is available

### DIFF
--- a/lib/init/grass.md
+++ b/lib/init/grass.md
@@ -116,7 +116,8 @@ interface and mapset selected.
 If you specify a graphical user interface (**--gui**) the *grass*
 program will try to verify that the system you specified exists and that
 you can access it successfully. If any of these checks fail then *grass*
-will automatically switch back to the text user interface mode.
+will automatically switch back to the text user interface mode. Note:
+text mode requires an interactive shell terminal e.g. xterm.
 
 ### Running non-interactive jobs
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2506,7 +2506,7 @@ def main() -> None:
             shell_process = None
 
         # start GUI and register shell PID in rc file
-        gui_process = start_gui(grass_gui) if grass_gui == "wxpython" else None
+        gui_process = start_gui(grass_gui)
 
         if shell_process:
             kv = {}

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2317,6 +2317,19 @@ def main() -> None:
             grass_gui = read_gui(gisrc, default_gui)
         # check that the GUI works but only if not doing a batch job
         grass_gui = check_gui(expected_gui=grass_gui)
+        if not use_shell and grass_gui == "text":
+            # Without a shell, the GUI is the only way to interact with the
+            # session, so there is nothing left to start. check_gui() has
+            # already reported why the GUI is not available.
+            fatal(
+                _(
+                    "Neither an interactive terminal nor a graphical user"
+                    " interface is available.\n"
+                    "Run {cmd_name} from a terminal, use --exec to run"
+                    " a command, or use --text to read commands from"
+                    " standard input."
+                ).format(cmd_name=CMD_NAME)
+            )
         # save GUI only if we are not doibg batch job
         save_gui(gisrc, grass_gui)
 
@@ -2493,7 +2506,7 @@ def main() -> None:
             shell_process = None
 
         # start GUI and register shell PID in rc file
-        gui_process = start_gui(grass_gui)
+        gui_process = start_gui(grass_gui) if grass_gui == "wxpython" else None
 
         if shell_process:
             kv = {}
@@ -2505,7 +2518,7 @@ def main() -> None:
             exit_val = shell_process.wait()
             if exit_val != 0:
                 warning(_("Failed to start shell '%s'") % os.getenv("SHELL"))
-        else:
+        elif gui_process:
             gui_process.wait()
 
         # close GUI if running


### PR DESCRIPTION
`check_gui` can return None and there is no guard before call `gui_process.wait()`.

As this state can be reached only on a broken setup, it makes sense to just warn user and exit.
Discovered by a wrong Docker usage – not common, but also possible to reach.

Co-authored with Claude Opus 5

Test: `env -u DISPLAY grass /path/to/mapset < /dev/null`