### PR TITLE
doc: Replace the broken Weblate badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/OSGeo/grass/badge)](https://securityscorecards.dev/viewer/?uri=github.com/OSGeo/grass)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/2470/badge)](https://www.bestpractices.dev/projects/2470)
 [![Coverity](https://scan.coverity.com/projects/1038/badge.svg)](https://scan.coverity.com/projects/grass)  
-[![Translation status](https://weblate.osgeo.org/widget/grass-gis/svg-badge.svg)](https://weblate.osgeo.org/engage/grass-gis/)  
+[![Translation status](https://img.shields.io/badge/translations-Weblate-144d3f?logo=weblate)](https://weblate.osgeo.org/engage/grass-gis/)  
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 [![Hosted by OSGeo](https://img.shields.io/badge/hosted%20by-OSGeo-4cb05b.svg?style=flat&labelColor=00393f)](https://www.osgeo.org/)
 


### PR DESCRIPTION
The Weblate badge does not render on GitHub. weblate.osgeo.org is behind a Cloudflare managed challenge which answers non-browser requests with an HTTP 403 challenge page, so the SVG never reaches the reader. Opening the URL in a browser works, which is why the badge looks fine when it is checked by hand.

This uses a static shields.io badge instead. The link to the GRASS project on Weblate stays, but the translation percentage is gone.

The ultimate fix would be to OSGeo infrastructure: exempting the /widget/ and /widgets/ paths from the Cloudflare challenge would make a live badge work again, and this change can be reverted then.

Old: [![Translation status](https://weblate.osgeo.org/widget/grass-gis/svg-badge.svg)](https://weblate.osgeo.org/engage/grass-gis/)  
New: [![Translation status](https://img.shields.io/badge/translations-Weblate-144d3f?logo=weblate)](https://weblate.osgeo.org/engage/grass-gis/) 

More generally though, I don't know if the 25% translated makes sense. 25% of which language? Of all languages started?

Original:
<img width="515" height="99" alt="image" src="https://github.com/user-attachments/assets/854425c9-33cc-4443-9246-4a5758e7ddc6" />

So, perhaps this new neutral badge the right badge to display, unless a more fitting number or info can be shown (like number of languages which are almost complete?).