### PR TITLE
r.lake: Only set seed point when coordinates are given

### DIFF
--- a/raster/r.lake/main.c
+++ b/raster/r.lake/main.c
@@ -272,13 +272,14 @@ int main(int argc, char *argv[])
     }
 
     /* Set seed point */
-    if (sdxy_opt->answer)
+    if (sdxy_opt->answer) {
         /* Check is water level higher than seed point */
         if (in_terran[start_row][start_col] >= water_level)
             G_fatal_error(
                 _("Given water level at seed point is below earth surface. "
                   "Increase water level or move seed point."));
-    out_water[start_row][start_col] = 1;
+        out_water[start_row][start_col] = 1;
+    }
 
     /* Close seed map for reading. */
     if (smap_opt->answer)

--- a/raster/r.lake/tests/r_lake_test.py
+++ b/raster/r.lake/tests/r_lake_test.py
@@ -1,0 +1,69 @@
+import os
+
+import pytest
+
+import grass.script as gs
+from grass.tools import Tools
+
+
+@pytest.fixture
+def session_with_dem(tmp_path):
+    """A GRASS session with a DEM holding two separate low areas.
+
+    dem: a basin in the south-east corner (rows 15-20, cols 15-20) at
+    elevation 5, a second low area in the north-west corner (rows 1-6,
+    cols 1-6) at elevation 8, and a ridge at elevation 50 separating them.
+    seedmap: a single seed cell inside the south-east basin.
+
+    Only the south-east basin is seeded, so with water_level=10 only it
+    should fill. The north-west area is below the water level but is not
+    reachable from the seed.
+    """
+    project = tmp_path / "r_lake_project"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        tools = Tools(session=session)
+        tools.g_region(n=20, s=0, e=20, w=0, res=1)
+        tools.r_mapcalc(
+            expression=(
+                "dem = if(row() >= 15 && col() >= 15, 5, "
+                "if(row() <= 6 && col() <= 6, 8, 50))"
+            )
+        )
+        tools.r_mapcalc(
+            expression="seedmap = if(row() == 18 && col() == 18, 1, null())"
+        )
+        yield session
+
+
+def test_seed_raster_fills_only_the_seeded_basin(session_with_dem):
+    """A seed raster fills only areas connected to a seed cell."""
+    tools = Tools(session=session_with_dem)
+
+    tools.r_lake(elevation="dem", seed="seedmap", water_level=10, lake="lake_out")
+
+    # The seeded basin is 6x6 cells and nothing else should be wet.
+    stats = tools.r_univar(map="lake_out", format="json").json
+    assert stats["n"] == 36
+
+
+def test_seed_raster_leaves_unseeded_low_area_dry(session_with_dem):
+    """A low area not connected to any seed stays dry."""
+    tools = Tools(session=session_with_dem)
+
+    tools.r_lake(elevation="dem", seed="seedmap", water_level=10, lake="lake_out")
+
+    # Cell in the middle of the unseeded north-west low area.
+    queried = tools.r_what(map="lake_out", coordinates=(2.5, 17.5), format="json").json
+    assert queried[0]["lake_out"]["value"] is None
+
+
+def test_seed_raster_produces_a_single_water_body(session_with_dem):
+    """The result contains exactly one water body when one seed is given."""
+    tools = Tools(session=session_with_dem)
+
+    tools.r_lake(elevation="dem", seed="seedmap", water_level=10, lake="lake_out")
+    tools.r_clump(input="lake_out", output="clumps")
+
+    info = tools.r_info(map="clumps", format="json").json
+    assert info["max"] == 1


### PR DESCRIPTION
## Problem

In `raster/r.lake/main.c` the statement that plants the seed point sits outside the braceless `if (sdxy_opt->answer)` block that is meant to guard it, so it runs on every invocation:

```c
if (sdxy_opt->answer)
    /* Check is water level higher than seed point */
    if (in_terran[start_row][start_col] >= water_level)
        G_fatal_error(...);
out_water[start_row][start_col] = 1;
```

`start_row` and `start_col` are initialised to `0` and are only assigned in the `coordinates=` branch. The parser makes `seed=` and `coordinates=` mutually exclusive, so on every `seed=<raster>` run the line above sets `out_water[0][0] = 1`, adding a seed at the north-west corner cell of the computational region that the user never asked for.

The stray seed is not inert. If the terrain at that corner is below `water_level`, the flood fill spreads from it exactly as it would from a real seed, producing a second water body unconnected to the seed map. If the corner is above `water_level` it is cleared on the first sweep and nothing happens, which is why the defect is easy to miss.

## Impact

The tool exits 0 and emits no warning, so the result looks correct. The reported `Lake area` and `Lake volume` include the spurious body, and the documented workflow of feeding a lake map from one run back in as the seed for the next carries the contamination forward.

## Reproduction

A 20x20 region with a basin in the south-east at elevation 5, a separate low area in the north-west at elevation 8, a ridge at elevation 50 between them, one seed cell inside the south-east basin, and `water_level=10`. Only the south-east basin is reachable from the seed, so the expected result is 36 wet cells in a single water body.

| | before | after |
| --- | --- | --- |
| wet cells | 72 | 36 |
| distinct water bodies | 2 | 1 |
| north-west cell (2.5, 17.5) | 2 | NULL |
| reported lake area | 72.000000 | 36.000000 |
| reported lake volume | 252.000000 | 180.000000 |

## Fix

Add the braces so the seed point is set only when coordinates are given. With `seed=`, `out_water` is already fully populated from the seed raster, so nothing else is needed.

## Tests

`r.lake` had no tests. This adds `raster/r.lake/tests/r_lake_test.py` with three cases covering the seed map path: total wet cells, the unseeded low area staying dry, and the number of distinct water bodies. All three fail on `main` and pass with the fix.

The `coordinates=` path is unchanged. Seeding inside the basin still yields 36 cells, and seeding on the dry ridge still fails with `Given water level at seed point is below earth surface.`
