### PR TITLE
r.clump: Fail with the clump limit instead of overflowing the index

### DIFF
--- a/raster/r.clump/clump.c
+++ b/raster/r.clump/clump.c
@@ -319,10 +319,10 @@ CELL clump(int *in_fd, int out_fd, int diag, int minsize)
                     /* start a new clump */
                     if (label >= MAX_LABEL)
                         G_fatal_error(
-                            _("Too many clumps: the maximum number of clumps "
-                              "is %d. Reduce the extent or the resolution of "
-                              "the computational region, or use a threshold "
-                              "to merge similar cells."),
+                            _("Too many clumps: the maximum supported number "
+                              "of clumps is %d. Reduce the extent or the "
+                              "resolution of the computational region, or use "
+                              "a threshold to merge similar cells."),
                             MAX_LABEL);
                     label++;
                     cur_clump[col] = label;
@@ -656,10 +656,10 @@ CELL clump_n(int *in_fd, char **inname, int nin, double threshold, int out_fd,
                     /* start a new clump */
                     if (label >= MAX_LABEL)
                         G_fatal_error(
-                            _("Too many clumps: the maximum number of clumps "
-                              "is %d. Reduce the extent or the resolution of "
-                              "the computational region, or use a threshold "
-                              "to merge similar cells."),
+                            _("Too many clumps: the maximum supported number "
+                              "of clumps is %d. Reduce the extent or the "
+                              "resolution of the computational region, or use "
+                              "a threshold to merge similar cells."),
                             MAX_LABEL);
                     label++;
                     cur_clump[col] = label;

--- a/raster/r.clump/clump.c
+++ b/raster/r.clump/clump.c
@@ -26,9 +26,15 @@
 #include <grass/glocale.h>
 #include "local_proto.h"
 #include <errno.h>
+#include <limits.h>
 #include <string.h>
 
-#define INCR 1024
+#define INCR      1024
+
+/* Clump IDs are stored as CELL, a 32 bit signed integer, so the number of
+ * clumps cannot exceed the largest CELL value. Stopping INCR short of that
+ * also keeps nalloc, which grows in INCR steps, from overflowing. */
+#define MAX_LABEL (INT_MAX - INCR)
 
 int print_time(time_t *);
 
@@ -311,6 +317,13 @@ CELL clump(int *in_fd, int out_fd, int diag, int minsize)
             if (NEW == 0 || OLD == NEW) { /* ok */
                 if (OLD == 0) {
                     /* start a new clump */
+                    if (label >= MAX_LABEL)
+                        G_fatal_error(
+                            _("Too many clumps: the maximum number of clumps "
+                              "is %d. Reduce the extent or the resolution of "
+                              "the computational region, or use a threshold "
+                              "to merge similar cells."),
+                            MAX_LABEL);
                     label++;
                     cur_clump[col] = label;
                     if (label >= nalloc) {
@@ -641,6 +654,13 @@ CELL clump_n(int *in_fd, char **inname, int nin, double threshold, int out_fd,
             if (NEW == 0 || OLD == NEW) { /* ok */
                 if (OLD == 0) {
                     /* start a new clump */
+                    if (label >= MAX_LABEL)
+                        G_fatal_error(
+                            _("Too many clumps: the maximum number of clumps "
+                              "is %d. Reduce the extent or the resolution of "
+                              "the computational region, or use a threshold "
+                              "to merge similar cells."),
+                            MAX_LABEL);
                     label++;
                     cur_clump[col] = label;
                     if (label >= nalloc) {


### PR DESCRIPTION
Fixes #6412.

`r.clump` stopped with

```
ERROR: G_realloc: unable to allocate 18446744065119617024 bytes of memory at raster/r.clump/clump.c:633
```

which reads as a memory problem. It is not one, and the reporter went looking for a disk-based mode because of it.

## Where the number comes from

`label` is a `CELL` and `nalloc` an `int`, both 32 bit:

```c
label++;
cur_clump[col] = label;
if (label >= nalloc) {
    nalloc += INCR;                                    /* INCR is 1024 */
    index = (CELL *)G_realloc(index, nalloc * sizeof(CELL));
}
```

`nalloc` starts at `INCR` and only ever grows by `INCR`, so it is always a multiple of 1024 and lands **exactly** on 2³¹, which as a signed 32 bit value is `INT_MIN`. `nalloc * sizeof(CELL)` then converts `INT_MIN * 4` to `size_t`:

```
(2**64) - 2147483648 * 4 = 18446744065119617024
```

That is the number in the report, so this is the path taken rather than a guess. `label` itself overflows one step earlier, which is undefined behaviour and would give a negative clump ID.

## The fix

@metzm said on the issue that the real problem is the clump count, and that the limit "can not be raised" — clump IDs *are* the raster values, so the ceiling is one `CELL`. So this reports the limit instead of overflowing past it, at both places that start a new clump.

`MAX_LABEL` stops `INCR` short of `INT_MAX` rather than at it, so `nalloc` — which moves in `INCR` steps and must exceed `label` — cannot overflow either. The cost is 1024 of 2.1 billion possible clumps.

The new message says what the limit is and what to do about it, since the previous one sent the reporter after the wrong problem.

## Verification

I cannot add a regression test for this: reaching it needs a raster with more than 2³¹ clumps, so the reporter's 220000 × 240000 region is roughly the smallest case. Rather than assert it untested, the mechanism above is arithmetic that anyone can check against the reported number.

What I did check: builds clean, `clang-format` reports no changes, and the four existing tests in `raster/r.clump/tests/test_clump.py` still pass.