### PR TITLE
lib/vector: Reject out of range categories when reading ASCII

### DIFF
--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -219,6 +219,17 @@ int Vect_read_ascii(FILE *ascii, struct Map_info *Map)
                 goto cleanup_exit;
             }
 
+            /* Vect_cat_set() has its range check commented out, so an
+               out-of-range value read here would be stored and only cause
+               trouble later, for example on export. */
+            if (catn < 1 || cat < 0) {
+                G_warning(_("Layer number or category number out of range: "
+                            "[%s]"),
+                          buff);
+                n_lines = -1;
+                goto cleanup_exit;
+            }
+
             Vect_cat_set(Cats, catn, cat);
         }
 

--- a/vector/v.in.ascii/tests/conftest.py
+++ b/vector/v.in.ascii/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+import grass.script as gs
+
+
+@pytest.fixture
+def xy_session(tmp_path):
+    """Active session in an XY project"""
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        yield session

--- a/vector/v.in.ascii/tests/v_in_ascii_categories_test.py
+++ b/vector/v.in.ascii/tests/v_in_ascii_categories_test.py
@@ -1,0 +1,61 @@
+"""Tests for category values read from the standard format
+
+Vect_cat_set() has its range check commented out, so a category read from an
+ASCII file was stored whatever its value. A negative one survived the import
+and only caused trouble later: v.out.ogr skipped such a point without -c and
+exported it twice with it (https://github.com/OSGeo/grass/issues/6563).
+"""
+
+import pytest
+
+import grass.script as gs
+from grass.exceptions import CalledModuleError
+
+VALID = "P 1 1\n0 0\n1 1\nP 1 1\n1 0\n1 2\n"
+NEGATIVE_CATEGORY = "P 1 1\n0 0\n1 1\nP 1 1\n1 0\n1 -2147483647\n"
+ZERO_LAYER = "P 1 1\n0 0\n0 5\n"
+ZERO_CATEGORY = "P 1 1\n0 0\n1 0\n"
+
+
+def import_ascii(session, tmp_path, text, name):
+    path = tmp_path / f"{name}.txt"
+    path.write_text(text)
+    gs.run_command(
+        "v.in.ascii",
+        input=str(path),
+        output=name,
+        format="standard",
+        flags="n",
+        overwrite=True,
+        env=session.env,
+    )
+
+
+def test_valid_categories_are_imported(xy_session, tmp_path):
+    """A file with ordinary categories still imports"""
+    import_ascii(xy_session, tmp_path, VALID, "valid")
+    categories = gs.read_command(
+        "v.category", input="valid", option="print", env=xy_session.env
+    )
+    assert categories.split() == ["1", "2"]
+
+
+def test_zero_category_is_accepted(xy_session, tmp_path):
+    """Category 0 is allowed, since OGR layers use it"""
+    import_ascii(xy_session, tmp_path, ZERO_CATEGORY, "zerocat")
+    categories = gs.read_command(
+        "v.category", input="zerocat", option="print", env=xy_session.env
+    )
+    assert categories.split() == ["0"]
+
+
+def test_negative_category_is_rejected(xy_session, tmp_path):
+    """A negative category fails the import instead of being stored"""
+    with pytest.raises(CalledModuleError):
+        import_ascii(xy_session, tmp_path, NEGATIVE_CATEGORY, "negcat")
+
+
+def test_zero_layer_is_rejected(xy_session, tmp_path):
+    """Layer numbers start at 1, so 0 fails the import"""
+    with pytest.raises(CalledModuleError):
+        import_ascii(xy_session, tmp_path, ZERO_LAYER, "zerolayer")


### PR DESCRIPTION
Fixes #6563.

`Vect_read_ascii()` passed the layer and category it parsed straight to `Vect_cat_set()`. That function's own range check is commented out — deliberately, with a note about the portable type length — so a value outside the documented `1 - GV_CAT_MAX` range was accepted and stored, and only caused trouble much later.

That is what the issue reports: a point carrying `-2147483647` was skipped by `v.out.ogr` without `-c`, and exported **twice** with it.

@metzm's comment on the issue identified the real cause — negative categories should not have been accepted in the first place — so this rejects the feature at import rather than trying to make the export cope with it.

Category 0 stays allowed, since OGR layers use it (per "Categories and Layers" in the Programmer's Manual). Layer numbers start at 1, so 0 is rejected.

## Reproducing it

```
printf "P 1 1\n0 0\n1 1\nP 1 1\n1 0\n1 -2147483647\n" | \
  v.in.ascii -n input=- output=pts format=standard
```

Before: imports silently, `v.category ... option=print` shows `-2147483647`.
After: `WARNING: Layer number or category number out of range: [1 -2147483647]` and the import fails.

## Tests

`vector/v.in.ascii/tests/v_in_ascii_categories_test.py` covers the negative category and layer 0 being rejected, plus ordinary categories and category 0 still importing. Checked against the unfixed build, where the two rejection tests fail with `DID NOT RAISE CalledModuleError` and the two happy-path tests pass either way. `clang-format` and `ruff` report no changes.

I used an AI assistant while preparing this. I understand the change and can explain it.
