### PR TITLE
r.sim.water: in manual page link r.manning addon instead of table

### DIFF
--- a/raster/r.sim/r.sim.water/r.sim.water.html
+++ b/raster/r.sim/r.sim.water/r.sim.water.html
@@ -163,36 +163,22 @@ machines due to the independence of sampling points. Therefore, the methods
 are useful both for everyday exploratory work using a desktop computer and
 for large, cutting-edge applications using high performance computing.
 
-<p>
-<b>Suggested Manning's n for surface roughness</b><br>
-from <a href="https://baharmon.github.io/hydrology-in-grass">https://baharmon.github.io/hydrology-in-grass</a>
-<p>
-<table border="1">
- <tr><th>NLCD Landcover Category</th><th>Manning’s n value</th></tr>
- <tr><td>Open Water</td><td>0.001</td></tr>
- <tr><td>Developed, Open Space</td><td>0.0404</td></tr>
- <tr><td>Developed, Low Intensity</td><td>0.0678</td></tr>
- <tr><td>Developed, Medium Intensity</td><td>0.0678</td></tr>
- <tr><td>Developed, High Intensity</td><td>0.0404</td></tr>
- <tr><td>Barren Land</td><td>0.0113</td></tr>
- <tr><td>Deciduous Forest</td><td>0.36</td></tr>
- <tr><td>Evergreen Forest</td><td>0.32</td></tr>
- <tr><td>Mixed Forest</td><td>0.4</td></tr>
- <tr><td>Shrub/Scrub</td><td>0.4</td></tr>
- <tr><td>Grassland/Herbaceuous</td><td>0.368</td></tr>
- <tr><td>Pasture/Hay</td><td>0.325</td></tr>
- <tr><td>Cultivated Crops</td><td>0.325</td></tr>
- <tr><td>Woody Wetlands</td><td>0.086</td></tr>
- <tr><td>Emergent Herbaceuous Wetlands</td><td>0.1825</td></tr>
-</table>
+<h3>Manning's n for surface roughness</h3>
+
+The <b>man</b> raster map can be derived from a land cover raster with the
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.manning.html">r.manning</a>
+addon, which provides Manning's n values for the NLCD and ESA WorldCover
+land cover classifications as well as for user-defined ones:
+
+<div class="code"><pre>
+g.extension extension=r.manning
+r.manning input=nlcd_landcover output=mannings_n landcover=nlcd
+</pre></div>
 
 <p>
-The <a href="https://www.usgs.gov/centers/eros/science/annual-nlcd-science-product-user-guide">NLCD user guide</a>
-provides more information about the different NLCD classes.
-
-<p>
-Increasing the number of threads with <b>nprocs</b> does not really
-speed up the simulation.
+For the shallow overland flow simulated here, Manning's n is generally
+higher than for deeper channel or floodplain flow, especially over
+vegetated surfaces, see the <em>r.manning</em> documentation.
 
 <h2>EXAMPLE</h2>
 
@@ -282,9 +268,10 @@ The International Series in Engineering and Computer Science: Volume 773. Spring
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="v.surf.rst.html">v.surf.rst</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.manning.html">r.manning</a> (addon),
+<a href="r.sim.sediment.html">r.sim.sediment</a>,
 <a href="r.slope.aspect.html">r.slope.aspect</a>,
-<a href="r.sim.sediment.html">r.sim.sediment</a>
+<a href="v.surf.rst.html">v.surf.rst</a>
 </em>
 
 <h2>AUTHORS</h2>

--- a/raster/r.sim/r.sim.water/r.sim.water.md
+++ b/raster/r.sim/r.sim.water/r.sim.water.md
@@ -151,33 +151,21 @@ independence of sampling points. Therefore, the methods are useful both
 for everyday exploratory work using a desktop computer and for large,
 cutting-edge applications using high performance computing.
 
-**Suggested Manning's n for surface roughness**  
-from <https://baharmon.github.io/hydrology-in-grass>
+### Manning's n for surface roughness
 
-| NLCD Landcover Category       | Manning’s n value |
-|-------------------------------|-------------------|
-| Open Water                    | 0.001             |
-| Developed, Open Space         | 0.0404            |
-| Developed, Low Intensity      | 0.0678            |
-| Developed, Medium Intensity   | 0.0678            |
-| Developed, High Intensity     | 0.0404            |
-| Barren Land                   | 0.0113            |
-| Deciduous Forest              | 0.36              |
-| Evergreen Forest              | 0.32              |
-| Mixed Forest                  | 0.4               |
-| Shrub/Scrub                   | 0.4               |
-| Grassland/Herbaceuous         | 0.368             |
-| Pasture/Hay                   | 0.325             |
-| Cultivated Crops              | 0.325             |
-| Woody Wetlands                | 0.086             |
-| Emergent Herbaceuous Wetlands | 0.1825            |
+The **man** raster map can be derived from a land cover raster with the
+[r.manning](https://grass.osgeo.org/grass-stable/manuals/addons/r.manning.html)
+addon, which provides Manning's n values for the NLCD and ESA WorldCover
+land cover classifications as well as for user-defined ones:
 
-The [NLCD user
-guide](https://www.usgs.gov/centers/eros/science/annual-nlcd-science-product-user-guide)
-provides more information about the different NLCD classes.
+```sh
+g.extension extension=r.manning
+r.manning input=nlcd_landcover output=mannings_n landcover=nlcd
+```
 
-Increasing the number of threads with **nprocs** does not really speed
-up the simulation.
+For the shallow overland flow simulated here, Manning's n is generally
+higher than for deeper channel or floodplain flow, especially over
+vegetated surfaces, see the *r.manning* documentation.
 
 ## EXAMPLE
 
@@ -257,8 +245,9 @@ Carolina sample dataset.*
 
 ## SEE ALSO
 
-*[v.surf.rst](v.surf.rst.md), [r.slope.aspect](r.slope.aspect.md),
-[r.sim.sediment](r.sim.sediment.md)*
+*[r.manning](https://grass.osgeo.org/grass-stable/manuals/addons/r.manning.html)
+(addon), [r.sim.sediment](r.sim.sediment.md),
+[r.slope.aspect](r.slope.aspect.md), [v.surf.rst](v.surf.rst.md)*
 
 ## AUTHORS
 


### PR DESCRIPTION
I replaced part of documentation in r.sim.water that included a table with manning values with link to r.manning addon that uses published values.