### PR TITLE
temporal: Avoid PLY debug-mode overhead in raster algebra gunittest

### DIFF
--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
@@ -127,7 +127,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_extent1(self) -> None:
         """Testing the temporal extent operators."""
-        ta = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        ta = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         ta.parse(expression="R = A {:,during,r} C", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -141,7 +141,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), "2 days")
 
-        ta = tgis.TemporalRasterAlgebraParser(run=True, debug=True, dry_run=True)
+        ta = tgis.TemporalRasterAlgebraParser(run=True, debug=False, dry_run=True)
         pc = ta.parse(expression="R = A {:,during,r} C", basename="r", overwrite=True)
 
         self.assertEqual(len(pc["register"]), 2)
@@ -155,7 +155,7 @@ class TestTemporalRasterAlgebra(TestCase):
         """Testing the conditional time dimension bug, that uses the time
         dimension of the conditional statement instead the time dimension
         of the then/else statement."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = if({contains}, B == 5,  A - 1,  A + 1)",
             basename="r",
@@ -189,7 +189,9 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 + 1
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True, time_suffix="gran")
+        tra = tgis.TemporalRasterAlgebraParser(
+            run=True, debug=False, time_suffix="gran"
+        )
         tra.parse(expression="R = A + (A {#, equal,l} A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -228,7 +230,9 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 + 1
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True, time_suffix="time")
+        tra = tgis.TemporalRasterAlgebraParser(
+            run=True, debug=False, time_suffix="time"
+        )
         tra.parse(expression="R = A + td(A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -267,7 +271,7 @@ class TestTemporalRasterAlgebra(TestCase):
         r3 = a3 / 1
         r4 = a4 / 1
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A / td(A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -294,7 +298,7 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 + 1
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {+,equal} td(A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -321,7 +325,7 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 + 1
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {/, equal} td(A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -345,7 +349,7 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 + a4
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression='R = if({equal}, start_date(A) >= "2001-01-02", A + A)',
             basename="r",
@@ -381,7 +385,7 @@ class TestTemporalRasterAlgebra(TestCase):
         r4 = a4 - a4
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = if({equal}, A#A == 1, A - A)", basename="r", overwrite=True
         )
@@ -409,7 +413,7 @@ class TestTemporalRasterAlgebra(TestCase):
               will compute a3 + c1
 
         """
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression='R = if(start_date(A) < "2001-01-03" && A#A == 1, A{+, starts,l}C, A{+, finishes,l}C)',
             basename="r",
@@ -427,7 +431,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_simple_arith_1(self) -> None:
         """Simple arithmetic test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = A {*, equal} A {+, equal} A", basename="r", overwrite=True
         )
@@ -443,7 +447,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_simple_arith_2(self) -> None:
         """Simple arithmetic test that creates an empty strds"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = A {*, during} A {+, during} A", basename="r", overwrite=True
         )
@@ -453,7 +457,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_simple_arith_3(self) -> None:
         """Simple arithmetic test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A / A + A*A/A", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -467,7 +471,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_1(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {+,equal,i} B", basename="r", overwrite=True)
         D = tgis.open_old_stds("R", type="strds")
         D.select()
@@ -475,7 +479,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_2(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {+,during,i} B", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -489,7 +493,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_3(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {+,starts,i} B", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -503,7 +507,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_4(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = A {+,finishes,intersect} B", basename="r", overwrite=True
         )
@@ -519,7 +523,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_5(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = A {+,starts|finishes,i} B", basename="r", overwrite=True
         )
@@ -535,7 +539,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_6(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {+,overlaps,u} C", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -549,7 +553,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_7(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {+,overlapped,u} C", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -563,7 +567,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_intersection_8(self) -> None:
         """Simple temporal intersection test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression='R = A {+,during,l} buff_t(C, "1 day") ',
             basename="r",
