### PR TITLE
tests: Un-shadow duplicated test method names in r.random and t.rast.gapfill

### DIFF
--- a/raster/r.random/testsuite/test_r_random.py
+++ b/raster/r.random/testsuite/test_r_random.py
@@ -83,11 +83,11 @@ class TestRasterTile(TestCase):
         topology = {"points": 20, "primitives": 20}
         self.assertVectorFitsTopoInfo(vector=self.vector, reference=topology)
 
-    def test_random_raster_flag_z(self):
+    def test_random_raster_flag_n(self):
         """Testing r.random  runs successfully"""
         self.assertModule(
             "r.random",
-            flags="z",
+            flags="n",
             input=self.input,
             npoints=self.npoints,
             raster=self.raster + "_null",
@@ -98,11 +98,11 @@ class TestRasterTile(TestCase):
             self.raster, msg="landcover_1m_raster_random_null was not created"
         )
 
-    def test_vector_random_flag_z(self):
+    def test_vector_random_flag_n(self):
         """Testing r.random  runs successfully"""
         self.assertModule(
             "r.random",
-            flags="z",
+            flags="n",
             input=self.input,
             npoints=self.npoints,
             vector=self.vector + "_null",

--- a/temporal/t.rast.gapfill/testsuite/test_gapfill.py
+++ b/temporal/t.rast.gapfill/testsuite/test_gapfill.py
@@ -298,7 +298,7 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
-    def test_simple_gran(self):
+    def test_simple_gran_time_suffix(self):
         self.assertModule(
             "t.rast.gapfill",
             input="A",


### PR DESCRIPTION
Two gunittest classes define the same test method name twice. Python binds the
second `def` over the first while executing the class body, so the earlier test
is gone before `unittest` ever looks at the class — it is never collected and
never run.

### `raster/r.random/testsuite/test_r_random.py`

`test_random_raster_flag_z` (line 86) and `test_vector_random_flag_z` (line 101)
are redefined at lines 154 and 169.

The shadowed pair is the one that writes the `_null` outputs and is documented as
`# check if random raster ( with NULL values ) was created`. Those are exactly
the maps `tearDownClass` already cleans up:

```python
name=(
    cls.raster,
    cls.raster + "_null",           # <- nothing creates this today
    cls.raster + "_without_topology",
    cls.raster + "_3D",
    ...
```

`-z` is *"Generate vector points as 3D points"* and is already covered by the
surviving pair (which writes `_3D`). The NULL behaviour is `-n`,
*"Generate points also for NULL cells"* (`raster/r.random/main.c`, `flag.zero`).
So the shadowed pair is renamed to `test_random_raster_flag_n` /
`test_vector_random_flag_n` and passes `flags="n"`.

### `temporal/t.rast.gapfill/testsuite/test_gapfill.py`

`test_simple_gran` (line 256) is redefined at line 301. The second copy passes
`suffix="time"` and asserts the `test_2001_02_01T00_00_00` naming, so it is
renamed `test_simple_gran_time_suffix` — matching the convention in
`t.rast.neighbors` and `t.rast.accumulate`. That restores the default (`gran`)
suffix test, which asserts the `test_2001_02` naming.

`setUp` / `tearDown` recreate and drop the `A` strds per test, so the two now run
independently.

### Effect

Importing each module with `grass.*` stubbed and counting the collected
`test_*` attributes:

```
raster/r.random/testsuite/test_r_random.py  [TestRasterTile]
   BEFORE:  8 test methods
   AFTER : 10 test methods   (+ test_random_raster_flag_n, test_vector_random_flag_n)

temporal/t.rast.gapfill/testsuite/test_gapfill.py  [TestRasterToVector]
   BEFORE: 5 test methods
   AFTER : 6 test methods    (+ test_simple_gran_time_suffix)
```

I do not have a GRASS build here, so the newly collected tests have not been
executed locally — the Ubuntu gunittest job is the real check on this PR.

One pre-existing nit left alone: `test_random_raster_flag_n`, `_flag_b` and
`_flag_z` all assert `assertRasterExists(self.raster)` while their `msg=` names
the suffixed map. Tightening those three is a separate cleanup; say the word and
I will fold it in.

---

AI-assisted (the shadowing was surfaced by an AST sweep; the `-n` vs `-z`
reasoning and the diff are mine after reading `main.c` and the teardown list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
