### PR TITLE
grass.pygrass: Close RasterRow via context manager in region tests

### DIFF
--- a/python/grass/pygrass/raster/testsuite/test_raster_region.py
+++ b/python/grass/pygrass/raster/testsuite/test_raster_region.py
@@ -39,16 +39,13 @@ class RasterRowRegionTestCase(TestCase):
 
         rast = RasterRow(self.name)
         rast.set_region(region)
-        rast.open(mode="r")
-
-        self.assertCountEqual(
-            rast[0].tolist(), [22, 22, 22, 22, 22, 32, 32, 32, 32, 32]
-        )
-        self.assertCountEqual(
-            rast[5].tolist(), [23, 23, 23, 23, 23, 33, 33, 33, 33, 33]
-        )
-
-        rast.close()
+        with rast:
+            self.assertCountEqual(
+                rast[0].tolist(), [22, 22, 22, 22, 22, 32, 32, 32, 32, 32]
+            )
+            self.assertCountEqual(
+                rast[5].tolist(), [23, 23, 23, 23, 23, 33, 33, 33, 33, 33]
+            )
 
     def test_resampling_2(self):
         region = Region()
@@ -63,21 +60,18 @@ class RasterRowRegionTestCase(TestCase):
 
         rast = RasterRow(self.name)
         rast.set_region(region)
-        rast.open(mode="r")
+        with rast:
+            # [nan, nan, nan, nan, nan, nan, nan, nan]
+            # [nan, nan, nan, nan, nan, nan, nan, nan]
+            # [nan, nan, 11.0, 21.0, 31.0, 41.0, nan, nan]
+            # [nan, nan, 12.0, 22.0, 32.0, 42.0, nan, nan]
+            # [nan, nan, 13.0, 23.0, 33.0, 43.0, nan, nan]
+            # [nan, nan, 14.0, 24.0, 34.0, 44.0, nan, nan]
+            # [nan, nan, nan, nan, nan, nan, nan, nan]
+            # [nan, nan, nan, nan, nan, nan, nan, nan]
 
-        # [nan, nan, nan, nan, nan, nan, nan, nan]
-        # [nan, nan, nan, nan, nan, nan, nan, nan]
-        # [nan, nan, 11.0, 21.0, 31.0, 41.0, nan, nan]
-        # [nan, nan, 12.0, 22.0, 32.0, 42.0, nan, nan]
-        # [nan, nan, 13.0, 23.0, 33.0, 43.0, nan, nan]
-        # [nan, nan, 14.0, 24.0, 34.0, 44.0, nan, nan]
-        # [nan, nan, nan, nan, nan, nan, nan, nan]
-        # [nan, nan, nan, nan, nan, nan, nan, nan]
-
-        self.assertCountEqual(rast[2].tolist()[2:6], [11.0, 21.0, 31.0, 41.0])
-        self.assertCountEqual(rast[5].tolist()[2:6], [14.0, 24.0, 34.0, 44.0])
-
-        rast.close()
+            self.assertCountEqual(rast[2].tolist()[2:6], [11.0, 21.0, 31.0, 41.0])
+            self.assertCountEqual(rast[5].tolist()[2:6], [14.0, 24.0, 34.0, 44.0])
 
     def test_resampling_to_numpy(self):
         region = Region()


### PR DESCRIPTION
This is to address a file that completely crashes instead of failing a single test (affected the others in the file). Part of the cleanup before randomizing tests order (for at least Windows). 

Note that now, this allows 3 tests to fail on Windows (still under the threshold), instead of crashing (so hidden). I have another PR stacked up for that.


The rest below is AI explaining using context managers instead of not executing close() when the code had an exception.


## Description

`test_raster_region.py`'s `test_resampling_1` and `test_resampling_2` called
`rast.close()` as a bare statement after their assertions. If an assertion
(or anything else) raised, that `close()` call was skipped and the
`RasterRow` stayed open for the rest of the process.

`Region.set_raster_region()` documents exactly why that matters:

> **Attention:** All raster objects must be closed or the process will be
> terminated.

`test_resampling_to_numpy`, the next test in this file, calls
`region.set_raster_region()` on every resampling step. So a raster left open
by an earlier test doesn't just fail that earlier test — it crashes the
*next* test with an unrelated-looking C-level `FERROR: Input window changed
while maps are open for read`, instead of whatever the real original failure
was.

Fixed by using `with rast:` (`RasterRow` already documents and supports this)
instead of a manual `open()`/`close()` pair, so the raster is always closed,
assertion failure or not.

## Known follow-up

Windows CI on this branch shows the fatal, whole-file-crashing `FERROR` is
gone, but the file still doesn't fully pass: three individual failures show
up instead (count/value mismatches in `test_resampling_1` and
`test_resampling_2`, and an oversized array allocation in
`test_resampling_to_numpy`). These point to a separate, pre-existing bug
where the small test region doesn't appear to actually restrict what gets
read back on Windows. I haven't been able to reproduce it without a Windows
machine, so I'm not attempting a fix for it here — this PR only fixes the
resource leak that was masking it.

## Motivation and context

Found while investigating Windows CI test-order-dependency:
`test_raster_region.py` was one of a small set of consistently-failing
Windows gunittest files.

## How has this been tested?

Windows CI on this branch (see the follow-up note above) — I couldn't
reproduce or build GRASS on Windows locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the
  [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md)
  of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

AI wrote the message, and researched a bit.