### PR TITLE
contributing: Add a testing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,51 +120,33 @@ pytest raster/r.slope.aspect/tests/r_slope_aspect_test.py
 ```
 
 **Run gunittest-style tests** (legacy `testsuite/` directories; currently the
-only way to use larger datasets like the `nc_spm` sample dataset) by creating a
-throwaway mapset in an existing project (judge by exit code, not the verbose
-output):
+only way to use larger datasets like the `nc_spm` sample dataset) in a
+temporary mapset, which is created and removed for each run (judge by exit
+code, not the verbose output):
 
 ```bash
-grass -c <project>/<mapset> --exec ./test_x.py
+cd raster/r.slope.aspect/testsuite
+grass --tmp-mapset ~/grassdata/nc_spm_08_grass7/ \
+    --exec python test_r_slope_aspect.py
 ```
+
+The test files are not executable, so `--exec` needs `python` in front of the
+file name. Some tests load data files by relative path, so run them from their
+own directory. Do not use `grass -c <project>/<mapset>`: it fails on the
+second run because the mapset already exists.
 
 ## Writing Tests
 
-Write new tests in pytest unless the test requires the NC SPM sample dataset
-(a real-world dataset used for integration tests).
+See `doc/development/testing.md` for the testing conventions: when to use
+pytest versus gunittest, where test files go and how they are named, how to
+get a GRASS session in a pytest test, how to use `grass.tools`, how to
+generate test data, and how to run the tests. The notes below add what is
+specific to working as an agent.
 
-Test files follow two patterns:
-
-- `*/tests/*_test.py` or `*/tests/test_*.py` — pytest style (use this for
-  new tests); `*_test.py` is more common
-- `*/testsuite/test_*.py` — gunittest style (use only when the test requires
-  the NC SPM sample dataset)
-
-Test file names must include the tool name with underscores
-(e.g., `r_slope_aspect` for *r.slope.aspect*). If a tool has multiple
-test files, add the tested feature or domain (e.g.,
-`r_slope_aspect_angles_test.py`, `r_slope_aspect_memory_test.py`).
-Tests of libraries, packages, and modules should have the full name of the
-unit included with the added feature or domain info if needed.
-
-pytest configuration is in `pyproject.toml`. pytest tests require a running
-GRASS session with a project/mapset; see
-`raster/r.slope.aspect/tests/conftest.py` for a representative session
-fixture. For new pytest tests, use `grass.tools` with `Tools`: the `Tools`
-object needs `session=session` (or `env=session.env`) at creation, but
-individual tool calls do not need `env`. When using `grass.script` in
-pytest, every call (`gs.run_command()`, `gs.parse_command()`, etc.) must
-pass `env=session.env` explicitly. gunittest-style tests (`testsuite/`) run
-in an existing GRASS session and need neither `Tools` setup nor `env`
-passing.
-
-Always create sessions with `gs.setup.init(project, env=os.environ.copy())`,
-never `gs.setup.init(project)`. Without `env`, the session is set up in the
-global `os.environ`, and `init()` prepends the GRASS executable paths to
-`PATH` on every call without removing them again, so `PATH` keeps growing for
-the rest of the pytest process. Tests are not isolated from each other:
-pytest runs them in one process, and a later test which copies `os.environ`
-inherits whatever earlier tests left there.
+When using `grass.script` in pytest, every call (`gs.run_command()`,
+`gs.parse_command()`, etc.) must pass `env=session.env` explicitly.
+gunittest-style tests (`testsuite/`) run in an existing GRASS session and need
+neither `Tools` setup nor `env` passing.
 
 Some APIs, notably `grass.temporal`, still read the session from
 `os.environ` and cannot take an `env`. When a test needs one of those, create
@@ -182,11 +164,6 @@ pass an `io.StringIO` object as the parameter value (e.g.,
 `input=StringIO(ascii_text)`); `Tools` converts it to `-` and pipes the
 content automatically.
 
-Test data can be created in several ways: `r.mapcalc` raster algebra
-expressions (e.g., `elevation = 6 - col()`), numpy arrays, GRASS tools
-that generate synthetic data (e.g., `r.surf.fractal` for elevation-like
-surfaces), and import tools like `r.in.ascii`, `v.in.ascii` (CSV
-coordinates), or standard format importers (e.g., GeoJSON for vector data).
 When the goal is to get a numpy array result in Python (rather than
 creating a named raster in the project), `r.mapcalc.simple`
 (`r_mapcalc_simple`) is easier to use than `r.mapcalc`. To convert an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,8 @@ Further notes for various platforms can be found on a dedicated
 [wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install).
 
 Before creating a PR, please test your changes.
-Refer to [testing README](./testsuite/README.md) for details.
+See the [testing documentation](./doc/development/testing.md) for how to run
+the tests and how to write new ones.
 Once you create a PR, a series of automated checks which will run on your pull request.
 This is a part of the standard iterative process of integrating
 changes into the main code, so if that happens,

--- a/doc/development/CMakeLists.txt
+++ b/doc/development/CMakeLists.txt
@@ -3,6 +3,7 @@ set(web_only_doc_files
     investigating_history
     style_guide
     building_with_cmake
+    testing
 )
 
 add_custom_target(

--- a/doc/development/Makefile
+++ b/doc/development/Makefile
@@ -6,6 +6,7 @@ MDFILES := \
 	github_guide.md \
 	investigating_history.md \
 	style_guide.md \
-	building_with_cmake.md
+	building_with_cmake.md \
+	testing.md
 
 default: $(patsubst %,$(MDDIR)/source/%,$(MDFILES))

--- a/doc/development/README.md
+++ b/doc/development/README.md
@@ -10,6 +10,11 @@ maintaining GRASS.
 - [GRASS Programming Style Guide](style_guide.md)
 - [Guide to contributing on GitHub](github_guide.md)
 
+## Testing
+
+- [Testing GRASS](testing.md)
+- ["grass.gunittest" documentation](https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html)
+
 ## Python API
 
 - ["grass" Python package documentation](https://grass.osgeo.org/grass-devel/manuals/libpython/)

--- a/doc/development/style_guide.md
+++ b/doc/development/style_guide.md
@@ -7,9 +7,10 @@
     4. [Documentation](#documentation)
 2. [Best Practices](#best-practices)
     1. [General](#general)
-    2. [Python scripts](#developing-python-scripts)
-    3. [GRASS Addons](#developing-grass-addons)
-    4. [GRASS GUI](#developing-grass-gui)
+    2. [Testing](#testing)
+    3. [Python scripts](#developing-python-scripts)
+    4. [GRASS Addons](#developing-grass-addons)
+    5. [GRASS GUI](#developing-grass-gui)
 
 ## Code Style and Formatting
 
@@ -491,6 +492,20 @@ multiple sentences should end with periods. Short phrases should not.
 Punctuated events, such as errors, deserve a period, e.g., _"Operation
 complete."_ Phrases which imply ongoing action should have an ellipse, e.g.,
  _"Reading raster map..."_.
+
+### Testing
+
+New code should come with tests, and a bug fix should come with a test which
+fails without the fix. When the code being fixed has no tests at all, add a
+test for its basic functionality as well.
+
+**Why?** A test which only reproduces the bug shows that the fix works, but it
+says nothing about the behavior which was already correct. A test of the basic
+functionality is what shows that the fix did not break it.
+
+Write new tests with _pytest_ and place them in a `tests` directory next to
+the code they test. See the [testing documentation](testing.md) for the
+conventions, examples, and how to run the tests.
 
 ### Developing Python scripts
 

--- a/doc/development/testing.md
+++ b/doc/development/testing.md
@@ -1,0 +1,182 @@
+# Testing
+
+New code should come with tests, and a bug fix should come with a test which
+fails without the fix; when the code being fixed has no tests at all, add a
+test for its basic functionality as well, so it is clear the fix did not break
+it.
+
+GRASS has two testing frameworks. Use _pytest_ for everything new. Use the
+older _grass.gunittest_ framework when the test needs the North Carolina
+sample dataset, or when it needs data supplied as files. Neither is currently
+possible with _pytest_.
+
+The two live side by side in the source tree: _pytest_ tests go into a
+`tests` directory next to the code they test, _grass.gunittest_ tests into a
+`testsuite` directory.
+
+## Running tests
+
+Running tests requires a built and installed GRASS with the `grass` command
+available. Point Python at that installation first:
+
+```bash
+export PYTHONPATH="$(grass --config python_path):${PYTHONPATH}"
+export LD_LIBRARY_PATH="$(grass --config path)/lib:${LD_LIBRARY_PATH}"
+```
+
+Then run the tests of the tool you are working on:
+
+```bash
+pytest raster/r.slope.aspect/tests/
+```
+
+Running `pytest` without a path from the top of the source tree collects the
+`testsuite` directories as well, because the collection patterns in
+`pyproject.toml` include them. Most _grass.gunittest_ tests need a GRASS
+session and the sample dataset, so they fail when run this way. Exclude them
+as the CI does:
+
+```bash
+pytest -k "not testsuite"
+```
+
+A _grass.gunittest_ test runs inside a GRASS session instead. Give it a
+temporary mapset, which is created and removed for each run:
+
+```bash
+cd raster/r.slope.aspect/testsuite
+grass --tmp-mapset ~/grassdata/nc_spm_08_grass7/ \
+    --exec python test_r_slope_aspect.py
+```
+
+The test files are not executable, so `--exec` needs `python` in front of
+the file name, and some of them load data files by relative path, so run them
+from their own directory.
+
+## Writing pytest tests
+
+### File placement and naming
+
+Tests of a tool go next to it, in a `tests` directory, in a file named after
+the tool with dots replaced by underscores, e.g.
+`raster/r.slope.aspect/tests/r_slope_aspect_test.py`. When a tool needs more
+than one file, add the feature or domain under test, e.g.
+`r_slope_aspect_memory_test.py`. Tests of libraries and packages use the full
+name of the unit the same way, e.g. `lib/gis/tests/lib_gis_env_test.py`.
+
+Both `<name>_test.py` and `test_<name>.py` are collected, so either is fine;
+`<name>_test.py` is the more common form in the source tree.
+
+### Session fixture
+
+Most tests need a GRASS session with a project and some data, so they set one
+up in a fixture. Putting the fixture in a `conftest.py` file next to the tests
+is not required, but it is common, because it keeps the setup separate from
+the tests and lets several test files share it. This is the session fixture
+used by the _r.slope.aspect_ tests, in
+`raster/r.slope.aspect/tests/conftest.py`:
+
+```python
+import os
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
+
+
+@pytest.fixture
+def xy_dataset_session(tmp_path):
+    """Active session in an XY project with a raster (scope: function)"""
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with (
+        gs.setup.init(project, env=os.environ.copy()) as session,
+        Tools(session=session) as tools,
+    ):
+        tools.g_region(s=0, n=5, w=0, e=6, res=1)
+        tools.r_mapcalc(expression="rows_raster = row()")
+        yield session
+```
+
+Always pass `env=os.environ.copy()` to `gs.setup.init()`, never call
+`gs.setup.init(project)` on its own. Without it the session modifies the
+global environment, and since all tests run in the same process, a later test
+which copies `os.environ` inherits whatever earlier tests left behind.
+
+Create an XY project, as above, unless the test is about coordinate
+reference systems or needs real ground units; then pass `epsg` to
+`gs.create_project()`.
+
+Creating a project and its data for every test is fine when the data is small,
+as above. When the data is large, plentiful, or expensive to compute, give the
+session fixture module scope so the tests share it, and add a function-scoped
+fixture using `TemporaryMapsetSession` from `grass.experimental`. Each test
+then gets its own mapset in the shared project, which keeps the tests isolated
+from each other. This suits most tool tests; tests of data management tools
+often need something else. `raster/conftest.py` follows this pattern.
+
+Fixtures in a `conftest.py` are available to all tests below it in the
+directory tree, so a fixture useful to a whole group of tools can live higher
+up. The `raster`, `vector`, and `scripts` directories each have one, and many
+`tests` directories use those instead of defining their own. The source tree
+has many more examples than this page can show.
+
+### Test functions
+
+A test asks the fixture for the session and runs tools against it:
+
+```python
+from grass.tools import Tools
+
+
+def test_slope_of_constant_slope_raster(xy_dataset_session):
+    """Slope of a raster with a constant slope is constant"""
+    tools = Tools(session=xy_dataset_session)
+    tools.r_slope_aspect(elevation="rows_raster", slope="slope")
+    stats = tools.r_univar(map="slope", format="json")
+    assert stats["min"] == 45
+    assert stats["max"] == 45
+```
+
+A result gives access to the output in several ways: `text`, `stdout`,
+`keyval` for `format="shell"`, and `json` for `format="json"`, which can also
+be subscripted directly as above. See the `Tools` documentation for the rest.
+
+### Test data
+
+Where possible, generate small, deterministic data instead of using data
+files. Raster algebra with _r.mapcalc_ covers most needs, using `row()` and
+`col()` for predictable values, e.g. `elevation = 6 - col()`. Vector data can
+come from _v.random_ with a fixed `seed`, or from _v.in.ascii_ and
+_r.in.ascii_, which accept an `io.StringIO` object as their input parameter.
+NumPy arrays can be passed to tools and requested back from them through
+_grass.tools_.
+
+When the test needs specific data which cannot be generated, the data has to
+be supplied as files, which is currently possible only with _grass.gunittest_
+in a `testsuite` directory.
+
+### Tests which run in parallel
+
+Tests run in parallel, several per process, so a test which changes
+`os.environ` can break unrelated tests running next to it. This applies to
+rendering and to _grass.temporal_, which reads the session from the global
+environment. Mark such a test so it is run on its own:
+
+```python
+@pytest.mark.needs_solo_run
+def test_something_which_changes_the_environment(xy_dataset_session):
+    ...
+```
+
+## More information
+
+- [grass.gunittest documentation](https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html)
+  for writing and running _grass.gunittest_ tests
+- [testsuite/README.md](https://github.com/OSGeo/grass/blob/main/testsuite/README.md)
+  for the sample datasets and continuous integration
+- [pytest documentation](https://docs.pytest.org/) for fixtures,
+  `parametrize`, and `pytest.raises`
+- [AGENTS.md](https://github.com/OSGeo/grass/blob/main/AGENTS.md) for
+  additional instructions for AI assistants and agents

--- a/doc/development/testing.md
+++ b/doc/development/testing.md
@@ -51,7 +51,8 @@ grass --tmp-mapset ~/grassdata/nc_spm_08_grass7/ \
 
 The test files are not executable, so `--exec` needs `python` in front of
 the file name, and some of them load data files by relative path, so run them
-from their own directory.
+from their own directory. The North Carolina sample dataset used above is
+available from <https://grass.osgeo.org/sampledata/north_carolina/>.
 
 ## Writing pytest tests
 
@@ -175,7 +176,7 @@ def test_something_which_changes_the_environment(xy_dataset_session):
 - [grass.gunittest documentation](https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html)
   for writing and running _grass.gunittest_ tests
 - [testsuite/README.md](https://github.com/OSGeo/grass/blob/main/testsuite/README.md)
-  for the sample datasets and continuous integration
+  for the root testsuite directory and continuous integration
 - [pytest documentation](https://docs.pytest.org/) for fixtures,
   `parametrize`, and `pytest.raises`
 - [AGENTS.md](https://github.com/OSGeo/grass/blob/main/AGENTS.md) for

--- a/man/mkdocs/docs/development_intro.md
+++ b/man/mkdocs/docs/development_intro.md
@@ -15,7 +15,8 @@ title: Development Introduction
 
 ## Testing
 
-- [Testing](https://grass.osgeo.org/grass-stable/manuals/libpython/gunittest_testing.html)
+- [Testing](testing.md)
+- [grass.gunittest](https://grass.osgeo.org/grass-stable/manuals/libpython/gunittest_testing.html)
 
 ## Addons
 

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -7,6 +7,8 @@ without a focus on a specific part of the code.
 
 There are two testing mechanism in place, _pytest_ which is the modern way of testing
 GRASS. Tests using _pytest_ are written just as any other Python tests.
+See the [testing documentation](../doc/development/testing.md) for the GRASS
+_pytest_ conventions, including test placement, session fixtures, and test data.
 
 In parallel, there is also custom unittest-based framework centered around
 _grass.gunittest_ package. These tests run in the NC sample datasets and can be

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -3,38 +3,12 @@
 <!-- markdownlint-disable-next-line line-length -->
 Tests are in directories `tests` and `testsuite` under each directory which has tests.
 This directory contains additional scripts and information to test functionality
-without a focus on a specific part of the code.
+without a focus on a specific part of the code. Currently, that is
+`raster_md5test.sh`, a shell test which runs in a GRASS session and is
+collected by _grass.gunittest_ like any other test in a `testsuite` directory.
 
-There are two testing mechanism in place, _pytest_ which is the modern way of testing
-GRASS. Tests using _pytest_ are written just as any other Python tests.
-See the [testing documentation](../doc/development/testing.md) for the GRASS
-_pytest_ conventions, including test placement, session fixtures, and test data.
-
-In parallel, there is also custom unittest-based framework centered around
-_grass.gunittest_ package. These tests run in the NC sample datasets and can be
-executed using _pytest_ or directly. The unittest-based adds a number of custom
-assert methods to accommodate different data and outputs typical in GRASS.
-_grass.gunittest_ documentation:
-<https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html>
-
-## Running tests
-
-Tests can be executed using _pytest_:
-
-```bash
-# Setup the Python environment (if not set up already).
-# Replace grass by path to the executable if not installed on path.
-export PYTHONPATH=\$(grass --config python_path):\$PYTHONPATH
-export LD_LIBRARY_PATH=\$(grass --config path)/lib:\$LD_LIBRARY_PATH
-# Run the test.
-pytest
-```
-
-## Test data
-
-To test manually or to write tests, you may need to use the North Carolina
-Sample dataset, available from
-<https://grass.osgeo.org/sampledata/north_carolina/>.
+See the [testing documentation](../doc/development/testing.md) for how GRASS
+tests are written and run.
 
 ## CI
 

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -1,10 +1,9 @@
 # Test suite
 
-<!-- markdownlint-disable-next-line line-length -->
-Tests are in directories `tests` and `testsuite` under each directory which has tests.
-This directory contains additional scripts and information to test functionality
-without a focus on a specific part of the code. Currently, that is
-`raster_md5test.sh`, a shell test which runs in a GRASS session and is
+Tests are in directories `tests` and `testsuite` under each directory which has
+tests. This directory contains additional scripts and information to test
+functionality without a focus on a specific part of the code. Currently, that
+is `raster_md5test.sh`, a shell test which runs in a GRASS session and is
 collected by _grass.gunittest_ like any other test in a `testsuite` directory.
 
 See the [testing documentation](../doc/development/testing.md) for how GRASS
@@ -13,4 +12,4 @@ tests are written and run.
 ## CI
 
 Most tests run in the CI. See the `.github` directory for details and
-use it as a reference.
+use it as a reference if needed.


### PR DESCRIPTION
The most complete statement of GRASS testing conventions lived in AGENTS.md, written for AI agents, and a contributor following the documented path never saw it. style_guide.md had no testing section, testsuite/README.md gave pytest a single sentence, and the Testing section in development_intro.md linked only the gunittest manual.

This adds testing.md covering the choice between pytest and gunittest, test placement and naming, session fixtures, grass.tools, test data, running the tests, and tests which cannot run in parallel. AGENTS.md now points at the guide and keeps only its agent-specific notes, so the two cannot drift too much.

This change was drafted with the help of Claude Code (Fable 5).

<details>
<summary><b>Details (AI-generated)</b></summary>

### What the guide covers

Choosing between pytest and gunittest; where test files go and how they are named; setting up a session fixture; running tools with `grass.tools`; generating test data; running the tests; and `needs_solo_run`, which is load-bearing because CI's default pass runs `--numprocesses=auto -m 'not needs_solo_run'` and was documented nowhere.

The conventions come from test code in the tree rather than from prose. Where the tree and `AGENTS.md` disagreed, the tree won.

### The gunittest command was wrong

`grass -c <project>/<mapset> --exec ./test_x.py` fails with `Permission denied`. The test files are not executable (311 of 317 are mode 644, and only 13 have a shebang), and `lib/init/grass.py` only recovers from `ENOENT`, not `EACCES`. Separately, the `-c` form aborts on a second run because the mapset already exists, which is exactly the case of re-running a test after a fix.

Both `testing.md` and `AGENTS.md` now use `--tmp-mapset` with an explicit `python` interpreter, and note that some tests load data files by relative path and so must be run from their own directory.

### Reachability and the build

Linked from `CONTRIBUTING.md`, `doc/development/README.md`, `testsuite/README.md`, a new short Testing section in `style_guide.md`, and `man/mkdocs/docs/development_intro.md`. Registered in `doc/development/Makefile` and `doc/development/CMakeLists.txt`, the same two places `style_guide.md` is registered; without both, the page builds nowhere and the link from `development_intro.md` 404s.

Like the other development guides, the page is reached through `development_intro.md` rather than through the mkdocs `nav`. That is existing behaviour, not something this PR changes.

### style_guide.md

Gains a short Testing section stating the expectation and pointing at the guide. It asks that a bug fix touching untested code also add a test for that code's basic functionality, so it is visible that the fix did not break behaviour which was already correct.

### Verification

- The fixture and test in the guide were extracted from the finished page and run against a local build. They pass. The asserted values match the existing `r_slope_aspect_test.py`, which also passes.
- The corrected gunittest command was extracted verbatim from `AGENTS.md` and executed: exit 0, and again on a second consecutive run. A separate run reported `Ran 16 tests` and `OK`.
- The old `-c` form was executed and reproduced both failures.
- A local mkdocs build confirms `testing.html` is generated and that the link from `development_intro.html` resolves. This built against an existing dist tree with the new page added, not from a full build of this branch.
- pre-commit passes. `gersemi` could not run in this environment because its cache directory was not writable, so the one-line `CMakeLists.txt` change is unverified by that hook.

### Left for separate changes

`testsuite/README.md` lines 25-26 contain literal backslashes in the export commands, so copying them sets literal strings instead of running the command substitutions. `python/grass/grassdb/tests/grass_grassdb_create_xy.py` matches no collection pattern in `pyproject.toml` and is therefore never run, despite containing a test function.

</details>
