### PR TITLE
CI: allow workflow tasks to be skipped if not relevant for the changes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,17 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/cmake.yml
+
   build-cmake:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     env:
       CMAKE_VERSION: "3.22.0"

--- a/.github/workflows/detect-relevant-changes.yml
+++ b/.github/workflows/detect-relevant-changes.yml
@@ -58,20 +58,13 @@ jobs:
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
-          # An empty token forces git-based diffing instead of the GitHub
-          # REST API, which is also used by every other job in the repo and
-          # shares a single per-repository rate limit.
+          # Use empty token to force git-based diffing, not GitHub REST API
           token: ""
-          # For a pull request, compares against its base branch. For a
-          # push, compares against the previous commit on the same branch
-          # instead of the default branch, which release branches would
-          # diverge from too much for a good comparison.
+          # For a PR, compare against its base branch
+          # For a push, compares against the previous commit on the same branch
           base: >-
             ${{ github.event_name == 'pull_request' &&
             github.event.pull_request.base.ref || github.ref }}
-          # Needed so that the "!"-prefixed patterns below actually exclude
-          # files, instead of the default behavior where any pattern in the
-          # list, negated or not, can match and include a file.
           predicate-quantifier: some-with-excludes
           filters: |
             relevant:

--- a/.github/workflows/detect-relevant-changes.yml
+++ b/.github/workflows/detect-relevant-changes.yml
@@ -1,0 +1,92 @@
+---
+name: Detect relevant changes reusable workflow
+
+# Reports whether a push or pull request touches anything that could affect
+# a build/test workflow, so that workflow can skip its expensive job. Instead
+# of using on.push.paths/on.pull_request.paths, here only the following job(s)
+# gets skipped, not the whole workflow. That way a required status check,
+# still reports success if it does not have any relevant changes.
+#
+# Usage, as the first job of a workflow:
+# ```
+# jobs:
+#   changes:
+#     uses: ./.github/workflows/detect-relevant-changes.yml
+#     with:
+#       own-workflow-path: .github/workflows/<this-file>.yml
+#   build:
+#     needs: changes
+#     if: ${{ needs.changes.outputs.run == 'true' }}
+#     ...
+# ```
+
+on:
+  workflow_call:
+    inputs:
+      own-workflow-path:
+        type: string
+        required: true
+        description: >-
+          Path of the calling workflow file, e.g. .github/workflows/pytest.yml.
+          Always treated as relevant, since other workflow files are not.
+    outputs:
+      run:
+        description: >-
+          'true' if some changed file could affect a build or test, 'false'
+          if all changed files are documentation, translations, or CI/tooling
+          config unrelated to the calling workflow.
+        value: ${{ jobs.changes.outputs.run }}
+
+permissions: {}
+
+jobs:
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      run: >-
+        ${{ steps.filter.outputs.relevant == 'true' ||
+        steps.filter.outputs.always_relevant == 'true' }}
+    steps:
+      # dorny/paths-filter needs a local git history to diff against.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check for changes outside of irrelevant files
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          # An empty token forces git-based diffing instead of the GitHub
+          # REST API, which is also used by every other job in the repo and
+          # shares a single per-repository rate limit.
+          token: ""
+          # For a pull request, compares against its base branch. For a
+          # push, compares against the previous commit on the same branch
+          # instead of the default branch, which release branches would
+          # diverge from too much for a good comparison.
+          base: >-
+            ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.base.ref || github.ref }}
+          # Needed so that the "!"-prefixed patterns below actually exclude
+          # files, instead of the default behavior where any pattern in the
+          # list, negated or not, can match and include a file.
+          predicate-quantifier: some-with-excludes
+          filters: |
+            relevant:
+              - "**"
+              - "!docker/**"
+              - "!Dockerfile"
+              - "!**/*.po"
+              - "!**/*.md"
+              - "!binder/**"
+              - "!.claude/**"
+              - "!renovate.json5"
+              - "!.editorconfig"
+              - "!.github/**/*.yml"
+              - "!.github/**/*.yaml"
+            always_relevant:
+              - "${{ inputs.own-workflow-path }}"
+              - ".github/workflows/detect-relevant-changes.yml"
+              - ".github/workflows/verify-success.yml"

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -11,8 +11,18 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/gcc.yml
+
   build:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
 
     concurrency:
       group: >-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,8 +18,18 @@ concurrency:
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/macos.yml
+
   macos_build:
     name: macOS build
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: macos-26
     env:
       PYTHONWARNINGS: always

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -11,8 +11,18 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/osgeo4w.yml
+
   build:
     name: ${{ matrix.os }} build and tests
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
 
     concurrency:
       group: >-

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,17 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/pytest.yml
+
   pytest:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     concurrency:
       group: >-
         ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
@@ -179,6 +189,7 @@ jobs:
   pytest-success:
     name: pytest Result
     needs:
+      - changes
       - pytest
     if: ${{ always() }}
     uses: ./.github/workflows/verify-success.yml

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,17 @@ on:
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect changed files
+    permissions:
+      contents: read
+    uses: ./.github/workflows/detect-relevant-changes.yml
+    with:
+      own-workflow-path: .github/workflows/ubuntu.yml
+
   ubuntu:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     permissions:
       contents: read
       actions: read
@@ -199,6 +209,7 @@ jobs:
   build-and-test-success:
     name: Build & Test Result
     needs:
+      - changes
       - ubuntu
     if: ${{ always() }}
     uses: ./.github/workflows/verify-success.yml


### PR DESCRIPTION
CI workflows have to run for all PRs because of branch protection. Sometimes, that consumes unnecessary much CI time.

Since we can not skip entire workflows, this PR adds a new filter-job, that checks if relevant files for the workflow got changed by a PR/commit. It is then used to skip the following job(s) within a workflow. That way, heavy CI jobs (like pytests) can be skipped if they do not add any value (e.g. if only docker files are changed) but the workfow itself still reports success.
This should save some valuable CI time and allow simple pure documentation changes to be merged faster.

When reviewing, please be extra critical with the list of files that causes workflow jobs to be skipped. Also, I am not 100% sure how this will affect CI runs that start after a PR is merged...

Written with the help of AI.