### PR TITLE
r.kappa: Avoid reopening NamedTemporaryFile on Windows in testsuite

### DIFF
--- a/raster/r.kappa/testsuite/test_r_kappa.py
+++ b/raster/r.kappa/testsuite/test_r_kappa.py
@@ -11,15 +11,13 @@ SPDX-License-Identifier: GPL-2.0-or-later
 import os
 import json
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 from grass.script import read_command
 from grass.script import decode
-from grass.script.core import tempname
+from grass.script.core import tempfile, tempname
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.checkers import keyvalue_equals, diff_keyvalue
-from grass.gunittest.utils import xfail_windows
 
 
 class MatrixCorrectnessTest(TestCase):
@@ -488,19 +486,18 @@ class JSONOutputTest(TestCase):
                 ),
             )
 
-    @xfail_windows
     def test_file(self):
         for i in range(len(self.references)):
-            f = NamedTemporaryFile()
+            outfile = tempfile(create=False)
             self.runModule(
                 "r.kappa",
                 reference=self.references[i],
                 classification=self.classifications[i],
-                output=f.name,
+                output=outfile,
                 format="json",
                 overwrite=True,
             )
-            json_out = json.loads(f.read())
+            json_out = json.loads(Path(outfile).read_text())
             self.assertTrue(
                 keyvalue_equals(
                     self.expected_outputs[i], json_out, precision=self.precision


### PR DESCRIPTION
## Description

`test_file` in `raster/r.kappa/testsuite/test_r_kappa.py` kept a
`NamedTemporaryFile` handle open while passing its path to `r.kappa` as the
output file. Windows rejects a second process opening a file while the
creating process still holds the handle open; POSIX allows it. Use
`grass.script.core.tempfile()` to get an unopened path instead, the same fix
already applied to `r.mfilter`'s testsuite in #7878, and drop the
now-unneeded `@xfail_windows` marker.

## Motivation and context

Split out of a PR, which bundled this fix together with unrelated Windows CI 
changes (randomized test order infrastructure) (which is now filed as https://github.com/OSGeo/grass/pull/7906). 
This is a standalone, independently mergeable fix.

## How has this been tested?

Mirrors the already-merged, already-verified fix for the identical
anti-pattern in `r.mfilter` (#7878).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] PR title provides summary of the changes and starts with one of the
  [pre-defined prefixes](utils/release.yml)
- [x] My code follows the [code style](doc/development/style_guide.md)
  of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

---

Generated with Claude Code, from my instructions. (I still reworded the PR body)