@@ -581,7 +585,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_neighbors_1(self) -> None:
         """Simple temporal neighborhood computation test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A[-1] + A[1]", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -595,7 +599,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_neighbors_2(self) -> None:
         """Simple temporal neighborhood computation test"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A[0,0,-1] + A[0,0,1]", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -609,7 +613,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_tmap_function1(self) -> None:
         """Testing the tmap function."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = tmap(singletmap)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -626,7 +630,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_tmap_function2(self) -> None:
         """Testing the tmap function."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = tmap(singletmap) + 1", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -643,7 +647,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_map_function1(self) -> None:
         """Testing the map function."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = map(singlemap) + A", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -660,7 +664,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_map_function2(self) -> None:
         """Testing the map function."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R =  A * map(singlemap)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -677,7 +681,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_select_same_left_right(self) -> None:
         """Testing the temporal select operator with the same map for left and right."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A : A", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -693,7 +697,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_select(self) -> None:
         """Testing the temporal select operator."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A : D", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -709,7 +713,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_select_operators1(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A : D", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -725,7 +729,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_select_operators2(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {!:,during} C", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -742,7 +746,7 @@ class TestTemporalRasterAlgebra(TestCase):
     def test_temporal_select_operators3(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         different temporal operators (lr|+&)"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {:,during,d} B", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -759,7 +763,7 @@ class TestTemporalRasterAlgebra(TestCase):
     def test_temporal_select_operators4(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         different temporal operators (lr|+&)"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A {:,equal|during,r} C", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -780,7 +784,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_hash_operator1(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = if(A # D == 1, A)", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -796,7 +800,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_hash_operator2(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = A # D", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -812,7 +816,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_hash_operator3(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = C {#,contains} A", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -828,7 +832,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_temporal_hash_operator4(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = if({contains},A # D == 1, C {#,contains} A)",
             basename="r",
@@ -848,7 +852,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_raster_arithmetic_relation_1(self) -> None:
         """Arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {+,contains,l} A ", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -864,7 +868,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_raster_arithmetic_relation_2(self) -> None:
         """Arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {*,contains,l} A ", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -880,7 +884,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_raster_arithmetic_relation_3(self) -> None:
         """Arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {+,contains,l} A ", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -896,7 +900,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_raster_arithmetic_relation_4(self) -> None:
         """Arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(expression="R = B {+,contains,r} A ", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
@@ -912,7 +916,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_raster_arithmetic_relation_5(self) -> None:
         """Complex arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         tra.parse(
             expression="R = tmap(singletmap) {+,equal| precedes| follows,l} A + map(singlemap)",
             basename="r",
@@ -932,7 +936,7 @@ class TestTemporalRasterAlgebra(TestCase):
 
     def test_capacity_1(self) -> None:
         """Arithmetic test with temporal intersection"""
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False)
         expr = "R = (((((((A + A) - A) * A) / A) % A) - td(A)) - (A # A))"
         tra.parse(expression=expr, basename="r", overwrite=True)
 
@@ -947,7 +951,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True, dry_run=True)
+        tra = tgis.TemporalRasterAlgebraParser(run=True, debug=False, dry_run=True)
         pc = tra.parse(expression=expr, basename="r", overwrite=True)
 
         self.assertEqual(len(pc["register"]), 4)


### PR DESCRIPTION
Related to #7897, this is the result of AI investigating what could have fixed it. The approach here would be to not write a full debug file for each test (reducing work to do, and avoiding the unclosed file in that code path). 

Note that other test files still use debug=True. Investigation on 100 other runs on main (of my fork, but only logs retrievable, so I don’t think it got 100 of them), there was another time where it failed for timeout on that file, where this fix would have had an impact. So, the lower bound on the occurrence would be 1%.


On the test run on my fork, macOS had lower time taken for that file (writing files seems slower now), but Ubuntu 24.04 didn’t, but that machine was slower overall. So, don’t count on faster test times because of that.

## Description

`unittests_temporal_raster_algebra.py` constructs `TemporalRasterAlgebraParser(..., debug=True)` in all 43 of its test methods. That flag makes the vendored PLY `yacc.yacc()` rebuild and dump the full LALR debug trace to `parser.out` on every call — measured locally at 2.86 MB per dump, identical every time since the grammar is static, and the file handle is never closed (`ResourceWarning: unclosed file ...'parser.out'`). None of this is used by the tests. Production code (`t.rast.algebra.py`) already uses `debug=False`, as does the base class's own default; only this test file overrides it.

This PR switches all 45 instantiations in that file to `debug=False`, matching production usage and removing ~129 MB of redundant writes and 45 leaked file descriptors per test run.

## Motivation and context

Investigating an intermittent macOS-only CI timeout on this exact test file (`Timeout >300.0s`). I can't prove this fixes that specific timeout — comparing recent macOS CI runs shows the same 300s ceiling hit by an unrelated test on a different occasion, which points more to runner-level I/O contention than a deterministic bug, and a local before/after timing comparison showed no measurable difference on a fast disk. This change is a genuine, independently-justified cleanup (dead debug output, a real leaked file handle) that reduces this file's exposure to slow/contended disk, not a targeted fix for the flake.

## How has this been tested?

Built GRASS from source locally and ran `unittests_temporal_raster_algebra.py` directly, both before (`debug=True`) and after (`debug=False`): 43/43 tests pass both ways, confirming no behavioral change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] PR title provides summary of the changes and starts with one of the pre-defined prefixes
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. (test-only change; existing 43 tests still pass)

---

Investigated and fixed with AI assistance (Claude Code); the analysis, the decision of what (not) to fix, and the verification above are mine.