### PR TITLE
temporal: create limited connection to TGIS DB in current mapset for (un-) registering maps

### DIFF
--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -20,7 +20,12 @@ from datetime import datetime
 import grass.script as gs
 
 from .abstract_map_dataset import AbstractMapDataset
-from .core import get_current_mapset, get_tgis_message_interface, init_dbif
+from .core import (
+    get_current_mapset,
+    get_tgis_message_interface,
+    init_dbif,
+    SQLDatabaseInterfaceConnection,
+)
 from .datetime_math import (
     check_datetime_string,
     increment_datetime_by_string,
@@ -33,15 +38,15 @@ from .open_stds import open_old_stds
 
 
 def register_maps_in_space_time_dataset(
-    type,
-    name,
+    type: str,
+    name: str | None = None,
     maps=None,
     file=None,
     start=None,
     end=None,
     unit=None,
     increment=None,
-    dbif=None,
+    dbif: SQLDatabaseInterfaceConnection | None = None,
     interval: bool = False,
     fs: str = "|",
     update_cmd_list: bool = True,
@@ -72,7 +77,8 @@ def register_maps_in_space_time_dataset(
     :param increment: Time increment between maps for time stamp creation
                      (format absolute: NNN seconds, minutes, hours, days,
                      weeks, months, years; format relative: 1.0)
-    :param dbif: The database interface to be used
+    :param dbif: The database interface to be used (deprecated,
+                will be removed in future versions)
     :param interval: If True, time intervals are created in case the start
                     time and an increment is provided
     :param fs: Field separator used in input file
@@ -117,17 +123,21 @@ def register_maps_in_space_time_dataset(
     if not maps and not file:
         msgr.fatal(_("Please specify maps or file"))
 
-    # We may need the mapset
+    if dbif is not None:
+        msgr.warning(
+            _(
+                "The dbif argument is deprecated and will be removed in future "
+                "versions. The database connection will be created automatically"
+                "only for the current mapset."
+            )
+        )
+    # Create a new DB connection only for the current mapset
     mapset = get_current_mapset()
-    dbif, connection_state_changed = init_dbif(dbif)
-
-    # create new stds only in the current mapset
-    # remove all connections to any other mapsets
-    # ugly hack !
-    currcon = {mapset: dbif.connections[mapset]}
-    dbif.connections = currcon
+    dbif = SQLDatabaseInterfaceConnection(mapsets=mapset)
+    dbif.connect()
 
     # The name of the space time dataset is optional
+    sp = None
     if name:
         sp = open_old_stds(name, type, dbif)
 
@@ -175,7 +185,7 @@ def register_maps_in_space_time_dataset(
                 # Check if last column is an end time or a semantic label.
                 # Relative timestamps are integers, absolute timestamps are
                 # datetime strings; anything else is a semantic label.
-                if sp.is_time_relative():
+                if sp is not None and sp.is_time_relative():
                     try:
                         int(line_list[2])
                     except ValueError:
@@ -251,6 +261,7 @@ def register_maps_in_space_time_dataset(
         map_object_layer = map_object.get_layer()
         map_object_type = map_object.get_type()
         if not map_object.map_exists():
+            dbif.close()
             msgr.fatal(
                 _("Unable to update {t} map <{mid}>. The map does not exist.").format(
                     t=map_object_type, mid=map_object_id
@@ -277,7 +288,7 @@ def register_maps_in_space_time_dataset(
                     msgr.fatal(
                         _(
                             "Unable to register {t} map <{mid}> with "
-                            "layer {l}. The map has timestamp and "
+                            "layer {l}. The map has no timestamp and "
                             "the start time is not set."
                         ).format(
                             t=map_object_type,
@@ -297,8 +308,10 @@ def register_maps_in_space_time_dataset(
                 # We need to check if the time is absolute and the unit was specified
                 time_object = check_datetime_string(start)
                 if isinstance(time_object, datetime) and unit:
+                    dbif.close()
                     msgr.fatal(_("unit can only be set for relative time"))
                 if not isinstance(time_object, datetime) and not unit:
+                    dbif.close()
                     msgr.fatal(_("unit must be set in case of relative time stamps"))
 
                 if unit:
@@ -375,8 +388,7 @@ def register_maps_in_space_time_dataset(
         # Try to read an existing time stamp from the grass spatial database
         # in case this map wasn't already registered in the temporal database
         # Read the spatial database time stamp only, if no time stamp was provided for
-        # this map
-        # as method argument or in the input file
+        # this map as method argument or in the input file
         if not is_in_db and not start:
             map_object.read_timestamp_from_grass()
 
@@ -457,8 +469,7 @@ def register_maps_in_space_time_dataset(
             ds.select(dbif)
             ds.update_from_registered_maps(dbif)
 
-    if connection_state_changed is True:
-        dbif.close()
+    dbif.close()
 
     msgr.percent(num_maps, num_maps, 1)
 

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -349,10 +349,10 @@ def register_maps_in_space_time_dataset(
                 continue
 
             # Reload properties from database
-            map_object.select(dbif)
+            map_object.select(dbif, mapset)
 
             # Save the datasets that must be updated
-            datasets = map_object.get_registered_stds(dbif)
+            datasets = map_object.get_registered_stds(dbif, mapset)
             if datasets is not None:
                 for dataset in datasets:
                     if dataset != "":

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -653,7 +653,10 @@ def register_map_object_list(
     output_stds_id = output_stds.get_id() if output_stds else None
 
     register_maps_in_space_time_dataset(
-        type, output_stds_id, unit=unit, file=filename, dbif=dbif
+        type,
+        output_stds_id,
+        unit=unit,
+        file=filename,
     )
 
     # Remove empty maps and unregister them from the temporal database

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -126,9 +126,7 @@ def register_maps_in_space_time_dataset(
     if dbif is not None:
         msgr.warning(
             _(
-                "The dbif argument is deprecated and will be removed in future "
-                "versions. The database connection will be created automatically"
-                "only for the current mapset."
+                "The dbif argument is deprecated and will be removed in a future release."
             )
         )
     # Create a new DB connection only for the current mapset

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -46,6 +46,7 @@ def register_maps_in_space_time_dataset(
     end=None,
     unit=None,
     increment=None,
+    *,
     dbif: SQLDatabaseInterfaceConnection | None = None,
     interval: bool = False,
     fs: str = "|",
@@ -363,7 +364,7 @@ def register_maps_in_space_time_dataset(
                     if map_object_layer:
                         msgr.fatal(
                             _(
-                                "Unable to update {t} map <{id}> "
+                                "Unable to update {t} map <{mid}> "
                                 "with layer {l}. The temporal types "
                                 "are different."
                             ).format(

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -613,7 +613,6 @@ def import_stds(
             start="file",
             end="file",
             unit=relative_time_unit,
-            dbif=None,
             fs=fs,
             update_cmd_list=False,
         )

--- a/python/grass/temporal/testsuite/test_register_function.py
+++ b/python/grass/temporal/testsuite/test_register_function.py
@@ -316,7 +316,6 @@ class TestRasterRegisterFunctions(TestCase):
             start="2001-01-01 10:30:01",
             increment="1 year",
             interval=True,
-            dbif=self.dbif,
         )
 
         map_1 = tgis.RasterDataset("elevation@PERMANENT")
@@ -340,7 +339,6 @@ class TestRasterRegisterFunctions(TestCase):
             start="2001-01-01 10:30:01",
             increment="1 year",
             interval=True,
-            dbif=self.dbif,
         )
 
         map_1 = tgis.VectorDataset("lakes@PERMANENT")

--- a/temporal/t.register/t.register.py
+++ b/temporal/t.register/t.register.py
@@ -126,7 +126,6 @@ def main():
         end=end,
         unit=unit,
         increment=increment,
-        dbif=None,
         interval=interval,
         fs=separator,
     )

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -62,19 +62,13 @@ def main():
     if not maps and not file:
         gs.fatal(_("%s= or %s= must be specified") % ("input", "file"))
 
-    mapset = gs.gisenv()["MAPSET"]
+    mapset = tgis.get_current_mapset()
 
-    dbif = tgis.SQLDatabaseInterfaceConnection()
+    dbif = tgis.SQLDatabaseInterfaceConnection(mapsets=mapset)
     dbif.connect()
 
-    # modify a stds only if it is in the current mapset
-    # remove all connections to any other mapsets
-    # ugly hack !
-    currcon = {}
-    currcon[mapset] = dbif.connections[mapset]
-    dbif.connections = currcon
-
     # In case a space time dataset is specified
+    sp = None
     if input:
         sp = tgis.open_old_stds(input, type, dbif)
 
@@ -84,7 +78,7 @@ def main():
 
     # Map names as comma separated string
     if maps is not None and maps != "":
-        maplist = [maps] if maps.find(",") == -1 else maps.split(",")
+        maplist = maps.split(",")
 
         # Build the maplist
         for count in range(len(maplist)):
@@ -117,30 +111,30 @@ def main():
         if count % 10 == 0:
             gs.percent(count, num_maps, 1)
 
-        map = tgis.dataset_factory(type, mapid)
+        map_item = tgis.dataset_factory(type, mapid)
 
         # Unregister map if in database
-        if map.is_in_db(dbif, mapset=mapset):
+        if map_item.is_in_db(dbif, mapset=mapset):
             # Unregister from a single dataset
             if input:
                 # Collect SQL statements
-                statement += sp.unregister_map(map=map, dbif=dbif, execute=False)
+                statement += sp.unregister_map(map=map_item, dbif=dbif, execute=False)
 
             # Unregister from temporal database
             else:
                 # We need to update all datasets after the removement of maps
-                map.metadata.select(dbif)
-                datasets = map.get_registered_stds(dbif)
+                map_item.metadata.select(dbif)
+                datasets = map_item.get_registered_stds(dbif)
                 # Store all unique dataset ids in a dictionary
                 if datasets:
                     for dataset in datasets:
                         update_dict[dataset] = dataset
                 # Collect SQL statements
-                statement += map.delete(dbif=dbif, update=False, execute=False)
+                statement += map_item.delete(dbif=dbif, update=False, execute=False)
         else:
             gs.warning(
                 _("Unable to find %s map <%s> in temporal database")
-                % (map.get_type(), map.get_id())
+                % (map_item.get_type(), map_item.get_id())
             )
 
         count += 1
@@ -157,7 +151,7 @@ def main():
     else:
         gs.message(_("Unregister maps from the temporal database"))
 
-    if input:
+    if input and sp is not None:
         sp.update_from_registered_maps(dbif)
         sp.update_command_string(dbif=dbif)
     elif len(update_dict) > 0:

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -123,7 +123,7 @@ def main():
             # Unregister from temporal database
             else:
                 # We need to update all datasets after the removement of maps
-                map_item.metadata.select(dbif)
+                map_item.metadata.select(dbif, mapset=mapset)
                 datasets = map_item.get_registered_stds(dbif)
                 # Store all unique dataset ids in a dictionary
                 if datasets:
@@ -141,7 +141,7 @@ def main():
 
     # Execute the collected SQL statenents
     if statement:
-        dbif.execute_transaction(statement)
+        dbif.execute_transaction(statement, mapset=mapset)
 
     gs.percent(num_maps, num_maps, 1)
 


### PR DESCRIPTION
Replaces a hack that modified a broad SQLDatabaseInterfaceConnection with a clean DB connection limited only for the current mapset.