### PR TITLE
wxGUI: fix E501 in seven launchers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,15 +24,8 @@ per-file-ignores =
     man/build_html.py: E501
     doc/examples/python/m.distance.py: E501
     gui/scripts/d.wms.py: E501
-    gui/wxpython/image2target/g.gui.image2target.py: E501
-    gui/wxpython/photo2image/g.gui.photo2image.py: E501
     gui/wxpython/psmap/*: E501
-    gui/wxpython/animation/g.gui.animation.py: E501
-    gui/wxpython/tplot/g.gui.tplot.py: E501
-    gui/wxpython/iclass/g.gui.iclass.py: E501
     gui/wxpython/mapdisp/test_mapdisp.py: E501
-    gui/wxpython/mapswipe/g.gui.mapswipe.py: E501
-    gui/wxpython/timeline/g.gui.timeline.py: E501
     # Generated file
     gui/wxpython/menustrings.py: E501
     # C wrappers call libgis.G_gisinit before importing other modules.

--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -12,7 +12,7 @@
 ############################################################################
 
 # %module
-# % description: Tool for animating a series of raster and vector maps or a space time raster or vector dataset.
+# % description: Animates maps or space time raster and vector datasets.
 # % keyword: general
 # % keyword: GUI
 # % keyword: display

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -13,7 +13,7 @@
 
 # %module
 # % label: Tool for supervised classification of imagery data.
-# % description: Generates spectral signatures for an image by allowing the user to outline regions of interest.
+# % description: Generates image spectral signatures from outlined regions of interest.
 # % keyword: general
 # % keyword: GUI
 # % keyword: classification

--- a/gui/wxpython/image2target/g.gui.image2target.py
+++ b/gui/wxpython/image2target/g.gui.image2target.py
@@ -12,7 +12,7 @@
 ############################################################################
 
 # %module
-# % description: Georectifies a map and allows managing Ground Control Points for 3D correction.
+# % description: Georectifies a map using managed 3D Ground Control Points.
 # % keyword: imagery
 # % keyword: GUI
 # % keyword: aerial

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -31,7 +31,7 @@
 # % key: mode
 # % description: View mode
 # % options: swipe,mirror
-# % descriptions:swipe;swiping the upper map layer to show the map layer below ;mirror;synchronized maps side by side
+# % descriptions: swipe;Reveal lower map by swiping;mirror;Synchronize maps side by side
 # % answer: swipe
 # % required: no
 # %end

--- a/gui/wxpython/photo2image/g.gui.photo2image.py
+++ b/gui/wxpython/photo2image/g.gui.photo2image.py
@@ -43,8 +43,8 @@
 # %option
 # % key: order
 # % type: string
-# % label: The rectification order (no of Fiducial=4 -> order=1, no of Fiducial=8 -> order=2)
-# % description: The rectification order (no of Fiducial=4 -> order=1, no of Fiducial=8 -> order=2)
+# % label: Rectification order (4 fiducials: 1; 8 fiducials: 2)
+# % description: Rectification order (4 fiducials: 1; 8 fiducials: 2)
 # % required: yes
 # % answer: 1
 # %end

--- a/gui/wxpython/timeline/g.gui.timeline.py
+++ b/gui/wxpython/timeline/g.gui.timeline.py
@@ -12,7 +12,7 @@
 ############################################################################
 
 # %module
-# % description: Allows comparing temporal datasets by displaying their temporal extents in a plot.
+# % description: Compares temporal datasets by plotting their temporal extents.
 # % keyword: general
 # % keyword: GUI
 # % keyword: temporal

--- a/gui/wxpython/tplot/g.gui.tplot.py
+++ b/gui/wxpython/tplot/g.gui.tplot.py
@@ -62,7 +62,7 @@
 # %option G_OPT_F_OUTPUT
 # % required: no
 # % label: Name for output graphical file
-# % description: Full path for output file containing the plot, ddd extension to specify format (.png, .pdf, .svg)
+# % description: Output plot path; extension sets format (.png, .pdf, or .svg)
 # %end
 
 # %option G_OPT_F_OUTPUT


### PR DESCRIPTION
Fixes part of #1522.

Shorten parser metadata in seven GUI launchers so each file passes the 88-character E501 limit, then remove their per-file exemptions. The parser fields remain single-line records.

Validation:
- `uvx flake8 --isolated --max-line-length=88 --select=E501 <seven files>`
- `uvx pre-commit run --files .flake8 <seven files>`

AI use: I used OpenAI Codex to help implement this change, then reviewed the diff and ran the checks above.
