### PR TITLE
lib/datetime: Add pytest unit tests for datetime_scan and datetime_format

### DIFF
--- a/lib/datetime/tests/lib_datetime_calendar_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_calendar_ctypes_test.py
@@ -1,0 +1,67 @@
+"""Tests for the calendar arithmetic ctypes bindings
+
+datetime_is_leap_year(), datetime_days_in_year() and datetime_days_in_month()
+take plain year/month/ad integers rather than a DateTime struct, so no GRASS
+session is needed here.
+"""
+
+import pytest
+
+from grass.lib import date as libdate
+
+AD = 1
+BC = 0
+
+
+@pytest.mark.parametrize(
+    ("year", "expected"),
+    [
+        # Divisible by 4 but not 100: a regular leap year.
+        (2004, True),
+        (2001, False),
+        # Divisible by 100 but not 400: the Gregorian exception.
+        (1900, False),
+        # Divisible by 400: the exception to the exception.
+        (2000, True),
+    ],
+)
+def test_is_leap_year_follows_the_gregorian_rule(year, expected) -> None:
+    assert bool(libdate.datetime_is_leap_year(year, AD)) == expected
+
+
+def test_is_leap_year_treats_every_bc_year_as_non_leap() -> None:
+    """BC years are never leap here, unlike a proleptic Gregorian calendar
+
+    404 BC would be a leap year under a proleptic Gregorian calendar, but
+    datetime_is_leap_year() special-cases BC to always return false. This
+    is a simplification worth locking in rather than assuming leap-year
+    rules apply symmetrically to BC dates.
+    """
+    assert libdate.datetime_is_leap_year(404, BC) == 0
+
+
+@pytest.mark.parametrize(("year", "days"), [(2000, 366), (2001, 365)])
+def test_days_in_year_matches_leap_year_status(year, days) -> None:
+    assert libdate.datetime_days_in_year(year, AD) == days
+
+
+@pytest.mark.parametrize(
+    ("year", "month", "ad", "days"),
+    [
+        # February in and out of a leap year.
+        (2000, 2, AD, 29),
+        (1900, 2, AD, 28),
+        # February in a BC year: always 28 days, since BC is never leap.
+        (4, 2, BC, 28),
+        # A 30-day and a 31-day month, unaffected by leap years.
+        (2001, 4, AD, 30),
+        (2001, 1, AD, 31),
+    ],
+)
+def test_days_in_month(year, month, ad, days) -> None:
+    assert libdate.datetime_days_in_month(year, month, ad) == days
+
+
+@pytest.mark.parametrize("month", [0, 13])
+def test_days_in_month_rejects_out_of_range_month(month) -> None:
+    assert libdate.datetime_days_in_month(2000, month, AD) < 0

