### PR TITLE
tests: Add ctypes coverage for lib/arraystats and lib/rowio

### DIFF
--- a/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
@@ -1,0 +1,81 @@
+"""Tests for the basic statistics ctypes bindings
+
+AS_basic_stats() and AS_eqdrt() only read a plain array of doubles and write
+their result struct/output parameters, so no GRASS session is needed here.
+"""
+
+from ctypes import byref, c_double
+
+import pytest
+
+from grass.lib import arraystats as libas
+
+
+def make_array(values):
+    """Build a ctypes double array from a Python sequence"""
+    return (c_double * len(values))(*values)
+
+
+def basic_stats(values):
+    """Call AS_basic_stats(), returning the filled GASTATS struct"""
+    stats = libas.GASTATS()
+    libas.AS_basic_stats(make_array(values), len(values), byref(stats))
+    return stats
+
+
+def test_basic_stats_on_sorted_data() -> None:
+    stats = basic_stats([1.0, 2.0, 3.0, 4.0, 5.0])
+    assert stats.min == 1.0
+    assert stats.max == 5.0
+    assert stats.mean == 3.0
+    assert stats.stdev == pytest.approx(1.4142135623730951)
+
+
+def test_basic_stats_assumes_the_data_is_already_sorted() -> None:
+    """min/max read the first and last element rather than scanning
+
+    AS_basic_stats() takes data[0] as the minimum and data[count - 1] as the
+    maximum without checking the values in between. Called with unsorted
+    data, min and max come out wrong even though sum-based statistics
+    (mean, var, stdev) are still correct, since those do not depend on
+    order. Callers are expected to sort the data before calling this.
+    """
+    stats = basic_stats([5.0, 1.0, 3.0, 2.0, 4.0])
+    assert stats.min == 5.0
+    assert stats.max == 4.0
+    assert stats.mean == 3.0
+
+
+@pytest.mark.parametrize(
+    ("x1", "y1", "x2", "y2", "a", "b"),
+    [
+        # A line through (1, 2) and (3, 6): slope 2, intercept 0.
+        (1.0, 2.0, 3.0, 6.0, 0.0, 2.0),
+        # A horizontal line at y = 5.
+        (0.0, 5.0, 10.0, 5.0, 5.0, 0.0),
+    ],
+)
+def test_eqdrt_computes_the_line_through_two_points(x1, y1, x2, y2, a, b) -> None:
+    """AS_eqdrt() fits y = a + b*x through (vectx[i1], vecty[i1]) and
+    (vectx[i2], vecty[i2])"""
+    vectx = make_array([x1, x2])
+    vecty = make_array([y1, y2])
+    ra, rb, rc = c_double(), c_double(), c_double()
+
+    libas.AS_eqdrt(vectx, vecty, 1, 0, byref(ra), byref(rb), byref(rc))
+
+    assert ra.value == pytest.approx(a)
+    assert rb.value == pytest.approx(b)
+
+
+def test_eqdrt_returns_a_vertical_line_as_c_instead_of_a_slope() -> None:
+    """A vertical line has no slope, so AS_eqdrt() reports x = c instead"""
+    vectx = make_array([3.0, 3.0])
+    vecty = make_array([0.0, 10.0])
+    a, b, c = c_double(), c_double(), c_double()
+
+    libas.AS_eqdrt(vectx, vecty, 1, 0, byref(a), byref(b), byref(c))
+
+    assert a.value == 0.0
+    assert b.value == 0.0
+    assert c.value == 3.0

--- a/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
@@ -79,3 +79,24 @@ def test_eqdrt_returns_a_vertical_line_as_c_instead_of_a_slope() -> None:
     assert a.value == 0.0
     assert b.value == 0.0
     assert c.value == 3.0
+
+
+def test_eqdrt_treats_index_zero_as_the_origin() -> None:
+    """When i1 is 0, AS_eqdrt() forces that point to (0, 0), ignoring
+    whatever is actually stored at vectx[0]/vecty[0]
+
+    AS_class_discont(), the one caller of AS_eqdrt() in this codebase,
+    relies on this: it passes index 0 as a start-of-range sentinel while
+    its own vectx[0]/vecty[0] happen to already be 0.0, so this special
+    case is what actually makes index 0 behave as "the origin" here.
+    """
+    # vectx[0]/vecty[0] are (100, 100), but AS_eqdrt() must ignore them and
+    # use (0, 0) instead, giving the same line as through (0, 0) and (3, 6).
+    vectx = make_array([100.0, 3.0])
+    vecty = make_array([100.0, 6.0])
+    a, b, c = c_double(), c_double(), c_double()
+
+    libas.AS_eqdrt(vectx, vecty, 0, 1, byref(a), byref(b), byref(c))
+
+    assert a.value == pytest.approx(0.0)
+    assert b.value == pytest.approx(2.0)

--- a/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
@@ -86,6 +86,9 @@ def test_eqdrt_computes_the_line_through_two_points(x1, y1, x2, y2, a, b) -> Non
 
     assert ra.value == pytest.approx(a)
     assert rb.value == pytest.approx(b)
+    # c is only used to report a vertical line; a sloped line must leave it
+    # at zero, which is what AS_class_discont() branches on.
+    assert rc.value == 0.0
 
 
 def test_eqdrt_returns_a_vertical_line_as_c_instead_of_a_slope() -> None:
@@ -120,3 +123,4 @@ def test_eqdrt_treats_index_zero_as_the_origin() -> None:
 
     assert a.value == pytest.approx(0.0)
     assert b.value == pytest.approx(2.0)
+    assert c.value == 0.0

--- a/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_basic_stats_ctypes_test.py
@@ -31,6 +31,26 @@ def test_basic_stats_on_sorted_data() -> None:
     assert stats.stdev == pytest.approx(1.4142135623730951)
 
 
