### PR TITLE
gui: add new datasets (Raleigh, NC and Flagstaff, AZ) for download

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -45,16 +45,34 @@ from gui_core.wrap import Button, StaticText
 # TODO: labels (and descriptions) translatable?
 LOCATIONS = [
     {
-        "label": "Complete North Carolina dataset",
+        "label": "Raleigh, North Carolina, USA",
+        "url": "https://grass.osgeo.org/sampledata/raleigh_northcarolina_usa_epsg6542.zip",  # noqa: E501
+        "epsg": "6542",
+    },
+    {
+        "label": "Legacy full NC dataset",
         "url": "https://grass.osgeo.org/sampledata/north_carolina/nc_spm_08_grass7.tar.gz",  # noqa: E501
     },
     {
-        "label": "Basic North Carolina dataset",
+        "label": "Legacy basic NC dataset",
         "url": "https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.tar.gz",  # noqa: E501
+    },
+    {
+        "label": "Natural Earth Dataset in WGS84",
+        "url": "https://zenodo.org/records/13370131/files/natural_earth_dataset.zip",
+        "size": "121.3 MB",
+        "epsg": "4326",
+        "license": "ODC Public Domain Dedication and License 1.0",
+        "maintainer": "Brendan Harmon (brendan.harmon@gmail.com)",
     },
     {
         "label": "World dataset in LatLong/WGS84",
         "url": "https://grass.osgeo.org/sampledata/worldlocation.tar.gz",
+    },
+    {
+        "label": "Flagstaff, Arizona, USA",
+        "url": "https://grass.osgeo.org/sampledata/flagstaff_az_usa_epsg6341.zip",
+        "epsg": "6341",
     },
     {
         "label": "Spearfish (SD) dataset",
@@ -75,14 +93,6 @@ LOCATIONS = [
     {
         "label": "GISMentors dataset, Czech Republic",
         "url": "https://www.training.gismentors.cz/geodata/grass/gismentors.zip",
-    },
-    {
-        "label": "Natural Earth Dataset in WGS84",
-        "url": "https://zenodo.org/records/13370131/files/natural_earth_dataset.zip",
-        "size": "121.3 MB",
-        "epsg": "4326",
-        "license": "ODC Public Domain Dedication and License 1.0",
-        "maintainer": "Brendan Harmon (brendan.harmon@gmail.com)",
     },
 ]
 


### PR DESCRIPTION
This PR adds to gui download list new GRASS projects (datasets):
- Raleigh, NC - that's a new version of the NC dataset, it's closer to the basic version, but the idea is it will eventually replace the NC datasets in documentation/tutorials.
- Flagstaff, AZ - developed by @cmbarton, uses the same names so the tutorials that were developed can be run with both these datasets.

Also related is this tutorial: https://github.com/OSGeo/grass-tutorials/pull/144 that describes how to create a dataset like that (focused on US data).

Unrelated change - I moved Natural Earth dataset closer to the top, since it is likely more relevant.