--- a/lib/datetime/tests/lib_datetime_change_from_to_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_change_from_to_ctypes_test.py
@@ -1,0 +1,90 @@
+"""Tests for the datetime_change_from_to() ctypes binding
+
+datetime_change_from_to() only reads and writes a DateTime struct already in
+memory, so no GRASS session is needed here.
+
+This covers only the straightforward truncate/extend cases (round == -1,
+i.e. floor, or extending to a lower precision than before). The function
+also supports rounding up when precision is lost (round > 0) and an
+"increment by half" mode (round == 0); both involve substantially more
+elaborate carry logic that is out of scope for this first pass.
+"""
+
+from ctypes import byref, create_string_buffer
+
+from grass.lib import date as libdate
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning the resulting DateTime"""
+    dt = libdate.DateTime()
+    assert libdate.datetime_scan(byref(dt), text.encode()) == 0, text
+    return dt
+
+
+def format_datetime(dt):
+    """Format a DateTime with datetime_format(), returning the text"""
+    buf = create_string_buffer(128)
+    assert libdate.datetime_format(byref(dt), buf) == 0
+    return buf.value.decode()
+
+
+def test_truncating_to_a_coarser_precision_drops_the_finer_fields() -> None:
+    """round=-1 (floor) drops the time of day rather than rounding it away"""
+    dt = scan("15 aug 2001 23:45:30")
+    ret = libdate.datetime_change_from_to(
+        byref(dt), libdate.DATETIME_YEAR, libdate.DATETIME_DAY, -1
+    )
+    assert ret == 0
+    assert format_datetime(dt) == "15 Aug 2001"
+
+
+def test_extending_to_a_finer_precision_zero_fills_the_new_fields() -> None:
+    dt = scan("15 aug 2001")
+    ret = libdate.datetime_change_from_to(
+        byref(dt), libdate.DATETIME_YEAR, libdate.DATETIME_SECOND, 0
+    )
+    assert ret == 0
+    assert format_datetime(dt) == "15 Aug 2001 00:00:00"
+
+
+def test_truncating_a_relative_interval() -> None:
+    incr = libdate.DateTime()
+    libdate.datetime_set_type(
+        byref(incr),
+        libdate.DATETIME_RELATIVE,
+        libdate.DATETIME_DAY,
+        libdate.DATETIME_SECOND,
+        0,
+    )
+    libdate.datetime_set_day(byref(incr), 2)
+    libdate.datetime_set_hour(byref(incr), 5)
+
+    ret = libdate.datetime_change_from_to(
+        byref(incr), libdate.DATETIME_DAY, libdate.DATETIME_DAY, -1
+    )
+    assert ret == 0
+    assert format_datetime(incr) == "2 days"
+
+
+def test_rejects_an_uninitialized_datetime() -> None:
+    """A DateTime that was never given a type via datetime_set_type() is
+    not a valid input: its mode is neither ABSOLUTE nor RELATIVE"""
+    dt = libdate.DateTime()
+    assert (
+        libdate.datetime_change_from_to(
+            byref(dt), libdate.DATETIME_YEAR, libdate.DATETIME_DAY, 0
+        )
+        == -1
+    )
+
+
+def test_rejects_an_invalid_from_for_the_datetimes_mode() -> None:
+    """An absolute datetime must always count from YEAR"""
+    dt = scan("15 aug 2001")
+    assert (
+        libdate.datetime_change_from_to(
+            byref(dt), libdate.DATETIME_MONTH, libdate.DATETIME_DAY, 0
+        )
+        == -2
+    )

--- a/lib/datetime/tests/lib_datetime_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_ctypes_test.py
@@ -1,0 +1,106 @@
+"""Tests for scanning and formatting through the datetime library ctypes bindings
+
+datetime_scan and datetime_format are pure string parsing and formatting: they
+read or write a DateTime struct and touch nothing outside it, so no GRASS
+session is needed here.
+"""
+
+from ctypes import byref, create_string_buffer
+
+import pytest
+
+from grass.lib import date as libdate
+
+# The size of the buffer passed to datetime_format(), matching the temp
+# buffers GRASS's own callers use (e.g. G_format_timestamp() in lib/gis).
+FORMAT_BUFFER_SIZE = 128
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning (return_code, DateTime)"""
+    dt = libdate.DateTime()
+    ret = libdate.datetime_scan(byref(dt), text.encode())
+    return ret, dt
+
+
+def format_datetime(dt):
+    """Format a DateTime with datetime_format(), returning (return_code, text)"""
+    buf = create_string_buffer(FORMAT_BUFFER_SIZE)
+    ret = libdate.datetime_format(byref(dt), buf)
+    return ret, buf.value.decode()
+
+
+def round_trip(text):
+    """Scan text and format the result back, asserting the scan succeeded"""
+    ret, dt = scan(text)
+    assert ret == 0, f"datetime_scan rejected {text!r}"
+    ret, formatted = format_datetime(dt)
+    assert ret == 0, f"datetime_format rejected the result of scanning {text!r}"
+    return formatted
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # A bare day/month/year: the coarsest granularity that is still a
+        # full date.
+        ("15 aug 2001", "15 Aug 2001"),
+        # A time of day extends the granularity down to seconds.
+        ("15 aug 2001 12:30:45", "15 Aug 2001 12:30:45"),
+        # A BC year is round-tripped with a "bc" suffix, not a negative year.
+        ("44 bc", "44 bc"),
+        # Midnight and noon are the two hours where a naive 24h-to-12h
+        # conversion breaks (0 % 12 == 12 % 12 == 0); this locks in that
+        # GRASS's own format keeps them as plain 00:00 and 12:00.
+        ("1 jan 2000 00:00", "1 Jan 2000 00:00"),
+        ("1 jan 2000 12:00", "1 Jan 2000 12:00"),
+        # A relative interval combining several units.
+        ("2 years 3 months", "2 years 3 months"),
+        # A timezone offset round-trips exactly, including the two
+        # boundary values datetime_is_valid_timezone() allows: -12:00 and
+        # +13:00.
+        ("15 aug 2001 12:30:45 +0530", "15 Aug 2001 12:30:45 +0530"),
+        ("1 jan 2000 00:00 +1300", "1 Jan 2000 00:00 +1300"),
+        ("1 jan 2000 00:00 -1200", "1 Jan 2000 00:00 -1200"),
+    ],
+)
+def test_scan_format_round_trip(text, expected) -> None:
+    assert round_trip(text) == expected
+
+
+def test_fractional_seconds_are_not_zero_padded() -> None:
+    """A fractional second under 10 is not padded to two digits
+
+    datetime_format() builds the seconds field with the printf-style spec
+    "%02.*f", which pads the *whole* formatted number to a minimum width of
+    2; since "1.500" is already 5 characters, no leading zero is added. This
+    looks like a formatting bug at a glance, so it is worth locking in as
+    the current, apparently intentional behavior.
+    """
+    assert round_trip("1 jan 2000 00:00:01.500") == "1 Jan 2000 00:00:1.500"
+
+
+def test_microsecond_precision_is_preserved() -> None:
+    assert round_trip("1 jan 2000 00:00:12.123456") == "1 Jan 2000 00:00:12.123456"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "not a date",
+        "2000-01-01",
+        # A day that does not exist in the given month.
+        "32 jan 2000",
+        # 12-hour clock input is rejected outright rather than silently
+        # misread, e.g. treating "2:30 pm" as 2:30 in the morning.
+        "2:30 pm",
+        "02:30 PM",
+        # One minute past either end of the valid timezone range.
+        "1 jan 2000 00:00 +1301",
+        "1 jan 2000 00:00 -1201",
+    ],
+)
+def test_scan_rejects_invalid_input(text) -> None:
+    ret, _dt = scan(text)
+    assert ret != 0

