### PR TITLE
doc: remove stale fields in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,6 @@
 cff-version: 1.2.0
 title: "GRASS"
 message: "If you use this software, please cite it using the metadata from this file."
-version: 8.4.2
 abstract: "GRASS, Geographic Resources Analysis Support System, is a powerful computational engine for raster, vector, and geospatial processing. It supports terrain and ecosystem modeling, hydrology, data management, and imagery processing. With a built-in temporal framework and Python API, it enables advanced time series analysis and rapid geospatial programming, optimized for large-scale analysis on various hardware configurations."
 type: software
 authors:
@@ -109,7 +108,6 @@ authors:
 repository-code: "https://github.com/OSGeo/grass"
 license: "GPL-2.0-or-later"
 doi: "10.5281/zenodo.5176030"
-date-released: 2025-11-27
 keywords:
   - "GIS"
   - "geospatial"


### PR DESCRIPTION
In CITATION.CFF version and date-released would have to be updated for each release, and given they are optional and haven't been updated, it's better to remove them. Zenodo uses the github release info instead.