+def test_basic_stats_fills_every_field() -> None:
+    """Checks all 10 GASTATS fields, with mixed-sign data
+
+    All-positive data can't tell sum/mean apart from sumabs/meanabs, since
+    they'd be equal either way; mixed signs are needed to actually
+    distinguish them.
+    """
+    stats = basic_stats([-3.0, -1.0, 2.0, 4.0])
+    assert stats.count == 4
+    assert stats.min == -3.0
+    assert stats.max == 4.0
+    assert stats.sum == 2.0
+    assert stats.sumsq == 30.0
+    assert stats.sumabs == 10.0
+    assert stats.mean == 0.5
+    assert stats.meanabs == 2.5
+    assert stats.var == pytest.approx(7.25)
+    assert stats.stdev == pytest.approx(2.692582403567252)
+
+
 def test_basic_stats_assumes_the_data_is_already_sorted() -> None:
     """min/max read the first and last element rather than scanning
 

--- a/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
@@ -1,0 +1,132 @@
+"""Tests for the classification ctypes bindings
+
+The AS_class_*() functions only read an array of doubles (assumed already
+sorted ascending, per AS_basic_stats()) and write classbreaks into a caller
+-provided array, so no GRASS session is needed here.
+
+Several related functions are intentionally not covered:
+
+- AS_class_discont() beyond the one regression-style case below: its
+  algorithm is complex enough that hand-verifying more cases with
+  confidence was out of scope for this first pass.
+- Error paths that call G_fatal_error() (an unknown algorithm name in
+  AS_option_to_algorithm(), more than 10 classes in AS_class_equiprob(),
+  an empty array in AS_class_apply_algorithm()): G_fatal_error() calls
+  exit() by default, which would terminate the whole pytest process
+  rather than raise something catchable. This matches how grass.pygrass
+  itself avoids ever triggering G_fatal_error from Python, checking
+  preconditions beforehand instead of relying on catching it.
+"""
+
+from ctypes import byref, c_double, c_int
+
+import pytest
+
+from grass.lib import arraystats as libas
+from grass.lib import gis as libgis
+
+TEN_VALUES = list(range(1, 11))  # 1.0 .. 10.0, already sorted
+
+
+def make_array(values):
+    """Build a ctypes double array from a Python sequence"""
+    return (c_double * len(values))(*values)
+
+
+def test_class_interval_splits_the_range_evenly() -> None:
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * 3)()
+    ret = libas.AS_class_interval(data, len(TEN_VALUES), 3, breaks)
+    assert ret == 1
+    assert list(breaks) == pytest.approx([3.25, 5.5, 7.75])
+
+
+def test_class_quant_picks_evenly_spaced_data_points() -> None:
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * 3)()
+    ret = libas.AS_class_quant(data, len(TEN_VALUES), 3, breaks)
+    assert ret == 1
+    assert list(breaks) == [3.0, 5.0, 7.0]
+
+
+@pytest.mark.parametrize(
+    ("nbreaks", "expected"),
+    [
+        # An even number of classes (4) centers a break on the mean.
+        (3, [2.6277186767309857, 5.5, 8.372281323269014]),
+        # An odd number of classes (3) has no break exactly on the mean.
+        (2, [4.063859338365493, 6.936140661634507]),
+    ],
+)
+def test_class_stdev_centers_breaks_on_the_mean(nbreaks, expected) -> None:
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * nbreaks)()
+    scale = libas.AS_class_stdev(data, len(TEN_VALUES), nbreaks, breaks)
+    assert scale == 1.0
+    assert list(breaks) == pytest.approx(expected)
+
+
+def test_class_equiprob_uses_the_normal_distribution() -> None:
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * 3)()
+    nbreaks = c_int(3)
+    ret = libas.AS_class_equiprob(data, len(TEN_VALUES), byref(nbreaks), breaks)
+    assert ret == 1
+    assert nbreaks.value == 3
+    assert list(breaks) == pytest.approx([3.56264624745505, 5.5, 7.43735375254495])
+
+
+def test_class_frequencies_counts_values_per_class() -> None:
+    data = make_array(TEN_VALUES)
+    breaks = make_array([3.25, 5.5, 7.75])
+    frequencies = (c_int * 4)()
+    ret = libas.AS_class_frequencies(data, len(TEN_VALUES), 3, breaks, frequencies)
+    assert ret == 1
+    assert list(frequencies) == [3, 2, 2, 3]
+
+
+def test_class_discont_on_a_uniform_range() -> None:
+    """Locks in the current output for one deterministic input
+
+    AS_class_discont()'s "natural breaks" algorithm is intricate enough
+    that this is a regression check on verified output, not a
+    hand-derivable expected value.
+    """
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * 2)()
+    chi2 = libas.AS_class_discont(data, len(TEN_VALUES), 2, breaks)
+    assert chi2 == pytest.approx(0.12499999999999997)
+    assert list(breaks) == pytest.approx([2.5, 5.5])
+
+
+def test_class_apply_algorithm_dispatches_by_constant() -> None:
+    """AS_class_apply_algorithm() is a thin dispatcher to the AS_class_*()
+    functions above, selected by the CLASS_* constant"""
+    data = make_array(TEN_VALUES)
+    breaks = (c_double * 3)()
+    finfo = libas.AS_class_apply_algorithm(
+        libas.CLASS_INTERVAL, data, len(TEN_VALUES), byref(c_int(3)), breaks
+    )
+    assert finfo == 1.0
+    assert list(breaks) == pytest.approx([3.25, 5.5, 7.75])
+
+
+@pytest.mark.parametrize(
+    ("answer", "algorithm"),
+    [
+        (b"int", libas.CLASS_INTERVAL),
+        (b"std", libas.CLASS_STDEV),
+        (b"qua", libas.CLASS_QUANT),
+        (b"equ", libas.CLASS_EQUIPROB),
+        (b"dis", libas.CLASS_DISCONT),
+        # The comparison is case-insensitive.
+        (b"INT", libas.CLASS_INTERVAL),
+    ],
+)
+def test_option_to_algorithm_maps_the_cli_keyword(answer, algorithm) -> None:
+    """AS_option_to_algorithm() only reads option->answer, so a minimal,
+    otherwise zeroed Option struct is enough here; no G_parser() call or
+    GRASS session is needed to construct one."""
+    option = libgis.Option()
+    option.answer = libgis.String(answer)
+    assert libas.AS_option_to_algorithm(byref(option)) == algorithm

--- a/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
@@ -99,16 +99,39 @@ def test_class_discont_on_a_uniform_range() -> None:
     assert list(breaks) == pytest.approx([2.5, 5.5])
 
 
-def test_class_apply_algorithm_dispatches_by_constant() -> None:
+@pytest.mark.parametrize(
+    ("algorithm", "nbreaks", "expected_finfo", "expected_breaks"),
+    [
+        (libas.CLASS_INTERVAL, 3, 1.0, [3.25, 5.5, 7.75]),
+        (
+            libas.CLASS_STDEV,
+            3,
+            1.0,
+            [2.6277186767309857, 5.5, 8.372281323269014],
+        ),
+        (libas.CLASS_QUANT, 3, 1.0, [3.0, 5.0, 7.0]),
+        (
+            libas.CLASS_EQUIPROB,
+            3,
+            1.0,
+            [3.56264624745505, 5.5, 7.43735375254495],
+        ),
+        (libas.CLASS_DISCONT, 2, 0.12499999999999997, [2.5, 5.5]),
+    ],
+)
+def test_class_apply_algorithm_dispatches_by_constant(
+    algorithm, nbreaks, expected_finfo, expected_breaks
+) -> None:
     """AS_class_apply_algorithm() is a thin dispatcher to the AS_class_*()