--- a/lib/datetime/tests/lib_datetime_difference_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_difference_ctypes_test.py
@@ -1,0 +1,99 @@
+"""Tests for the datetime_difference() ctypes binding
+
+datetime_difference() only reads two DateTime structs and writes a third, so
+no GRASS session is needed here.
+"""
+
+from ctypes import byref, create_string_buffer
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning the resulting DateTime"""
+    dt = libdate.DateTime()
+    assert libdate.datetime_scan(byref(dt), text.encode()) == 0, text
+    return dt
+
+
+def format_datetime(dt):
+    """Format a DateTime with datetime_format(), returning the text"""
+    buf = create_string_buffer(128)
+    assert libdate.datetime_format(byref(dt), buf) == 0
+    return buf.value.decode()
+
+
+def difference(a_text, b_text):
+    """Compute a - b and return (return_code, formatted result)"""
+    a = scan(a_text)
+    b = scan(b_text)
+    result = libdate.DateTime()
+    ret = libdate.datetime_difference(byref(a), byref(b), byref(result))
+    return ret, format_datetime(result)
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        ("20 aug 2001", "15 aug 2001", "5 days"),
+        ("15 aug 2001", "15 aug 2001", "0 days"),
+        # Crosses a month and year boundary.
+        ("1 jan 2002", "25 dec 2001", "7 days"),
+        # A time-of-day difference on the same calendar day.
+        (
+            "15 aug 2001 12:30:00",
+            "15 aug 2001 10:00:00",
+            "0 days 2 hours 30 minutes 0 seconds",
+        ),
+    ],
+)
+def test_difference_of_day_precision_dates(a, b, expected) -> None:
+    ret, formatted = difference(a, b)
+    assert ret == 0
+    assert formatted == expected
+
+
+def test_difference_is_negative_when_a_is_earlier_than_b() -> None:
+    """The sign of the result reflects which operand is later
+
+    The formatted output puts a space between the sign and the value
+    ("- 5 days", not "-5 days"): datetime_format() writes the "-" first,
+    then, since the buffer is already non-empty, prefixes the day field
+    with a space the same way it would between any two fields.
+    """
+    ret, formatted = difference("15 aug 2001", "20 aug 2001")
+    assert ret == 0
+    assert formatted == "- 5 days"
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        ("mar 2001", "jan 2001", "0 years 2 months"),
+        # Crossing a year boundary still measures forward in months.
+        ("jan 2002", "nov 2001", "0 years 2 months"),
+    ],
+)
+def test_difference_of_year_month_precision_dates(a, b, expected) -> None:
+    ret, formatted = difference(a, b)
+    assert ret == 0
+    assert formatted == expected
+
+
+def test_difference_accounts_for_timezone_offsets() -> None:
+    """Both operands are converted to UTC before comparing clock fields"""
+    # 12:30 +05:30 is 07:00 UTC; 12:30 +00:00 is 12:30 UTC, so a is earlier.
+    ret, formatted = difference(
+        "15 aug 2001 12:30:00 +0530", "15 aug 2001 12:30:00 +0000"
+    )
+    assert ret == 0
+    assert formatted == "- 0 days 5 hours 30 minutes 0 seconds"
+
+
+def test_difference_rejects_a_timezone_on_only_one_operand() -> None:
+    a = scan("15 aug 2001 12:30:00 +0530")
+    b = scan("15 aug 2001 10:00:00")
+    result = libdate.DateTime()
+    assert libdate.datetime_difference(byref(a), byref(b), byref(result)) != 0

--- a/lib/datetime/tests/lib_datetime_error_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_error_ctypes_test.py
@@ -1,0 +1,30 @@
+"""Tests for the error-state ctypes bindings
+
+datetime_error(), datetime_error_code() and datetime_error_msg() share a
+single, process-global error state (static variables in error.c), not one
+tied to any particular DateTime struct. No GRASS session is needed here, but
+because the state is global, each test sets it explicitly rather than
+assuming what a previous test may have left behind.
+"""
+
+from grass.lib import date as libdate
+
+
+def test_error_sets_the_code_and_message() -> None:
+    assert libdate.datetime_error(-5, b"custom message") == -5
+    assert libdate.datetime_error_code() == -5
+    assert libdate.datetime_error_msg() == b"custom message"
+
+
+def test_clear_error_resets_the_code_and_message() -> None:
+    libdate.datetime_error(-5, b"custom message")
+    libdate.datetime_clear_error()
+    assert libdate.datetime_error_code() == 0
+    assert libdate.datetime_error_msg() == b""
+
+
+def test_error_with_code_zero_clears_the_message() -> None:
+    libdate.datetime_error(-5, b"custom message")
+    libdate.datetime_error(0, None)
+    assert libdate.datetime_error_code() == 0
+    assert libdate.datetime_error_msg() == b""

--- a/lib/datetime/tests/lib_datetime_increment_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_increment_ctypes_test.py
@@ -1,0 +1,157 @@
+"""Tests for the increment ctypes bindings
+
+datetime_increment() and its supporting functions only read and write
+DateTime structs already in memory, so no GRASS session is needed here.
+"""
+
+from ctypes import byref, c_int, create_string_buffer
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning the resulting DateTime"""
+    dt = libdate.DateTime()
+    assert libdate.datetime_scan(byref(dt), text.encode()) == 0, text
+    return dt
+
+
+def format_datetime(dt):
+    """Format a DateTime with datetime_format(), returning the text"""
+    buf = create_string_buffer(128)
+    assert libdate.datetime_format(byref(dt), buf) == 0
+    return buf.value.decode()
+
+
+def relative(from_, to):
+    """A relative DateTime spanning from_ to to, both zeroed"""
+    incr = libdate.DateTime()
+    assert (
+        libdate.datetime_set_type(byref(incr), libdate.DATETIME_RELATIVE, from_, to, 0)
+        == 0
+    )
+    return incr
+
+
+@pytest.mark.parametrize(
+    ("text", "days", "expected"),
+    [
+        # Adding days can carry into the next month.
+        ("30 jan 2001", 5, "4 Feb 2001"),
+        ("15 aug 2001", 5, "20 Aug 2001"),
+    ],
+)
+def test_increment_by_days(text, days, expected) -> None:
+    dt = scan(text)
+    incr = relative(libdate.DATETIME_DAY, libdate.DATETIME_DAY)
+    libdate.datetime_set_day(byref(incr), days)
+    assert libdate.datetime_increment(byref(dt), byref(incr)) == 0
+    assert format_datetime(dt) == expected
+
+
+def test_decrement_by_days_borrows_from_the_previous_month() -> None:
+    """A negative day increment can carry back across a month boundary"""
+    dt = scan("3 mar 2001")
+    incr = relative(libdate.DATETIME_DAY, libdate.DATETIME_DAY)
+    libdate.datetime_set_day(byref(incr), 5)
+    libdate.datetime_set_negative(byref(incr))
+    assert libdate.datetime_increment(byref(dt), byref(incr)) == 0
+    assert format_datetime(dt) == "26 Feb 2001"
+
+
+@pytest.mark.parametrize(
+    ("text", "months", "expected"),
+    [
+        # Adding months can carry into the next year.
+        ("nov 2001", 3, "Feb 2002"),
+        ("nov 2001", 5, "Apr 2002"),
+    ],
+)
+def test_increment_by_months_on_a_year_month_datetime(text, months, expected) -> None:
+    """Month increments only apply to a datetime whose own precision is in
+    the year/month group; a full calendar date (day precision) cannot take
+    a month increment directly, see
+    test_increment_rejects_a_month_increment_on_a_day_precision_datetime.
+    """
+    dt = scan(text)
+    incr = relative(libdate.DATETIME_YEAR, libdate.DATETIME_MONTH)
+    libdate.datetime_set_month(byref(incr), months)
+    assert libdate.datetime_increment(byref(dt), byref(incr)) == 0
+    assert format_datetime(dt) == expected
+
+
+def test_increment_by_an_hour_carries_into_the_next_day() -> None:
+    dt = scan("15 aug 2001 23:30:00")
+    incr = relative(libdate.DATETIME_DAY, libdate.DATETIME_SECOND)
+    libdate.datetime_set_hour(byref(incr), 1)
+    assert libdate.datetime_increment(byref(dt), byref(incr)) == 0
+    assert format_datetime(dt) == "16 Aug 2001 00:30:00"
+
+
+def test_increment_rejects_a_month_increment_on_a_day_precision_datetime() -> None:
+    """Year/month and day/second increments cannot mix
+
+    A month has no fixed number of days, so a relative DateTime cannot span
+    both groups (enforced by datetime_set_type()'s own -5 error). The same
+    split applies to increments: a datetime with day precision can only be
+    incremented within the day/second group, even though "N months" is a
+    perfectly valid relative DateTime on its own.
+    """
+    dt = scan("15 nov 2001")
+    incr = relative(libdate.DATETIME_YEAR, libdate.DATETIME_MONTH)
+    libdate.datetime_set_month(byref(incr), 3)
+    assert libdate.datetime_increment(byref(dt), byref(incr)) != 0
+
+
+def test_check_increment_rejects_a_more_precise_increment() -> None:
+    src = scan("15 aug 2001")  # day precision
+    too_precise = relative(libdate.DATETIME_DAY, libdate.DATETIME_SECOND)
+    assert libdate.datetime_check_increment(byref(src), byref(too_precise)) == -2
+
+
+def test_check_increment_rejects_an_absolute_increment() -> None:
+    src = scan("15 aug 2001")
+    incr = libdate.DateTime()
+    libdate.datetime_set_type(
+        byref(incr),
+        libdate.DATETIME_ABSOLUTE,
+        libdate.DATETIME_YEAR,
+        libdate.DATETIME_YEAR,
+        0,
+    )
+    assert libdate.datetime_check_increment(byref(src), byref(incr)) == -1
+
+
+def test_get_increment_type_matches_the_source_precision() -> None:
+    """The recommended increment type mirrors the source's own to/fracsec,
+    using YEAR as the increment's from for a year/month source and DAY for
+    a day/second source (see datetime_increment tests above for why)."""
+    mode, from_, to, fracsec = c_int(), c_int(), c_int(), c_int()
+
+    full_datetime = scan("15 aug 2001 12:30:45")
+    assert (
+        libdate.datetime_get_increment_type(
+            byref(full_datetime), byref(mode), byref(from_), byref(to), byref(fracsec)
+        )
+        == 0
+    )
+    assert (mode.value, from_.value, to.value) == (
+        libdate.DATETIME_RELATIVE,
+        libdate.DATETIME_DAY,
+        libdate.DATETIME_SECOND,
+    )
+
+    year_month = scan("aug 2001")
+    assert (
+        libdate.datetime_get_increment_type(
+            byref(year_month), byref(mode), byref(from_), byref(to), byref(fracsec)
+        )
+        == 0
+    )
+    assert (mode.value, from_.value, to.value) == (
+        libdate.DATETIME_RELATIVE,
+        libdate.DATETIME_YEAR,
+        libdate.DATETIME_MONTH,
+    )

