### PR TITLE
r.lake: Reject seed coordinates on the region edge

### DIFF
--- a/raster/r.lake/main.c
+++ b/raster/r.lake/main.c
@@ -238,8 +238,8 @@ int main(int argc, char *argv[])
         start_col = (int)Rast_easting_to_col(east, &window);
         start_row = (int)Rast_northing_to_row(north, &window);
 
-        if (start_row < 0 || start_row > rows || start_col < 0 ||
-            start_col > cols)
+        if (start_row < 0 || start_row >= rows || start_col < 0 ||
+            start_col >= cols)
             G_fatal_error(_("Seed point outside the current region"));
     }
 

--- a/raster/r.lake/tests/r_lake_test.py
+++ b/raster/r.lake/tests/r_lake_test.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 import grass.script as gs
-from grass.tools import Tools
+from grass.tools import Tools, ToolError
 
 
 @pytest.fixture
@@ -67,3 +67,56 @@ def test_seed_raster_produces_a_single_water_body(session_with_dem):
 
     info = tools.r_info(map="clumps", format="json").json
     assert info["max"] == 1
+
+
+@pytest.fixture
+def session_with_flat_terrain(tmp_path):
+    """A GRASS session with flat terrain below the water level.
+
+    The region is 50 by 50 cells with n=50, s=0, e=50, w=0 and res=1, so the
+    valid cell indices are rows 0 to 49 and columns 0 to 49.
+    """
+    project = tmp_path / "r_lake_seed_project"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        tools = Tools(session=session)
+        tools.g_region(n=50, s=0, e=50, w=0, res=1)
+        tools.r_mapcalc(expression="terrain = 5")
+        yield session
+
+
+@pytest.mark.parametrize(
+    "coordinates", [(25.5, 0), (50, 25.5), (50, 0)], ids=["south", "east", "corner"]
+)
+def test_seed_coordinates_on_region_edge_are_rejected(
+    session_with_flat_terrain, coordinates
+):
+    """Coordinates on the southern or eastern edge are outside the region.
+
+    Those edges belong to the first cell beyond the region, so they must be
+    rejected instead of being used as cell indices.
+    """
+    tools = Tools(session=session_with_flat_terrain)
+
+    with pytest.raises(ToolError) as error:
+        tools.r_lake(
+            elevation="terrain",
+            water_level=10,
+            lake="lake_out",
+            coordinates=coordinates,
+        )
+
+    assert error.value.returncode == 1
+    assert "Seed point outside the current region" in error.value.errors
+
+
+def test_seed_coordinates_in_last_row_are_accepted(session_with_flat_terrain):
+    """Coordinates in the last row are inside the region and fill it."""
+    tools = Tools(session=session_with_flat_terrain)
+
+    tools.r_lake(
+        elevation="terrain", water_level=10, lake="lake_out", coordinates=(25.5, 0.5)
+    )
+
+    stats = tools.r_univar(map="lake_out", format="json").json
+    assert stats["n"] == 2500


### PR DESCRIPTION
## Problem

`r.lake` validates the seed coordinate before using it as a cell index:

```c
start_col = (int)Rast_easting_to_col(east, &window);
start_row = (int)Rast_northing_to_row(north, &window);

if (start_row < 0 || start_row > rows || start_col < 0 ||
    start_col > cols)
    G_fatal_error(_("Seed point outside the current region"));
```

The valid indices are `0` to `rows - 1` and `0` to `cols - 1`, so the comparisons need to be `>=`. As written, `start_row == rows` and `start_col == cols` pass the check.

Those values are reachable from ordinary input. `Rast_northing_to_row()` returns exactly `rows` for a coordinate on the southern edge of the region, and `Rast_easting_to_col()` returns exactly `cols` on the eastern edge. Neither is clamped afterwards.

The arrays have no spare element. `in_terran` and `out_water` hold exactly `rows` row pointers, and each row holds exactly `cols` values, so both indices are one past the end:

```c
in_terran = (FCELL **)G_malloc(rows * sizeof(FCELL *));
in_terran[row] = (FCELL *)G_malloc(cols * sizeof(FCELL));
out_water[row] = (FCELL *)G_calloc(cols, sizeof(FCELL));
...
if (in_terran[start_row][start_col] >= water_level)      /* out of bounds read */
    G_fatal_error(...);
out_water[start_row][start_col] = 1;                     /* out of bounds write */
```

## Effect

A seed on the southern edge reads a pointer from past the end of the pointer array and dereferences it, which crashes. A seed on the eastern edge reads past the end of a row and then writes four bytes past the end of another, after which the tool completes with exit code 0 and writes a lake map containing no water at all, with no warning.

AddressSanitizer on the current main branch:

```
seed on the southern edge (start_row == rows)
  heap-buffer-overflow READ of size 8 at raster/r.lake/main.c:277
  0 bytes after 400-byte region          (50 rows * 8 bytes)

seed on the eastern edge (start_col == cols)
  heap-buffer-overflow READ of size 4 at raster/r.lake/main.c:277
  0 bytes after 200-byte region          (50 cols * 4 bytes)
  heap-buffer-overflow WRITE of size 4 at raster/r.lake/main.c:281
```

## Reproduction

```sh
g.region rows=50 cols=50 w=0 e=50 s=0 n=50 res=1
r.mapcalc "terrain = 5"

r.lake elevation=terrain water_level=10 lake=lk coordinates=25.5,25.5   # 2500 cells
r.lake elevation=terrain water_level=10 lake=lk coordinates=25.5,0      # segmentation fault
r.lake elevation=terrain water_level=10 lake=lk coordinates=50,25.5     # exit 0, empty map
```

The coordinate does not have to be chosen deliberately. `g.region vector=<points>` sets the region bounds to the bounding box of the vector, so the southernmost and easternmost points sit exactly on the region edge:

```sh
g.region vector=pts
r.lake elevation=terrain water_level=10 lake=lk coordinates=<southernmost point>
# segmentation fault
```

## Fix

Use `>=` so the check covers the valid index range. Seeds on the edge then take the existing error path, which is what the check was written to do.

## Tests

Three cases covering the southern edge, the eastern edge and the corner, asserting the tool exits with the regular error rather than a signal, plus one case for a seed in the last row to confirm valid coordinates are still accepted. The three edge cases fail on main and pass with the fix.

`r.cost` and `r.walk` already use the `>=` form for the same check. `r.path` and `r.drain` do not, but they behave differently and are left for a separate change.
