### PR TITLE
style: Strip stray control characters instead of excluding files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -153,10 +153,8 @@ end_of_line = unset
 charset = unset
 insert_final_newline = unset
 
-# These are valid UTF-8 text but contain a few stray control characters that
-# editorconfig-checker's binary detection flags as non-utf-8.
-# configure is autoconf-generated and uses BEL (\007) as an awk field
-# separator; lib/external/ccmath is vendored third-party code; the two
-# r.drain READMEs are historical, pre-existing content.
-[{configure,raster/r.drain/README,scripts/r.drain/README,lib/external/ccmath/C01-matrix}]
+# configure is autoconf-generated and uses BEL (\007) as an awk
+# field separator, which editorconfig-checker's binary detection flags as
+# non-utf-8.
+[configure]
 charset = unset

--- a/lib/external/ccmath/C01-matrix
+++ b/lib/external/ccmath/C01-matrix
@@ -877,8 +877,8 @@ qrbd1
             updated by the computation
        v = pointer to store of n by n orthogonal matrix V updated
            by the computation
-       m = number of rows in the U1 matrix
-       n = size of the d and e arrays, number of columns in the U1
+       m = number of rows in the U1 matrix
+       n = size of the d and e arrays, number of columns in the U1
            matrix, and the number of rows and columns in the V matrix.
       return value: N = number of QR iterations required
 

--- a/raster/r.drain/README
+++ b/raster/r.drain/README
@@ -21,7 +21,7 @@ r.d2 reproduces most of the behavior of r.drain.  It does not use the
 all of the flags defined for r.drain.  My first draft of the model
 didn't correctly handle the ew,ns and diagonal resolutions (as
 r.fill.dir does not).  I believe that I fixed that problem.  There are
-also some other minor behaviors that differ a little from r.drain.
+also some other minor behaviors that differ a little from r.drain.
 
 r.d2 runs pretty quickly on a small, clean dem, but it can take quite a
 while  to run on a large cell map - particularly one with very many

--- a/scripts/r.drain/README
+++ b/scripts/r.drain/README
@@ -21,7 +21,7 @@ r.d2 reproduces most of the behavior of r.drain.  It does not use the
 all of the flags defined for r.drain.  My first draft of the model
 didn't correctly handle the ew,ns and diagonal resolutions (as
 r.fill.dir does not).  I believe that I fixed that problem.  There are
-also some other minor behaviors that differ a little from r.drain.
+also some other minor behaviors that differ a little from r.drain.
 
 r.d2 runs pretty quickly on a small, clean dem, but it can take quite a
 while  to run on a large cell map - particularly one with very many


### PR DESCRIPTION
Follow-up to #7459, resolving the discussion in #7888.

The editorconfig-checker bump to v3.11.3 added a pre-decode binary-detection
check that flags a file as binary, and so fails the utf-8 charset check, if it
contains any C0 control byte. Four files were marked `charset = unset` as a
mechanical workaround. In #7888, @nilason confirmed the bytes in three of them
carry no meaning and are better removed, including the vendored ccmath file,
which is no longer maintained upstream.

## Changes

- `raster/r.drain/README`, `scripts/r.drain/README`: drop a stray `0x18` (CAN)
  in line 24, `that <CAN>differ a little from r.drain.`
- `lib/external/ccmath/C01-matrix`: lines 880-881 held a `0x13`/`0x16`
  (DC3/SYN) pair acting as a subscript toggle around `U1`. The same matrix is
  written plainly as `U1` everywhere else in that file, including at lines
  682-694, 788, 803, 811 and 868, and in the very signature these two lines
  document (`u1 = pointer to store of m by n transformation matrix U1`), so
  the reading is confirmed rather than inferred.
- `.editorconfig`: the exception now covers only `configure`, whose BEL byte is
  a legitimate awk field separator in autoconf-generated code.

No behavioral change; documentation and build-config text only.

## Verification

`pre-commit run editorconfig-checker --all-files` reports zero charset, utf-8
or binary errors across the tree. `lib/external/ccmath/C01-matrix` is now
decoded and charset-checked without complaint rather than skipped, which is
the positive confirmation that the strip worked; the two READMEs no longer
appear at all.

The only errors in that run are line-ending ones, which are a local
`core.autocrlf=true` checkout artifact on Windows (`git ls-files --eol` shows
`i/lf w/crlf` on untouched files too), not something this PR introduces.

Closes #7888

AI (Claude Opus 5) was used to locate the byte sequences, verify the `U1`
reading against the rest of the file, and check the result with the hook.
