### PR TITLE
CI: Enable XML in codespell and fix typos- #685

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,4 +131,3 @@ repos:
           - markdown
           - python
           - tex
-          - xml

--- a/gui/wxpython/core/testsuite/data/test_toolboxes_menudata_ref.xml
+++ b/gui/wxpython/core/testsuite/data/test_toolboxes_menudata_ref.xml
@@ -61,14 +61,14 @@
         <menuitem>
           <label>Display map projection</label>
           <command>g.proj -p</command>
-          <help>Converts co-ordinate system descriptions (i.e. projection information) between various formats (including GRASS format).</help>
+          <help>Converts coordinate system descriptions (i.e. projection information) between various formats (including GRASS format).</help>
           <keywords>general,projection,create project</keywords>
           <handler>RunMenuCmd</handler>
         </menuitem>
         <menuitem>
           <label>Manage projections</label>
           <command>g.proj</command>
-          <help>Prints or modifies GRASS projection information files (in various co-ordinate system descriptions). Can also be used to create new GRASS locations.</help>
+          <help>Prints or modifies GRASS projection information files (in various coordinate system descriptions). Can also be used to create new GRASS locations.</help>
           <keywords>general,projection,create project</keywords>
           <handler>OnMenuCmd</handler>
         </menuitem>

--- a/gui/wxpython/xml/wxgui_items.xml
+++ b/gui/wxpython/xml/wxgui_items.xml
@@ -316,7 +316,7 @@
   <wxgui-item name="DisplayMapProjection">
     <label>Display map projection</label>
     <command>g.proj -p</command>
-    <description>Converts co-ordinate system descriptions (i.e. projection information) between various formats (including GRASS format).</description>
+    <description>Converts coordinate system descriptions (i.e. projection information) between various formats (including GRASS format).</description>
     <keywords>general,projection,create project,create project</keywords>
   </wxgui-item>
   <wxgui-item name="InstallExtensionFromAddons">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ skip = [
     "utils/fix_typos.sh",
     "utils/release.yml",                  # TODO
     '*.dox',                              # TODO
+    "*.svg",                              # Embedded base64 image data
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

Enables XML file type in codespell, fixes typos found in XML files, and skips SVG files (which codespell/identify treats as XML) to avoid false positives from embedded base64 image data.

## Changes

- **Enable XML in codespell**: Removed `xml` from `exclude_types` in `.pre-commit-config.yaml`.
- **Fix typos**: Corrected "co-ordinate" to "coordinate" in:
  - `gui/wxpython/xml/wxgui_items.xml` (1 occurrence)
  - `gui/wxpython/core/testsuite/data/test_toolboxes_menudata_ref.xml` (2 occurrences)
- **Skip SVG files**: Added `*.svg` to codespell's `skip` list in `pyproject.toml`. SVG is tagged as an XML type by `identify`, so enabling XML also unexcluded SVG; `gui/images/splash_screen.svg` embeds a base64 JPEG that codespell misread as typos (e.g. "nd", "Ot", "tHt"), which failed CI.

## Testing

- `pre-commit run codespell --all-files` passes locally.