### PR TITLE
v.generalize: Import math in the testsuite

### DIFF
--- a/vector/v.generalize/testsuite/v_generalize_test.py
+++ b/vector/v.generalize/testsuite/v_generalize_test.py
@@ -2,8 +2,9 @@ from grass.script import core as grass
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script import vector_info_topo
-import tempfile
+import math
 import os
+import tempfile
 
 
 class TestVGeneralize(TestCase):


### PR DESCRIPTION
`vector/v.generalize/testsuite/v_generalize_test.py` uses `math.sqrt` in
`TestVGeneralize.distance()`, but the module never imports `math`:

```python
from grass.script import core as grass
from grass.gunittest.case import TestCase
from grass.gunittest.main import test
from grass.script import vector_info_topo
import tempfile
import os
```

`test_chaiken_algorithm` calls `self.distance(midpoint, vertex)` (line 256) inside
its midpoint-proximity loop, so the test raises `NameError: name 'math' is not
defined` on the first iteration and never reaches the `assertLessEqual` /
vertex-count assertions it was written to make.

Fix: add the missing `import math`.

### Verification

Stubbing `grass.script` / `grass.gunittest` and calling the method directly
(no GRASS build needed):

```
BEFORE (upstream main): NameError: name 'math' is not defined
AFTER  (with fix):      distance((0,0),(3,4)) = 5.0
```

`ruff check --preview` and `ruff format --check` (v0.15.17, the pinned
`.pre-commit-config.yaml` rev, with the repo `pyproject.toml`) pass on the
patched file. `I001` is already disabled for `vector/**.py`, but the three
standard-library imports are left alphabetically ordered anyway.

---

AI-assisted (bug found by a pyflakes sweep, fix and verification reviewed by
me before submitting); per `CONTRIBUTING.md` the change is a one-line import,
not generated logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
