### PR TITLE
r.lake: Reject seed coordinates north or west of the region

### DIFF
--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -318,7 +318,7 @@ build_program_in_subdir(
 
 build_program_in_subdir(r.latlong DEPENDS grass_gis grass_raster grass_gproj)
 
-build_program_in_subdir(r.lake DEPENDS grass_gis grass_raster)
+build_program_in_subdir(r.lake DEPENDS grass_gis grass_raster ${LIBM})
 
 build_program_in_subdir(
     r.mask.status

--- a/raster/r.lake/Makefile
+++ b/raster/r.lake/Makefile
@@ -4,7 +4,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.lake
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.lake/main.c
+++ b/raster/r.lake/main.c
@@ -28,6 +28,7 @@
  *  Kaarliit, shii programma ir veltiita Tev.
  *
  */
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -232,8 +233,8 @@ int main(int argc, char *argv[])
 
         G_scan_easting(sdxy_opt->answers[0], &east, G_projection());
         G_scan_northing(sdxy_opt->answers[1], &north, G_projection());
-        start_col = (int)Rast_easting_to_col(east, &window);
-        start_row = (int)Rast_northing_to_row(north, &window);
+        start_col = (int)floor(Rast_easting_to_col(east, &window));
+        start_row = (int)floor(Rast_northing_to_row(north, &window));
 
         if (start_row < 0 || start_row >= rows || start_col < 0 ||
             start_col >= cols)

--- a/raster/r.lake/tests/r_lake_test.py
+++ b/raster/r.lake/tests/r_lake_test.py
@@ -110,12 +110,55 @@ def test_seed_coordinates_on_region_edge_are_rejected(
     assert "Seed point outside the current region" in error.value.errors
 
 
+@pytest.mark.parametrize(
+    "coordinates",
+    [(25.5, 50.5), (25.5, 50.9), (-0.5, 25.5), (-0.9, 25.5)],
+    ids=["north", "north-almost-one-cell", "west", "west-almost-one-cell"],
+)
+def test_seed_coordinates_less_than_a_cell_outside_are_rejected(
+    session_with_flat_terrain, coordinates
+):
+    """Coordinates north or west of the region are outside it.
+
+    Truncating the converted index towards zero turns the whole interval
+    between -1 and 0 into row or column 0, which hides these coordinates from
+    the check below zero.
+    """
+    tools = Tools(session=session_with_flat_terrain)
+
+    with pytest.raises(ToolError) as error:
+        tools.r_lake(
+            elevation="terrain",
+            water_level=10,
+            lake="lake_out",
+            coordinates=coordinates,
+        )
+
+    assert error.value.returncode == 1
+    assert "Seed point outside the current region" in error.value.errors
+
+
 def test_seed_coordinates_in_last_row_are_accepted(session_with_flat_terrain):
     """Coordinates in the last row are inside the region and fill it."""
     tools = Tools(session=session_with_flat_terrain)
 
     tools.r_lake(
         elevation="terrain", water_level=10, lake="lake_out", coordinates=(25.5, 0.5)
+    )
+
+    stats = tools.r_univar(map="lake_out", format="json").json
+    assert stats["n"] == 2500
+
+
+@pytest.mark.parametrize("coordinates", [(25.5, 50), (0, 25.5)], ids=["north", "west"])
+def test_seed_coordinates_on_north_and_west_edge_are_accepted(
+    session_with_flat_terrain, coordinates
+):
+    """The northern and western edges belong to the first row and column."""
+    tools = Tools(session=session_with_flat_terrain)
+
+    tools.r_lake(
+        elevation="terrain", water_level=10, lake="lake_out", coordinates=coordinates
     )
 
     stats = tools.r_univar(map="lake_out", format="json").json


### PR DESCRIPTION
Follow up to #7877, which covers the southern and eastern bounds. This one covers the northern and western bounds, which have a different problem.

## Problem

`r.lake` converts the seed coordinate to a cell index with a plain cast:

```c
start_col = (int)Rast_easting_to_col(east, &window);
start_row = (int)Rast_northing_to_row(north, &window);

if (start_row < 0 || start_row > rows || start_col < 0 ||
    start_col > cols)
    G_fatal_error(_("Seed point outside the current region"));
```

The cast truncates towards zero, so every value between -1 and 0 becomes 0. A coordinate less than one cell north or west of the region therefore never reaches the check below zero. It is accepted and quietly used as row 0 or column 0, which is a cell the user did not ask for.

Going further out works, because at -1 and beyond the cast produces a negative value and the check catches it.

## Reproduction

```sh
g.region rows=50 cols=50 w=0 e=50 s=0 n=50 res=1
r.mapcalc "terrain = 5"

r.lake elevation=terrain water_level=10 lake=lk coordinates=25.5,50     # on the north edge, row 0, correct
r.lake elevation=terrain water_level=10 lake=lk coordinates=25.5,50.5   # outside, accepted as row 0
r.lake elevation=terrain water_level=10 lake=lk coordinates=-0.5,25.5   # outside, accepted as column 0
r.lake elevation=terrain water_level=10 lake=lk coordinates=25.5,51.5   # outside, correctly rejected
```

The second and third commands should print `Seed point outside the current region` and instead they fill the map.

## Fix

Floor the converted value so the interval between -1 and 0 stays negative and the existing check sees it. The northern and western edges themselves still map to row 0 and column 0, so seeds there keep working.

## Tests

Four cases just outside the northern and western edges, which fail without the fix, and two cases on the edges themselves, which confirm valid seeds are still accepted.

Note that this touches `raster/r.lake/tests/r_lake_test.py` in the same place as #7877, so whichever merges second will need a small rebase.