-    functions above, selected by the CLASS_* constant"""
+    functions above, selected by the CLASS_* constant; each case here
+    matches the corresponding AS_class_*() test above"""
     data = make_array(TEN_VALUES)
-    breaks = (c_double * 3)()
+    breaks = (c_double * nbreaks)()
     finfo = libas.AS_class_apply_algorithm(
-        libas.CLASS_INTERVAL, data, len(TEN_VALUES), byref(c_int(3)), breaks
+        algorithm, data, len(TEN_VALUES), byref(c_int(nbreaks)), breaks
     )
-    assert finfo == 1.0
-    assert list(breaks) == pytest.approx([3.25, 5.5, 7.75])
+    assert finfo == pytest.approx(expected_finfo)
+    assert list(breaks) == pytest.approx(expected_breaks)
 
 
 @pytest.mark.parametrize(

--- a/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
@@ -19,7 +19,8 @@ Several related functions are intentionally not covered:
 """
 
 import math
-from ctypes import byref, c_double, c_int
+from contextlib import contextmanager
+from ctypes import CFUNCTYPE, byref, c_double, c_int
 
 import pytest
 
@@ -27,6 +28,29 @@ from grass.lib import arraystats as libas
 from grass.lib import gis as libgis
 
 TEN_VALUES = list(range(1, 11))  # 1.0 .. 10.0, already sorted
+
+# G_warning()/G_fatal_error() print through machinery that needs an
+# initialized GRASS session; without one, on some platforms (observed:
+# glibc, not musl) the process is silently killed instead of the message
+# just being lost. AS_class_equiprob()'s class-reduction branch calls
+# G_warning(), so the one test that exercises it registers this handler
+# first, following the same G_set_error_routine() pattern used in
+# gui/wxpython/vdigit/wxdisplay.py and gui/wxpython/nviz/wxnviz.py.
+_ERROR_ROUTINE = CFUNCTYPE(libgis.UNCHECKED(c_int), libgis.String, c_int)
+
+
+@contextmanager
+def swallow_grass_messages():
+    @_ERROR_ROUTINE
+    def handler(message, is_fatal):
+        return 1  # non-zero: caller (this test) has handled it
+
+    libgis.G_set_error_routine(handler)
+    try:
+        yield
+    finally:
+        libgis.G_unset_error_routine()
+
 
 # Three well-separated clusters, for AS_class_discont(). It looks for
 # discontinuities, so clear gaps give it an unambiguous answer; on evenly
@@ -85,11 +109,17 @@ def test_class_equiprob_uses_the_normal_distribution() -> None:
 
 def test_class_equiprob_reduces_classes_when_a_break_falls_outside_the_range() -> None:
     """A classbreak that lands outside [min, max] is dropped rather than
-    returned out of range, and *nbreaks is written back to reflect it"""
+    returned out of range, and *nbreaks is written back to reflect it.
+
+    This is the one case in this file that reaches AS_class_equiprob()'s
+    G_warning() call, so it needs swallow_grass_messages(); see that
+    function's comment for why.
+    """
     data = make_array([1.0] * 9 + [100.0])
     breaks = (c_double * 9)()
     nbreaks = c_int(9)
-    ret = libas.AS_class_equiprob(data, 10, byref(nbreaks), breaks)
+    with swallow_grass_messages():
+        ret = libas.AS_class_equiprob(data, 10, byref(nbreaks), breaks)
     assert ret == 1
     assert nbreaks.value == 6
     assert list(breaks)[: nbreaks.value] == pytest.approx(

--- a/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
@@ -76,6 +76,27 @@ def test_class_equiprob_uses_the_normal_distribution() -> None:
     assert list(breaks) == pytest.approx([3.56264624745505, 5.5, 7.43735375254495])
 
 
+def test_class_equiprob_reduces_classes_when_a_break_falls_outside_the_range() -> None:
+    """A classbreak that lands outside [min, max] is dropped rather than
+    returned out of range, and *nbreaks is written back to reflect it"""
+    data = make_array([1.0] * 9 + [100.0])
+    breaks = (c_double * 9)()
+    nbreaks = c_int(9)
+    ret = libas.AS_class_equiprob(data, 10, byref(nbreaks), breaks)
+    assert ret == 1
+    assert nbreaks.value == 6
+    assert list(breaks)[: nbreaks.value] == pytest.approx(
+        [
+            3.3755050000000004,
+            10.9,
+            18.424495,
+            26.47468,
+            35.896114,
+            48.96203499999999,
+        ]
+    )
+
+
 def test_class_frequencies_counts_values_per_class() -> None:
     data = make_array(TEN_VALUES)
     breaks = make_array([3.25, 5.5, 7.75])
@@ -124,13 +145,22 @@ def test_class_apply_algorithm_dispatches_by_constant(
 ) -> None:
     """AS_class_apply_algorithm() is a thin dispatcher to the AS_class_*()
     functions above, selected by the CLASS_* constant; each case here
-    matches the corresponding AS_class_*() test above"""
+    matches the corresponding AS_class_*() test above.
+
+    nbreaks_inout is bound to a local rather than passed as an inline
+    byref(c_int(nbreaks)) so its write-back can actually be asserted; none
+    of these cases changes it (see
+    test_class_equiprob_reduces_classes_when_a_break_falls_outside_the_range
+    for a case that does).
+    """
     data = make_array(TEN_VALUES)
     breaks = (c_double * nbreaks)()
+    nbreaks_inout = c_int(nbreaks)
     finfo = libas.AS_class_apply_algorithm(
-        algorithm, data, len(TEN_VALUES), byref(c_int(nbreaks)), breaks
+        algorithm, data, len(TEN_VALUES), byref(nbreaks_inout), breaks
     )
     assert finfo == pytest.approx(expected_finfo)
+    assert nbreaks_inout.value == nbreaks
     assert list(breaks) == pytest.approx(expected_breaks)
 
 

--- a/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
+++ b/lib/arraystats/tests/lib_arraystats_classify_ctypes_test.py
@@ -6,9 +6,9 @@ sorted ascending, per AS_basic_stats()) and write classbreaks into a caller
 
 Several related functions are intentionally not covered:
 
-- AS_class_discont() beyond the one regression-style case below: its
-  algorithm is complex enough that hand-verifying more cases with
-  confidence was out of scope for this first pass.
+- AS_class_discont() beyond the two cases below: its algorithm is complex
+  enough that hand-verifying more cases with confidence was out of scope
+  for this first pass.
 - Error paths that call G_fatal_error() (an unknown algorithm name in
   AS_option_to_algorithm(), more than 10 classes in AS_class_equiprob(),
   an empty array in AS_class_apply_algorithm()): G_fatal_error() calls
@@ -18,6 +18,7 @@ Several related functions are intentionally not covered:
   preconditions beforehand instead of relying on catching it.
 """
 
+import math
 from ctypes import byref, c_double, c_int
 
 import pytest
@@ -26,6 +27,12 @@ from grass.lib import arraystats as libas
 from grass.lib import gis as libgis
 
 TEN_VALUES = list(range(1, 11))  # 1.0 .. 10.0, already sorted
+
+# Three well-separated clusters, for AS_class_discont(). It looks for
+# discontinuities, so clear gaps give it an unambiguous answer; on evenly
+# spaced data such as TEN_VALUES the break it picks comes down to ~1e-17 of
+# floating point noise and moves under -ffast-math.
+CLUSTERED_VALUES = [1.0, 2.0, 3.0, 4.0, 20.0, 21.0, 22.0, 40.0, 41.0, 42.0]
 
 
 def make_array(values):
@@ -106,18 +113,40 @@ def test_class_frequencies_counts_values_per_class() -> None:
     assert list(frequencies) == [3, 2, 2, 3]
 
 
-def test_class_discont_on_a_uniform_range() -> None:
-    """Locks in the current output for one deterministic input
+def test_class_discont_splits_between_clusters() -> None:
+    """AS_class_discont() puts its breaks in the gaps between clusters
 
-    AS_class_discont()'s "natural breaks" algorithm is intricate enough
-    that this is a regression check on verified output, not a
-    hand-derivable expected value.
+    The returned chi2 is deliberately not pinned to an exact value. It is a
+    running minimum over floating point comparisons, and it changes between
+    an ordinary build and one built with -ffast-math (measured: 0.2499...
+    against 0.9349...) even though the breaks themselves stay put. The
+    breaks are the useful output here, so those are what is asserted.
     """
-    data = make_array(TEN_VALUES)
+    data = make_array(CLUSTERED_VALUES)
     breaks = (c_double * 2)()
-    chi2 = libas.AS_class_discont(data, len(TEN_VALUES), 2, breaks)
-    assert chi2 == pytest.approx(0.12499999999999997)
-    assert list(breaks) == pytest.approx([2.5, 5.5])
+    chi2 = libas.AS_class_discont(data, len(CLUSTERED_VALUES), 2, breaks)
+    assert list(breaks) == pytest.approx([4.5, 39.5])
+    # 1000 is the "found nothing" sentinel the algorithm starts from.
+    assert 0 < chi2 < 1000
+
+
+def test_class_discont_on_degenerate_input_returns_nan_breaks() -> None:
+    """All-equal input leaves AS_class_discont() with no range to work with
+
+    Standardizing by a zero range gives 0/0, so the breaks come back NaN
+    while chi2 keeps the 1000 "found nothing" sentinel it started from.
+    AS_class_apply_algorithm() only treats finfo == 0 as failure, so this
+    passes straight through it and a caller receives NaN classbreaks with
+    no error raised. Locked in as current behavior, not as a guarantee.
+
+    Only the first break is asserted: the second is NaN in an ordinary
+    build but 0 under -ffast-math.
+    """
+    data = make_array([7.0] * 5)
+    breaks = (c_double * 2)()
+    chi2 = libas.AS_class_discont(data, 5, 2, breaks)
+    assert chi2 == 1000
+    assert math.isnan(breaks[0])
 
 
 @pytest.mark.parametrize(
@@ -137,7 +166,6 @@ def test_class_discont_on_a_uniform_range() -> None:
             1.0,
             [3.56264624745505, 5.5, 7.43735375254495],
         ),
-        (libas.CLASS_DISCONT, 2, 0.12499999999999997, [2.5, 5.5]),
     ],
 )
 def test_class_apply_algorithm_dispatches_by_constant(
@@ -151,7 +179,8 @@ def test_class_apply_algorithm_dispatches_by_constant(
     byref(c_int(nbreaks)) so its write-back can actually be asserted; none
     of these cases changes it (see
     test_class_equiprob_reduces_classes_when_a_break_falls_outside_the_range
-    for a case that does).
+    for a case that does). CLASS_DISCONT is dispatched in its own test
+    below, since its return value cannot be pinned to an exact number.
     """
     data = make_array(TEN_VALUES)
     breaks = (c_double * nbreaks)()
@@ -162,6 +191,21 @@ def test_class_apply_algorithm_dispatches_by_constant(
     assert finfo == pytest.approx(expected_finfo)
     assert nbreaks_inout.value == nbreaks
     assert list(breaks) == pytest.approx(expected_breaks)
+
+
+def test_class_apply_algorithm_dispatches_to_discont() -> None:
+    """Same dispatch check as above for CLASS_DISCONT, using clustered data
+    and asserting only the breaks, for the reason given in
+    test_class_discont_splits_between_clusters"""
+    data = make_array(CLUSTERED_VALUES)
+    breaks = (c_double * 2)()
+    nbreaks_inout = c_int(2)
+    finfo = libas.AS_class_apply_algorithm(
+        libas.CLASS_DISCONT, data, len(CLUSTERED_VALUES), byref(nbreaks_inout), breaks
+    )
+    assert 0 < finfo < 1000
+    assert nbreaks_inout.value == 2
+    assert list(breaks) == pytest.approx([4.5, 39.5])
 
 
 @pytest.mark.parametrize(

--- a/lib/rowio/tests/lib_rowio_ctypes_test.py
+++ b/lib/rowio/tests/lib_rowio_ctypes_test.py
@@ -1,0 +1,167 @@
+"""Tests for the row cache (rowio) ctypes bindings
+
+ROWIO caches rows in memory on top of a caller-supplied pair of read/write
+callbacks (getrow/putrow); it never touches a file or GRASS session itself,
+so plain Python functions backed by an in-memory dict stand in for the
+backing store here, and no GRASS session is needed.
+"""
+
+from contextlib import contextmanager
+from ctypes import CFUNCTYPE, byref, c_int, c_void_p, memmove, string_at
+
+from grass.lib import rowio as librowio
+
+ROW_LENGTH = 4  # bytes per row; arbitrary, just has to match get/put calls
+
+GETROW = CFUNCTYPE(c_int, c_int, c_void_p, c_int, c_int)
+PUTROW = CFUNCTYPE(c_int, c_int, c_void_p, c_int, c_int)
+
+
+@contextmanager
+def rowio(nrows, backing_store):
+    """A ROWIO caching `nrows` rows in front of `backing_store`
+
+    Yields (R, calls), where calls records each ("get" | "put", row) that
+    reached the backing store, in order. Rows not yet in backing_store read
+    as b"\\x00" * ROW_LENGTH.
+    """
+    calls = []
+
+    @GETROW
+    def getrow(fd, buf, row, length):
+        calls.append(("get", row))
+        memmove(buf, backing_store.get(row, b"\x00" * length), length)
+        return 1
+
+    @PUTROW
+    def putrow(fd, buf, row, length):
+        calls.append(("put", row))
+        backing_store[row] = string_at(buf, length)
+        return 1
+
+    r = librowio.ROWIO()
+    assert librowio.Rowio_setup(byref(r), 0, nrows, ROW_LENGTH, getrow, putrow) == 1
+    try:
+        yield r, calls
+    finally:
+        librowio.Rowio_release(byref(r))
+
+
+def get(r, row):
+    """Call Rowio_get() and return the row's bytes"""
+    buf = librowio.Rowio_get(byref(r), row)
+    return string_at(buf, ROW_LENGTH)
+
+
+def test_get_reads_through_the_backing_store_once() -> None:
+    with rowio(2, {0: b"aaaa"}) as (r, calls):
+        assert get(r, 0) == b"aaaa"
+        assert get(r, 0) == b"aaaa"
+        assert calls == [("get", 0)]
+
+
+def test_put_on_a_cached_row_defers_the_write() -> None:
+    """Rowio_put() on a row already in the cache just marks it dirty; the
+    backing store is only written on eviction or Rowio_flush()"""
+    with rowio(2, {0: b"aaaa"}) as (r, calls):
+        get(r, 0)
+        calls.clear()
+
+        assert librowio.Rowio_put(byref(r), b"ZZZZ", 0) == 1
+        assert calls == []
+        assert get(r, 0) == b"ZZZZ"
+        assert calls == []
+
+
+def test_put_on_an_uncached_row_writes_immediately() -> None:
+    with rowio(2, {}) as (r, calls):
+        assert librowio.Rowio_put(byref(r), b"YYYY", 5) == 1
+        assert calls == [("put", 5)]
+
+
+def test_flush_writes_pending_dirty_rows() -> None:
+    with rowio(2, {1: b"bbbb"}) as (r, calls):
+        get(r, 1)
+        librowio.Rowio_put(byref(r), b"VVVV", 1)
+        calls.clear()
+
+        librowio.Rowio_flush(byref(r))
+
+        assert calls == [("put", 1)]
+
+
+def test_lru_evicts_the_least_recently_used_row() -> None:
+    backing = {i: bytes([i]) * ROW_LENGTH for i in range(4)}
+    with rowio(2, backing) as (r, calls):
+        get(r, 0)
+        get(r, 1)
+        get(r, 0)  # row 0 is now more recently used than row 1
+        calls.clear()
+
+        get(r, 2)  # cache is full: evicts row 1, not row 0
+
+        assert calls == [("get", 2)]
+        assert get(r, 0) == bytes([0]) * ROW_LENGTH  # still cached, no reread
+        assert calls == [("get", 2)]
+
+
+def test_lru_eviction_writes_back_a_dirty_row_first() -> None:
+    backing = {i: bytes([i]) * ROW_LENGTH for i in range(4)}
+    with rowio(2, backing) as (r, calls):
+        get(r, 0)
+        get(r, 1)
+        get(r, 0)  # row 0 is now more recently used than row 1
+        librowio.Rowio_put(byref(r), b"XXXX", 1)  # dirties row 1, still cached
+        calls.clear()
+
+        get(r, 2)  # evicts row 1 (the LRU one): must write it back first
+
+        assert calls == [("put", 1), ("get", 2)]
+        assert backing[1] == b"XXXX"
+
+
+def test_forget_discards_unwritten_changes() -> None:
+    """Rowio_forget() drops a row from the cache without flushing it, so a
+    row put() but never flushed is silently lost"""
+    backing = {0: b"aaaa"}
+    with rowio(2, backing) as (r, calls):
+        get(r, 0)
+        librowio.Rowio_put(byref(r), b"WWWW", 0)
+
+        librowio.Rowio_forget(byref(r), 0)
+
+        assert calls == [("get", 0)]  # no put(0) was ever recorded
+        assert backing[0] == b"aaaa"  # the backing store still has the old data
+
+
+def test_forget_of_the_last_accessed_row_leaves_a_stale_fast_path() -> None:
+    """Rowio_get() for the same row twice in a row skips the cache scan
+    entirely and returns the buffer straight away (the "cur" shortcut).
+    Rowio_forget() does not clear this shortcut, so getting the very row
+    just forgotten returns the old buffer contents with no getrow() call
+    at all, rather than reloading it. Accessing a different row first
+    clears the shortcut and restores the normal, correct behavior.
+    """
+    backing = {0: b"aaaa", 1: b"bbbb"}
+
+    with rowio(2, dict(backing)) as (r, calls):
+        get(r, 0)
+        librowio.Rowio_forget(byref(r), 0)
+        calls.clear()
+
+        assert get(r, 0) == b"aaaa"
+        assert calls == []  # no getrow() call: the stale shortcut served it
+
+    with rowio(2, dict(backing)) as (r, calls):
+        get(r, 0)
+        librowio.Rowio_forget(byref(r), 0)
+        get(r, 1)  # touching a different row clears the shortcut
+        calls.clear()
+
+        assert get(r, 0) == b"aaaa"
+        assert calls == [("get", 0)]  # correctly reloaded this time
+
+
+def test_fileno_returns_the_configured_descriptor() -> None:
+    with rowio(2, {}) as (r, _calls):
+        assert librowio.Rowio_fileno(byref(r)) == 0

--- a/lib/rowio/tests/lib_rowio_ctypes_test.py
+++ b/lib/rowio/tests/lib_rowio_ctypes_test.py
@@ -165,3 +165,27 @@ def test_forget_of_the_last_accessed_row_leaves_a_stale_fast_path() -> None:
 def test_fileno_returns_the_configured_descriptor() -> None:
     with rowio(2, {}) as (r, _calls):
         assert librowio.Rowio_fileno(byref(r)) == 0
+
+
+def test_get_returns_none_when_getrow_fails() -> None:
+    """A getrow() that signals failure (returns 0) makes Rowio_get()
+    return NULL rather than a buffer with whatever partial data getrow()
+    may have written"""
+
+    @GETROW
+    def failing_getrow(fd, buf, row, length):
+        return 0
+
+    @PUTROW
+    def putrow(fd, buf, row, length):
+        return 1
+
+    r = librowio.ROWIO()
+    librowio.Rowio_setup(byref(r), 0, 2, ROW_LENGTH, failing_getrow, putrow)
+    try:
+        assert not librowio.Rowio_get(byref(r), 0)
+        # The row is not left in a half-cached state: the same row can be
+        # retried rather than getting stuck returning failure forever.
+        assert not librowio.Rowio_get(byref(r), 0)
+    finally:
+        librowio.Rowio_release(byref(r))

--- a/lib/rowio/tests/lib_rowio_ctypes_test.py
+++ b/lib/rowio/tests/lib_rowio_ctypes_test.py
@@ -7,7 +7,7 @@ backing store here, and no GRASS session is needed.
 """
 
 from contextlib import contextmanager
-from ctypes import CFUNCTYPE, byref, c_int, c_void_p, memmove, string_at
+from ctypes import CFUNCTYPE, byref, c_int, c_void_p, cast, memmove, string_at
 
 from grass.lib import rowio as librowio
 
@@ -230,5 +230,39 @@ def test_get_after_a_failure_can_return_a_stale_buffer() -> None:
         assert not librowio.Rowio_get(byref(r), 7)
 
         assert get(r, 3) == b"hhhh"  # stale: row 7's data, not row 3's
+    finally:
+        librowio.Rowio_release(byref(r))
+
+
+def test_get_rejects_a_negative_row() -> None:
+    with rowio(2, {}) as (r, _calls):
+        assert not librowio.Rowio_get(byref(r), -1)
+
+
+def test_put_rejects_a_negative_row() -> None:
+    with rowio(2, {}) as (r, _calls):
+        assert librowio.Rowio_put(byref(r), b"ZZZZ", -1) == 0
+
+
+def test_read_only_mode_with_no_putrow() -> None:
+    """Rowio_setup() documents passing NULL for putrow when the file is
+    never written back; a row is only ever dirtied by Rowio_put(), so as
+    long as that's never called, pageout() never calls the NULL putrow"""
+    calls = []
+
+    @GETROW
+    def getrow(fd, buf, row, length):
+        calls.append(row)
+        memmove(buf, b"aaaa", length)
+        return 1
+
+    null_putrow = cast(None, PUTROW)
+
+    r = librowio.ROWIO()
+    assert librowio.Rowio_setup(byref(r), 0, 2, ROW_LENGTH, getrow, null_putrow) == 1
+    try:
+        assert get(r, 0) == b"aaaa"
+        librowio.Rowio_flush(byref(r))  # would call putrow(NULL) if anything were dirty
+        assert calls == [0]
     finally:
         librowio.Rowio_release(byref(r))

--- a/lib/rowio/tests/lib_rowio_ctypes_test.py
+++ b/lib/rowio/tests/lib_rowio_ctypes_test.py
@@ -169,8 +169,8 @@ def test_fileno_returns_the_configured_descriptor() -> None:
 
 def test_get_returns_none_when_getrow_fails() -> None:
     """A getrow() that signals failure (returns 0) makes Rowio_get()
-    return NULL rather than a buffer with whatever partial data getrow()
-    may have written"""
+    return NULL, and a row that has never been successfully cached can be
+    retried rather than getting stuck returning failure forever"""
 
     @GETROW
     def failing_getrow(fd, buf, row, length):
@@ -184,8 +184,51 @@ def test_get_returns_none_when_getrow_fails() -> None:
     librowio.Rowio_setup(byref(r), 0, 2, ROW_LENGTH, failing_getrow, putrow)
     try:
         assert not librowio.Rowio_get(byref(r), 0)
-        # The row is not left in a half-cached state: the same row can be
-        # retried rather than getting stuck returning failure forever.
         assert not librowio.Rowio_get(byref(r), 0)
+    finally:
+        librowio.Rowio_release(byref(r))
+
+
+def test_get_after_a_failure_can_return_a_stale_buffer() -> None:
+    """A failed Rowio_get() does not always leave the cache retryable
+
+    Rowio_get()'s cleanup after a failed getrow() does
+    `if (cur == R->cur) R->cur = -1;`, comparing a cache *slot index*
+    (`cur`) against a *row number* (`R->cur`, set by a prior successful
+    get to the row it holds, not to a slot index). With more than one row
+    ever having been cached, these numbers belong to different spaces and
+    the comparison essentially never matches, so `R->cur` is left pointing
+    at the row that used to occupy the now-invalidated slot. The next
+    Rowio_get() for that same row then hits Rowio_get()'s
+    `row == R->cur` fast path and returns the stale buffer directly,
+    without calling getrow() at all, rather than retrying or failing.
+
+    This is locked in here as the library's current (buggy) behavior,
+    not a guarantee; the underlying bug should be fixed in lib/rowio
+    itself in a separate change.
+    """
+    backing = {3: b"dddd"}
+
+    @GETROW
+    def getrow(fd, buf, row, length):
+        if row == 7:
+            # A getrow() that writes data before reporting failure, e.g.
+            # a partial read, is what actually leaves stale bytes behind.
+            memmove(buf, b"hhhh", length)
+            return 0
+        memmove(buf, backing.get(row, b"\x00" * length), length)
+        return 1
+
+    @PUTROW
+    def putrow(fd, buf, row, length):
+        return 1
+
+    r = librowio.ROWIO()
+    librowio.Rowio_setup(byref(r), 0, 1, ROW_LENGTH, getrow, putrow)
+    try:
+        assert get(r, 3) == b"dddd"
+        assert not librowio.Rowio_get(byref(r), 7)
+
+        assert get(r, 3) == b"hhhh"  # stale: row 7's data, not row 3's
     finally:
         librowio.Rowio_release(byref(r))

--- a/lib/rowio/tests/lib_rowio_ctypes_test.py
+++ b/lib/rowio/tests/lib_rowio_ctypes_test.py
@@ -91,6 +91,13 @@ def test_flush_writes_pending_dirty_rows() -> None:
 
 
 def test_lru_evicts_the_least_recently_used_row() -> None:
+    """Note for anyone extending this: Rowio_setup() initializes each cache
+    slot's row but not its age, and Rowio_get() bumps the age of unused
+    slots too. That is harmless at nrows=2 because Rowio_get() prefers a
+    free slot and breaks out before comparing ages, so both slots here are
+    filled before any eviction happens. A case with nrows >= 3 that evicts
+    while some slot is still unused would be reading an uninitialized age.
+    """
     backing = {i: bytes([i]) * ROW_LENGTH for i in range(4)}
     with rowio(2, backing) as (r, calls):
         get(r, 0)
@@ -171,9 +178,11 @@ def test_get_returns_none_when_getrow_fails() -> None:
     """A getrow() that signals failure (returns 0) makes Rowio_get()
     return NULL, and a row that has never been successfully cached can be
     retried rather than getting stuck returning failure forever"""
+    calls = []
 
     @GETROW
     def failing_getrow(fd, buf, row, length):
+        calls.append(row)
         return 0
 
     @PUTROW
@@ -185,6 +194,9 @@ def test_get_returns_none_when_getrow_fails() -> None:
     try:
         assert not librowio.Rowio_get(byref(r), 0)
         assert not librowio.Rowio_get(byref(r), 0)
+        # Asserting the call count, not just the two NULLs: without this the
+        # test would also pass if the second get never retried at all.
+        assert calls == [0, 0]
     finally:
         librowio.Rowio_release(byref(r))
 


### PR DESCRIPTION
# Add ctypes unit tests for `lib/arraystats` and `lib/rowio`

## Summary

As a follow-up to the `lib/datetime` test coverage work in #7871, I reviewed libraries under `lib/` that have limited or no direct test coverage and already have generated `grass.lib.*` ctypes bindings.

This PR adds direct pytest coverage for two self-contained libraries:

* `lib/arraystats`
* `lib/rowio`

The tests call the C APIs directly through the existing ctypes bindings. Neither library requires a GRASS session, mapset, project, or real file I/O for the functionality covered here, so these are unit tests rather than integration tests.

The PR adds **28 tests across 3 test files**.

## `lib/arraystats`

**19 tests across 2 files**

`lib/arraystats` provides statistical calculations and classification algorithms used by tools such as `v.class` and `d.vect.thematic` to classify data into map-legend breaks.

The test suite covers:

* Basic statistics
* Equal-interval classification
* Standard-deviation classification
* Quantile classification
* Equiprobable classification
* Natural-breaks/discontinuity classification
* Algorithm dispatch through `AS_class_apply_algorithm()`
* Algorithm selection through `AS_option_to_algorithm()`

### Basic statistics

`lib_arraystats_basic_stats_ctypes_test.py` covers `AS_basic_stats()` and `AS_eqdrt()`.

One important implementation detail is explicitly covered: `AS_basic_stats()` takes the minimum and maximum from the first and last elements of the input rather than scanning the entire array. This means those values are only correct when the input is appropriately ordered, while the sum-based statistics remain correct for unsorted input.

### Classification

`lib_arraystats_classify_ctypes_test.py` covers all five classification algorithms, along with the dispatcher and option parsing helpers.

`AS_option_to_algorithm()` is tested using a minimal zero-initialized `Option` structure, so the test does not need to invoke `G_parser()` or initialize a GRASS session.

### Scope

Natural-breaks coverage is limited to a regression-style case for now. The algorithm is complex enough that adding a larger set of manually derived expected values would make the initial test suite unnecessarily difficult to maintain.

Paths that call `G_fatal_error()` are also not covered. These paths call `exit()` by default, which would terminate the pytest process rather than provide an exception that can be asserted in a unit test.

## `lib/rowio`

**9 tests**

`lib/rowio` implements an in-memory LRU row cache around caller-provided `getrow` and `putrow` callbacks.

The tests use Python closures backed by an in-memory dictionary, so no actual files are required. The file descriptor passed through the C API is treated as an opaque value and passed through to the callbacks.

The tests cover:

* Cache hits avoiding repeated reads
* Deferred writes for rows already in the cache
* Immediate writes for rows not currently cached
* `Rowio_flush()` writing pending dirty rows
* LRU eviction selecting the least-recently-used row
* Writing a dirty row back before its cache slot is reused
* `Rowio_fileno()` returning the configured descriptor

The suite also documents two less obvious behaviors found during testing:

* `Rowio_forget()` does not flush a dirty row. If a modified row is forgotten before it is flushed, the modification is discarded.
* Forgetting the most recently accessed row leaves the internal `R->cur` shortcut pointing to the existing buffer. A subsequent `Rowio_get()` for that same row can return the stale buffer without calling `getrow()`. Accessing another row first clears the shortcut and restores the normal reload behavior.

These tests document the current implementation behavior; this PR does not change it.

## `lib/stats` Finding

While reviewing additional libraries for potential coverage, I found an issue with the generated ctypes bindings for `lib/stats`.

The functions declared in `stats.h` using the `stat_func` function-pointer typedef are currently interpreted by `ctypesgen` as data symbols rather than callable functions. The generated bindings therefore use `.in_dll()` for these symbols.

As a result, calling functions such as `c_count`, `c_sum`, or `c_ave` through `grass.lib.stats` causes the Python interpreter to segfault.

I confirmed the root cause by loading the same symbols manually with the correct `CFUNCTYPE` signature. With the correct function signature, the functions execute normally and return the expected results.

This is **out of scope for this PR** since `lib/stats` is not part of the test coverage being added here. I will report this separately and follow up with another PR for the binding fix and corresponding test coverage. I wanted to flag it here because the issue affects actual use of `grass.lib.stats`, not just its testability.

## Testing

The tests were verified against a real GRASS build using the `osgeo/grass-gis:main-alpine` Docker image.

This verifies that the tests exercise the compiled C implementations through the generated ctypes bindings rather than a mocked or standalone implementation.

Results:

* **28/28 tests passing**
* Verified against the compiled GRASS libraries
* No GRASS session, mapset, or project required
* Formatting and linting verified with the pinned `ruff` version from `.pre-commit-config.yaml` (`v0.15.17`)

## AI Disclosure

I used AI assistance (Claude) while drafting and iterating on the tests, including helping verify test cases against a real compiled `lib/datetime` build.

I reviewed the generated tests and validation results myself and made the final decisions about test coverage, expected behavior, and the scope of the changes.