--- a/lib/datetime/tests/lib_datetime_sign_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_sign_ctypes_test.py
@@ -1,0 +1,69 @@
+"""Tests for the sign, copy, equality and range ctypes bindings
+
+datetime_set_negative(), datetime_copy(), datetime_is_same() and
+datetime_is_between() all operate on values already in memory, so no GRASS
+session is needed here.
+"""
+
+from ctypes import byref
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning the resulting DateTime"""
+    dt = libdate.DateTime()
+    assert libdate.datetime_scan(byref(dt), text.encode()) == 0
+    return dt
+
+
+def test_datetimes_are_positive_by_default() -> None:
+    dt = scan("15 aug 2001")
+    assert libdate.datetime_is_positive(byref(dt))
+    assert not libdate.datetime_is_negative(byref(dt))
+
+
+def test_set_negative_and_invert_sign() -> None:
+    dt = scan("15 aug 2001")
+    libdate.datetime_set_negative(byref(dt))
+    assert libdate.datetime_is_negative(byref(dt))
+
+    libdate.datetime_invert_sign(byref(dt))
+    assert libdate.datetime_is_positive(byref(dt))
+
+
+def test_is_same_compares_by_value() -> None:
+    a = scan("15 aug 2001 12:30:45")
+    b = scan("15 aug 2001 12:30:45")
+    c = scan("16 aug 2001 12:30:45")
+    assert libdate.datetime_is_same(byref(a), byref(b))
+    assert not libdate.datetime_is_same(byref(a), byref(c))
+
+
+def test_copy_is_independent_of_the_source() -> None:
+    original = scan("15 aug 2001")
+    copied = libdate.DateTime()
+    libdate.datetime_copy(byref(copied), byref(original))
+    assert libdate.datetime_is_same(byref(original), byref(copied))
+
+    libdate.datetime_set_year(byref(copied), 1999)
+    assert original.year == 2001
+    assert copied.year == 1999
+
+
+@pytest.mark.parametrize(
+    ("x", "a", "b", "expected"),
+    [
+        # A normal ascending range, including both boundaries.
+        (5, 1, 10, True),
+        (1, 1, 10, True),
+        (10, 1, 10, True),
+        (0, 1, 10, False),
+        # The range is also accepted reversed (a > b).
+        (5, 10, 1, True),
+    ],
+)
+def test_is_between(x, a, b, expected) -> None:
+    assert bool(libdate.datetime_is_between(x, a, b)) == expected

--- a/lib/datetime/tests/lib_datetime_timezone_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_timezone_ctypes_test.py
@@ -1,0 +1,108 @@
+"""Tests for the timezone ctypes bindings
+
+datetime_set_timezone(), datetime_change_timezone() and friends only read
+and write fields of a DateTime struct already in memory, so no GRASS session
+is needed here.
+"""
+
+from ctypes import byref, c_int, create_string_buffer
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def scan(text):
+    """Parse text with datetime_scan(), returning the resulting DateTime"""
+    dt = libdate.DateTime()
+    assert libdate.datetime_scan(byref(dt), text.encode()) == 0
+    return dt
+
+
+def format_datetime(dt):
+    """Format a DateTime with datetime_format(), returning the text"""
+    buf = create_string_buffer(128)
+    assert libdate.datetime_format(byref(dt), buf) == 0
+    return buf.value.decode()
+
+
+@pytest.mark.parametrize(
+    ("tz", "hours", "minutes"),
+    [
+        (330, 5, 30),
+        # The sign is dropped: datetime_decompose_timezone() only reports
+        # magnitude, leaving the caller to read the sign off dt.tz itself.
+        (-330, 5, 30),
+        (0, 0, 0),
+    ],
+)
+def test_decompose_timezone(tz, hours, minutes) -> None:
+    hour, minute = c_int(), c_int()
+    libdate.datetime_decompose_timezone(tz, byref(hour), byref(minute))
+    assert (hour.value, minute.value) == (hours, minutes)
+
+
+@pytest.mark.parametrize(
+    ("minutes", "valid"),
+    [
+        # -12:00 and +13:00 are the documented boundary values.
+        (-720, True),
+        (780, True),
+        (-721, False),
+        (781, False),
+    ],
+)
+def test_is_valid_timezone_boundaries(minutes, valid) -> None:
+    assert bool(libdate.datetime_is_valid_timezone(minutes)) == valid
+
+
+def test_get_timezone_fails_when_none_is_set() -> None:
+    dt = scan("15 aug 2001 12:30:45")
+    minutes = c_int()
+    assert libdate.datetime_get_timezone(byref(dt), byref(minutes)) != 0
+
+
+def test_set_get_and_unset_timezone_round_trip() -> None:
+    dt = scan("15 aug 2001 12:30:45")
+    minutes = c_int()
+
+    assert libdate.datetime_set_timezone(byref(dt), 330) == 0
+    assert libdate.datetime_get_timezone(byref(dt), byref(minutes)) == 0
+    assert minutes.value == 330
+
+    assert libdate.datetime_unset_timezone(byref(dt)) == 0
+    assert libdate.datetime_get_timezone(byref(dt), byref(minutes)) != 0
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_clock"),
+    [
+        # 12:30:45 +05:30 is 07:00:45 in UTC, same calendar day.
+        ("15 aug 2001 12:30:45 +0530", "15 Aug 2001 07:00:45"),
+        # Shifting to UTC here crosses midnight into the previous day.
+        ("1 jan 2000 00:30:00 +0530", "31 Dec 1999 19:00:00"),
+    ],
+)
+def test_change_to_utc_shifts_the_clock(text, expected_clock) -> None:
+    """datetime_change_to_utc() adjusts the clock fields correctly
+
+    It does not, however, update dt.tz to 0 to match: the formatted output
+    keeps showing the original offset even though the clock now reads the
+    UTC time. This contradicts datetime_change_timezone()'s own doc comment
+    ("... and set dt.tz = minutes"), but is harmless today because the only
+    caller, datetime_difference(), discards the timezone field afterward and
+    only reads the shifted clock fields.
+    """
+    dt = scan(text)
+    original_tz = dt.tz
+
+    assert libdate.datetime_change_to_utc(byref(dt)) == 0
+
+    formatted = format_datetime(dt)
+    assert formatted.startswith(expected_clock)
+    assert dt.tz == original_tz
+
+
+def test_change_timezone_rejects_an_invalid_target() -> None:
+    dt = scan("15 aug 2001 12:30:45 +0530")
+    assert libdate.datetime_change_timezone(byref(dt), 781) != 0

--- a/lib/datetime/tests/lib_datetime_type_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_type_ctypes_test.py
@@ -1,0 +1,85 @@
+"""Tests for the DateTime type (mode/from/to/fracsec) ctypes bindings
+
+datetime_set_type() and datetime_check_type() only validate and write the
+type fields of a DateTime struct, so no GRASS session is needed here.
+"""
+
+from ctypes import byref
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def set_type(mode, from_, to, fracsec=0):
+    """Call datetime_set_type(), returning (return_code, DateTime)"""
+    dt = libdate.DateTime()
+    ret = libdate.datetime_set_type(byref(dt), mode, from_, to, fracsec)
+    return ret, dt
+
+
+@pytest.mark.parametrize(
+    ("mode", "from_", "to"),
+    [
+        (libdate.DATETIME_ABSOLUTE, libdate.DATETIME_YEAR, libdate.DATETIME_SECOND),
+        (libdate.DATETIME_ABSOLUTE, libdate.DATETIME_YEAR, libdate.DATETIME_YEAR),
+        (libdate.DATETIME_RELATIVE, libdate.DATETIME_YEAR, libdate.DATETIME_MONTH),
+        (libdate.DATETIME_RELATIVE, libdate.DATETIME_DAY, libdate.DATETIME_SECOND),
+    ],
+)
+def test_set_type_accepts_valid_combinations(mode, from_, to) -> None:
+    ret, dt = set_type(mode, from_, to)
+    assert ret == 0
+    assert libdate.datetime_is_valid_type(byref(dt))
+
+
+def test_set_type_rejects_unknown_mode() -> None:
+    ret, _dt = set_type(0, libdate.DATETIME_YEAR, libdate.DATETIME_SECOND)
+    assert ret == -1
+
+
+def test_set_type_rejects_from_after_to() -> None:
+    ret, _dt = set_type(
+        libdate.DATETIME_ABSOLUTE, libdate.DATETIME_SECOND, libdate.DATETIME_YEAR
+    )
+    assert ret == -4
+
+
+def test_set_type_rejects_absolute_from_other_than_year() -> None:
+    """An absolute datetime always counts from a year, never a smaller unit"""
+    ret, _dt = set_type(
+        libdate.DATETIME_ABSOLUTE, libdate.DATETIME_MONTH, libdate.DATETIME_SECOND
+    )
+    assert ret == -6
+
+
+def test_set_type_rejects_relative_interval_crossing_the_month_day_gap() -> None:
+    """A relative interval cannot span from the year/month group into the
+    day/second group, since there is no fixed number of days in a month"""
+    ret, _dt = set_type(
+        libdate.DATETIME_RELATIVE, libdate.DATETIME_YEAR, libdate.DATETIME_DAY
+    )
+    assert ret == -5
+
+
+def test_set_type_rejects_negative_fracsec_with_seconds() -> None:
+    ret, _dt = set_type(
+        libdate.DATETIME_ABSOLUTE,
+        libdate.DATETIME_YEAR,
+        libdate.DATETIME_SECOND,
+        -1,
+    )
+    assert ret == -7
+
+
+def test_is_absolute_and_is_relative_are_mutually_exclusive() -> None:
+    _, absolute = set_type(
+        libdate.DATETIME_ABSOLUTE, libdate.DATETIME_YEAR, libdate.DATETIME_YEAR
+    )
+    _, relative = set_type(
+        libdate.DATETIME_RELATIVE, libdate.DATETIME_YEAR, libdate.DATETIME_YEAR
+    )
+    assert libdate.datetime_is_absolute(byref(absolute))
+    assert not libdate.datetime_is_relative(byref(absolute))
+    assert libdate.datetime_is_relative(byref(relative))
+    assert not libdate.datetime_is_absolute(byref(relative))

--- a/lib/datetime/tests/lib_datetime_values_ctypes_test.py
+++ b/lib/datetime/tests/lib_datetime_values_ctypes_test.py
@@ -1,0 +1,112 @@
+"""Tests for the field get/set ctypes bindings (year, month, day, ...)
+
+datetime_set_year(), datetime_set_day() and friends only validate and write
+a single field of a DateTime struct, so no GRASS session is needed here.
+"""
+
+from ctypes import byref
+
+import pytest
+
+from grass.lib import date as libdate
+
+
+def absolute_datetime():
+    """A fresh absolute DateTime with year-to-second precision"""
+    dt = libdate.DateTime()
+    libdate.datetime_set_type(
+        byref(dt),
+        libdate.DATETIME_ABSOLUTE,
+        libdate.DATETIME_YEAR,
+        libdate.DATETIME_SECOND,
+        0,
+    )
+    return dt
+
+
+def test_set_year_rejects_zero() -> None:
+    """Year 0 does not exist in the AD/BC calendar: 1 BC is followed by 1 AD"""
+    dt = absolute_datetime()
+    assert libdate.datetime_set_year(byref(dt), 0) != 0
+
+
+@pytest.mark.parametrize("month", [0, 13])
+def test_set_month_rejects_out_of_range(month) -> None:
+    dt = absolute_datetime()
+    assert libdate.datetime_set_month(byref(dt), month) != 0
+
+
+@pytest.mark.parametrize(
+    ("year", "month", "day", "valid"),
+    [
+        # 2000 is a leap year, so February has 29 days.
+        (2000, 2, 29, True),
+        (2000, 2, 30, False),
+        # 1900 is not a leap year, so February has only 28 days.
+        (1900, 2, 29, False),
+        (1900, 2, 28, True),
+    ],
+)
+def test_set_day_is_validated_against_the_month_and_year(
+    year, month, day, valid
+) -> None:
+    """A day is only valid relative to the month and year already set"""
+    dt = absolute_datetime()
+    libdate.datetime_set_year(byref(dt), year)
+    libdate.datetime_set_month(byref(dt), month)
+    ret = libdate.datetime_set_day(byref(dt), day)
+    assert (ret == 0) == valid
+
+
+def test_setting_the_year_resets_the_day() -> None:
+    """Changing the year invalidates any day already set for the old year
+
+    datetime_set_year() zeroes the day field on an absolute datetime rather
+    than leaving a day that might not exist in the new year (e.g. keeping
+    day 29 after moving from a leap year to a non-leap one).
+    """
+    dt = absolute_datetime()
+    libdate.datetime_set_year(byref(dt), 2000)
+    libdate.datetime_set_month(byref(dt), 6)
+    libdate.datetime_set_day(byref(dt), 15)
+    assert dt.day == 15
+
+    libdate.datetime_set_year(byref(dt), 2001)
+    assert dt.day == 0
+
+
+@pytest.mark.parametrize(("hour", "valid"), [(23, True), (24, False)])
+def test_set_hour_rejects_24(hour, valid) -> None:
+    dt = absolute_datetime()
+    assert (libdate.datetime_set_hour(byref(dt), hour) == 0) == valid
+
+
+@pytest.mark.parametrize(("minute", "valid"), [(59, True), (60, False)])
+def test_set_minute_rejects_60(minute, valid) -> None:
+    dt = absolute_datetime()
+    assert (libdate.datetime_set_minute(byref(dt), minute) == 0) == valid
+
+
+@pytest.mark.parametrize(("second", "valid"), [(59.999, True), (60.0, False)])
+def test_set_second_rejects_60(second, valid) -> None:
+    dt = absolute_datetime()
+    assert (libdate.datetime_set_second(byref(dt), second) == 0) == valid
+
+
+def test_set_fracsec_rejects_negative() -> None:
+    dt = absolute_datetime()
+    assert libdate.datetime_set_fracsec(byref(dt), -1) != 0
+    assert libdate.datetime_set_fracsec(byref(dt), 3) == 0
+
+
+def test_check_year_reports_a_missing_year_component() -> None:
+    """A DateTime whose range does not include YEAR has no year to check"""
+    dt = libdate.DateTime()
+    libdate.datetime_set_type(
+        byref(dt),
+        libdate.DATETIME_RELATIVE,
+        libdate.DATETIME_HOUR,
+        libdate.DATETIME_SECOND,
+        0,
+    )
+    assert libdate.datetime_check_year(byref(dt), 2000) == -2


### PR DESCRIPTION
# Add ctypes unit tests for `lib/datetime`

## Summary

`lib/datetime` is the C library behind `G_format_timestamp` and `G_scan_timestamp`, and is used by the timestamp functionality across GRASS, including `r.timestamp`, `v.timestamp`, `r3.timestamp`, and the `t.*` modules.

As discussed in #7802, the library did not previously have a dedicated test suite. This PR adds direct unit tests for the C datetime API using the existing `grass.lib.date` ctypes bindings.

The tests call the C API directly. They do not invoke CLI tools, start a GRASS session, or depend on test fixtures. Since `lib/datetime` does not depend on `G_gisinit` or other GIS state, this keeps the tests at the unit-test level rather than turning them into integration tests.

The suite contains **107 tests across 10 test files**, following the existing ctypes test naming convention used by `lib_vector_rtree_ctypes_test.py`.

## Test Coverage

### `lib_datetime_ctypes_test.py`

Covers `datetime_scan` and `datetime_format`, including:

* Absolute and relative timestamps
* Round-trip parsing and formatting
* BC dates
* Timezone offsets and boundary values
* Fractional and microsecond-level precision
* Invalid timestamp input
* Rejection of 12-hour clock formats where the API expects 24-hour input

### `lib_datetime_type_ctypes_test.py`

Covers:

* `datetime_set_type`
* `datetime_check_type`
* Valid datetime types
* Documented error codes for invalid types

### `lib_datetime_values_ctypes_test.py`

Covers the field-level getters and setters for:

* Year
* Month
* Day
* Hour
* Minute
* Second
* Fractional seconds

Day validation is also covered against leap-year boundaries rather than treating February as having a fixed number of days.

### `lib_datetime_calendar_ctypes_test.py`

Covers:

* `datetime_is_leap_year`
* `datetime_days_in_year`
* `datetime_days_in_month`
* Leap-year behavior
* The documented simplification that BC years are never treated as leap years

### `lib_datetime_sign_ctypes_test.py`

Covers the sign and comparison helpers, including:

* Sign handling
* Copying datetime values
* Equality checks
* Range-related helpers

### `lib_datetime_timezone_ctypes_test.py`

Covers:

* Timezone validation
* Getting and setting timezone values
* Unsetting the timezone
* UTC conversion
* Boundary and offset handling

### `lib_datetime_increment_ctypes_test.py`

Covers `datetime_increment` and its associated validation helpers, including incrementing values across relevant calendar boundaries.

### `lib_datetime_difference_ctypes_test.py`

Covers `datetime_difference` across:

* Day differences
* Month differences
* Timezone-adjusted timestamps
* Cases where timezone offsets affect the resulting difference

### `lib_datetime_change_from_to_ctypes_test.py`

Covers precision changes between datetime representations, including:

* Truncating precision
* Extending precision
* Zero-filling when increasing precision

The more involved rounding modes are intentionally left for a follow-up rather than expanding the scope of this PR.

### `lib_datetime_error_ctypes_test.py`

Covers the library's global error-state API and verifies the expected error handling behavior.

## Existing Behavior Noted During Testing

While testing `datetime_change_timezone` and `datetime_change_to_utc`, I noticed that both functions correctly adjust the clock fields but do not update `dt->tz`, despite the function documentation stating that the timezone field should also be updated.

This does not currently affect the only caller, `datetime_difference`, because that caller discards the timezone field after the conversion.

I have not changed that behavior as part of this PR. Instead, the tests document the current behavior and include a comment explaining the discrepancy rather than treating it as an intentional API guarantee.

I think this would be better handled as a separate issue/PR so that the behavioral change can be reviewed independently.

## Validation

I tested the suite against an actual compiled version of `lib/datetime` rather than relying only on source-level inspection.

For the verification:

1. Compiled the `lib/datetime/*.c` sources into a shared library.
2. Ran the project's actual `ctypesgen` tooling against the real headers to generate the `grass.lib.date` bindings.
3. Ran the complete new test suite against that compiled library.
4. Verified that all **107 tests pass**.
5. Ran formatting and lint checks using the pinned `ruff` version from `.pre-commit-config.yaml` (`v0.15.17`).

This confirms that the tests exercise the compiled C implementation through the same ctypes interface used by the project, rather than testing a Python reimplementation or mocked behavior.

## AI Disclosure

I used AI assistance (Claude) while drafting and iterating on the tests, including helping verify test cases against a real compiled `lib/datetime` build.

I reviewed the generated tests and validation results myself and made the final decisions about coverage, expected behavior, and the scope of the changes.
