### PR TITLE
grass.pygrass: Mark test_raster_region resampling tests xfail on Windows

### DIFF
--- a/python/grass/pygrass/raster/testsuite/test_raster_region.py
+++ b/python/grass/pygrass/raster/testsuite/test_raster_region.py
@@ -1,5 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+from grass.gunittest.utils import xfail_windows
 
 from grass.pygrass.raster import RasterRow
 from grass.pygrass.raster import raster2numpy
@@ -26,6 +27,13 @@ class RasterRowRegionTestCase(TestCase):
         cls.runModule("g.remove", flags="f", type="raster", name=cls.name)
         cls.del_temp_region()
 
+    # Windows-only: the small region set below isn't actually restricting
+    # what RasterRow reads back (rast[0] comes back with ~100000 elements
+    # instead of 10). Confirmed this is specific to Windows: passes reliably
+    # on Linux both in isolation and as part of the full testsuite run (so
+    # it isn't a state leak from an earlier test file either). Needs
+    # investigation with actual Windows access; remove once fixed.
+    @xfail_windows
     def test_resampling_1(self):
         region = Region()
 
@@ -47,6 +55,7 @@ class RasterRowRegionTestCase(TestCase):
                 rast[5].tolist(), [23, 23, 23, 23, 23, 33, 33, 33, 33, 33]
             )
 
+    @xfail_windows  # same Windows-only issue as test_resampling_1
     def test_resampling_2(self):
         region = Region()
 
@@ -73,6 +82,7 @@ class RasterRowRegionTestCase(TestCase):
             self.assertCountEqual(rast[2].tolist()[2:6], [11.0, 21.0, 31.0, 41.0])
             self.assertCountEqual(rast[5].tolist()[2:6], [14.0, 24.0, 34.0, 44.0])
 
+    @xfail_windows  # same Windows-only issue as test_resampling_1
     def test_resampling_to_numpy(self):
         region = Region()
         region.ewres = 0.1


### PR DESCRIPTION
## Description

Follow-up to #7902 (`grass.pygrass: Close RasterRow via context manager in region tests`, already merged to main). Fixing that resource leak turned the fatal, whole-file-crashing `FERROR: Input window changed while maps are open for read` on Windows CI into a distinct, real bug: the small region that `test_resampling_1`, `test_resampling_2`, and `test_resampling_to_numpy` each set up isn't actually restricting what `RasterRow`/`raster2numpy` read back. Windows CI showed, for example, `rast[0].tolist()` coming back with roughly 100000 elements instead of the expected 10, and a numpy `_ArrayMemoryError` trying to allocate an 8,150,000-element array where an 8-element one was expected.

I built GRASS locally (CMake) to check whether this is a genuine Windows-only build difference or something reproducible here:

- `test_raster_region.py` run in isolation: passes (3/3).
- The entire 359-file gunittest suite run in sequence (matching how CI runs it, in case an earlier test file leaves region-related state behind that only this ordering exposes): still passes, and isn't among the files that failed in that full run.

Since it doesn't reproduce here even under matching full-suite conditions, this looks like a genuine platform difference in the compiled GRASS libraries (Windows CI here builds with MinGW via OSGeo4W) rather than a Python-level state leak, and isn't something I can responsibly guess a fix for without Windows access. Marked `@xfail_windows` on the three affected test methods instead, per the project's existing convention for exactly this situation (see `python/grass/gunittest/utils.py`), with a comment describing the symptom and noting it needs Windows access to debug further.

## Motivation and context

#7902 already turned the fatal crash into three individually visible failures. Without `xfail`, those would show as ordinary CI red without acknowledging they're a known, unreproduced, Windows-only issue distinct from the leak #7902 fixed.

## How has this been tested?

Built GRASS locally and ran the test both in isolation and as part of the full local gunittest suite (see above); confirmed it still passes on Linux with `@xfail_windows` added (a no-op there).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

---

I used Claude Code to help investigate and draft this fix, under my review throughout. #7902 already fixed the crash that was masking this bug; this PR doesn't fix the bug itself, only marks it `xfail` on Windows.