### PR TITLE
r.mfilter: Avoid reopening NamedTemporaryFile on Windows in testsuite

### DIFF
--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -1,7 +1,8 @@
-from tempfile import NamedTemporaryFile
+from pathlib import Path
+
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.gunittest.utils import xfail_windows
 
 
 class TestNeighbors(TestCase):
@@ -185,10 +186,9 @@ class TestNeighbors(TestCase):
 
     def create_filter(self, options):
         """Create a temporary filter file with the given name and options."""
-        f = NamedTemporaryFile()
-        f.write(options)
-        f.flush()
-        return f
+        filter_file = gs.tempfile(create=False)
+        Path(filter_file).write_bytes(options)
+        return filter_file
 
     @classmethod
     def setUpClass(cls):
@@ -203,7 +203,6 @@ class TestNeighbors(TestCase):
                 "g.remove", flags="f", type="raster", name=",".join(cls.to_remove)
             )
 
-    @xfail_windows
     def test_sequential(self):
         """Test output with sequential filter type."""
         test_case = "test_sequential"
@@ -216,16 +215,15 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -237,7 +235,6 @@ class TestNeighbors(TestCase):
             precision=1e-5,
         )
 
-    @xfail_windows
     def test_parallel(self):
         """Test output with parallel filter type."""
         test_case = "test_parallel"
@@ -250,16 +247,15 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -271,7 +267,6 @@ class TestNeighbors(TestCase):
             precision=1e-5,
         )
 
-    @xfail_windows
     def test_sequential_null(self):
         """Test output with sequential filter type with null mode enabled."""
         test_case = "test_sequential_null"
@@ -284,16 +279,15 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="lakes",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z,
-            filter=filter.name,
+            filter=filter,
             flags="z",
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case][False],
@@ -305,7 +299,6 @@ class TestNeighbors(TestCase):
             precision=1e-5,
         )
 
-    @xfail_windows
     def test_parallel_null(self):
         """Test output with parallel filter type with null mode enabled."""
         test_case = "test_parallel_null"
@@ -320,31 +313,30 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="lakes",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z,
-            filter=filter.name,
+            filter=filter,
             flags="z",
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z_threaded,
-            filter=filter.name,
+            filter=filter,
             flags="z",
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case][False],
@@ -366,7 +358,6 @@ class TestNeighbors(TestCase):
             precision=1e-5,
         )
 
-    @xfail_windows
     def test_multiple_filters(self):
         """Test output with multiple filters."""
         test_case = "test_multiple_filters"
@@ -379,16 +370,15 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -400,7 +390,6 @@ class TestNeighbors(TestCase):
             precision=1e-5,
         )
 
-    @xfail_windows
     def test_repeated_filters(self):
         """Test output with repeated filters."""
         test_case = "test_repeated_filters"
@@ -413,18 +402,17 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
             repeat=3,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             repeat=3,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],


### PR DESCRIPTION
## Description

Extracts and reworks one self-contained change out of upstream PR
[OSGeo/grass#2616](https://github.com/OSGeo/grass/pull/2616) ("CI: Address
Windows specific issues in testsuite", open since 2022, 35 commits, by
Stefan Blumentrath / @ninsbl) so it can be evaluated on its own. Opened
against this fork, for testing, not upstream.

`raster/r.mfilter/testsuite/test_r_mfilter.py` creates its filter-definition
temp file with `tempfile.NamedTemporaryFile()` and keeps it open (via
`.name`) while `r.mfilter` opens the same path again. On Windows this second
open fails, because Windows does not allow reopening a file that another
handle (here, the still-open Python file object) has locked. That's why all
6 tests in this file carry `@xfail_windows`. #2616 replaces this with
`grass.script.tempfile(create=False)`, which only reserves a unique path (via
`g.tempfile -d`) without holding it open, then writes to it directly.

## Motivation and context

An AI (Claude) review of #2616 in July 2026, and a second one now, flagged
this as the easiest individual piece of that PR to land as its own, minimal
PR: it is confined to one test file, has a well-understood, verifiable root
cause (the double-open bug is exactly what `@xfail_windows`'s own docstring
describes), and doesn't depend on any of the PR's other, more invasive
Windows changes.

That said, #2616's own diff for this file is not usable as a straight
cherry-pick: it was branched in 2022 and never rebased, so its diff against
current `main` also reverts changes unrelated to the tempfile fix that
landed on `main` in the meantime — a docstring correction
(`nc_spm_full_v2alphav2` -> `nc_spm_full_v2beta1`), tightened `variance`
reference values, and trailing-whitespace cleanup. This PR re-implements
just the tempfile fix against current `main`, so none of that unrelated
history gets clobbered. It also drops `filter.close()` (no longer needed,
since `filter` is now a path string, not a file object) and the
`@xfail_windows` markers themselves, per the instruction in
`xfail_windows`'s own docstring: "Once the test is fixed and passing, remove
the decorator."

I have not verified this on an actual Windows machine. If the Windows CI job
here still fails, the `@xfail_windows` markers should be restored, and the
underlying reasoning re-examined — the AI analysis should not be taken as
proof the fix works, only as a plausible, checkable hypothesis.

## How has this been tested?

- `python3 -m py_compile` on the changed file.
- `ruff check --preview` and `ruff format --diff` (both clean, ruff 0.15.17
  to match `.pre-commit-config.yaml`).
- Not run against a live GRASS build or on Windows (no build available in
  this environment) — relying on this fork's CI to confirm the fix on
  Windows and non-regression on Linux/macOS.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. (No new tests added; existing
tests in this file are what the change fixes and un-xfails.)

---

Original fix idea from Stefan Blumentrath (@ninsbl) in
[OSGeo/grass#2616](https://github.com/OSGeo/grass/pull/2616), reworked here
against current `main`. AI-assisted (Claude) analysis and implementation;
please verify independently before relying on this, especially the removal
of the `@xfail_windows` markers.

Generated with [Claude Code](https://claude.com/claude-code) (sonnet 5)