### PR TITLE
r.out.gdal: increase limit for the number of overviews

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -19,6 +19,7 @@ libzstd-dev
 pdal
 proj-bin
 python3-dateutil
+python3-gdal
 python3-matplotlib
 python3-numpy
 python3-pil

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -88,6 +88,7 @@ jobs:
             netcdf-devel
             proj-devel
             python3-core
+            python3-gdal
             python3-jupyter
             python3-matplotlib
             python3-numpy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,6 +61,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --break-system-packages -r .github/workflows/python_requirements.txt
           pip install --break-system-packages -r .github/workflows/optional_requirements.txt
+          pip install --break-system-packages GDAL=$(gdal-config --version)
           pip install --break-system-packages pytest pytest-timeout \
               pytest-github-actions-annotate-failures pytest-xdist pytest-cov
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --break-system-packages -r .github/workflows/python_requirements.txt
           pip install --break-system-packages -r .github/workflows/optional_requirements.txt
-          pip install --break-system-packages GDAL=$(gdal-config --version)
+          pip install --break-system-packages GDAL=="$(gdal-config --version)"
           pip install --break-system-packages pytest pytest-timeout \
               pytest-github-actions-annotate-failures pytest-xdist pytest-cov
 

--- a/raster/r.out.gdal/main.c
+++ b/raster/r.out.gdal/main.c
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     overviewopt = G_define_option();
     overviewopt->key = "overviews";
     overviewopt->type = TYPE_INTEGER;
-    overviewopt->options = "0-15";
+    overviewopt->options = "0-30";
     overviewopt->answer = "0";
     overviewopt->label =
         _("Number of overviews to create for the output dataset");
@@ -750,8 +750,8 @@ int main(int argc, char *argv[])
     /* overviews */
     if (overviewopt->answer) {
         n_overviews = atoi(overviewopt->answer);
-        if (n_overviews < 0 || n_overviews > 15) {
-            G_warning(_("Number of overviews must be between 0 and 15"));
+        if (n_overviews < 0 || n_overviews > 30) {
+            G_warning(_("Number of overviews must be between 0 and 30"));
             n_overviews = 0;
         }
     }

--- a/raster/r.out.gdal/main.c
+++ b/raster/r.out.gdal/main.c
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     overviewopt = G_define_option();
     overviewopt->key = "overviews";
     overviewopt->type = TYPE_INTEGER;
-    overviewopt->options = "0-5";
+    overviewopt->options = "0-15";
     overviewopt->answer = "0";
     overviewopt->label =
         _("Number of overviews to create for the output dataset");
@@ -750,8 +750,8 @@ int main(int argc, char *argv[])
     /* overviews */
     if (overviewopt->answer) {
         n_overviews = atoi(overviewopt->answer);
-        if (n_overviews < 0 || n_overviews > 5) {
-            G_warning(_("Number of overviews must be between 0 and 5"));
+        if (n_overviews < 0 || n_overviews > 15) {
+            G_warning(_("Number of overviews must be between 0 and 15"));
             n_overviews = 0;
         }
     }

--- a/raster/r.out.gdal/tests/test_r_out_gdal.py
+++ b/raster/r.out.gdal/tests/test_r_out_gdal.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from osgeo import gdal
+
 import grass.script as gs
 from grass.tools import Tools
 
@@ -39,6 +41,32 @@ def simple_raster_map(tmp_path_factory):
         )
 
         yield "test_raster", session, tmp_path
+
+
+@pytest.fixture(scope="module")
+def larger_raster_map(tmp_path_factory):
+    """Fixture to create a basic GRASS environment with a larger raster map containing attributes.
+
+    Set up a temporary GRASS project and region and create a raster map
+    using r.mapcalc.
+
+    Yields:
+        tuple: (map name, GRASS session handle, tmp_path)
+
+    """
+    tmp_path = tmp_path_factory.mktemp("r_out_gdal_project_large")
+    project = tmp_path / "grassdata"
+    gs.create_project(project, epsg=25833)
+
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        tools = Tools(session=session, consistent_return_value=True)
+        tools.g_region(n=500, s=0, e=500, w=0, res=1)
+
+        tools.r_mapcalc(
+            expression="larger_test_raster=1",
+        )
+
+        yield "larger_test_raster", session, tmp_path
 
 
 @pytest.mark.parametrize("file_format", list(FORMAT_DICT.keys()))
@@ -108,3 +136,33 @@ def test_fast_gtiff_export(simple_raster_map):
     assert output_file.exists(), f"{mapname} not exported to {output_file}"
     # Check that nodata and data range checks are NOT performed
     assert "Checking GDAL data type and nodata value" not in export.stderr
+
+
+def test_gtiff_export_with_many_overviews(larger_raster_map):
+    """Test export of GeoTiff with > 5 overviews.
+
+    Verifies:
+    - Export of > 5 overviews works.
+    """
+    mapname, session, tmp_path = larger_raster_map
+    tools = Tools(session=session, consistent_return_value=True)
+
+    output_file = tmp_path / f"{mapname}_lzw_10_overviews.tif"
+    export = tools.r_out_gdal(
+        input=mapname,
+        output=output_file,
+        format="GTiff",
+        createopt="COMPRESS=LZW",
+        overviews=9,
+    )
+
+    # Check successful export
+    assert output_file.exists(), f"{mapname} not exported to {output_file}"
+    # Check that nodata and data range checks are performed
+    assert "Checking GDAL data type and nodata value" in export.stderr
+
+    with gdal.Open(str(output_file)) as ds:
+        assert ds is not None, f"Failed to open {output_file} with GDAL"
+        assert ds.GetRasterBand(1).GetOverviewCount() == 9, (
+            f"Expected 9 overviews, got {ds.GetRasterBand(1).GetOverviewCount()}"
+        )

--- a/raster/r.out.gdal/tests/test_r_out_gdal.py
+++ b/raster/r.out.gdal/tests/test_r_out_gdal.py
@@ -143,6 +143,7 @@ def test_gtiff_export_with_many_overviews(larger_raster_map):
 
     Verifies:
     - Export of > 5 overviews works.
+    - GDAL handles excessive overview levels
     """
     mapname, session, tmp_path = larger_raster_map
     tools = Tools(session=session, consistent_return_value=True)
@@ -153,7 +154,7 @@ def test_gtiff_export_with_many_overviews(larger_raster_map):
         output=output_file,
         format="GTiff",
         createopt="COMPRESS=LZW",
-        overviews=9,
+        overviews=15,
     )
 
     # Check successful export
@@ -163,6 +164,7 @@ def test_gtiff_export_with_many_overviews(larger_raster_map):
 
     with gdal.Open(str(output_file)) as ds:
         assert ds is not None, f"Failed to open {output_file} with GDAL"
+        # GDAL removes excessive overviews (max is 9 for the given input size)
         assert ds.GetRasterBand(1).GetOverviewCount() == 9, (
             f"Expected 9 overviews, got {ds.GetRasterBand(1).GetOverviewCount()}"
         )


### PR DESCRIPTION
For large (e.g. country-wide) datasets, having mor than 5 overviews can be beneficial for viewing exported data in other systems.
The number of overviews `r.out.gdal` is able to write was capped at 5 as a limit in GRASS, not GDAL.

This PR increases that limit. It is now buped to15 overviews `r.out.gdal` can write to the resulting file. Happy to change the number to anything > 8 which I would consider a kind of minimal limit given todays dataset sizes...

Changes are covered by a pytest.