### PR TITLE
chore: Ignore common AI agent worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,12 @@ lib/*/latex/
 .coverage.*
 coverage.xml
 
+# Ignore project-local git worktree directories created by AI coding
+# agent workflows (e.g. Claude Code)
+.claude/worktrees/
+.worktrees/
+worktrees/
+
 # Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos
 


### PR DESCRIPTION
Add gitignore patterns for project-local git worktree directories
created by common AI coding agent workflows, including Claude Code's
`.claude/worktrees/`, as well as the generic `.worktrees/` and
`worktrees/` conventions.