### PR TITLE
temporal: deliberately set nprocs for functions that use OpenMP-parallelized tools

### DIFF
--- a/python/grass/temporal/aggregation.py
+++ b/python/grass/temporal/aggregation.py
@@ -113,7 +113,17 @@ def collect_map_names(sp, dbif, start, end, sampling):
 
 
 def aggregate_raster_maps(
-    inputs, base, start, end, count: int, method, register_null, dbif, offset: int = 0
+    inputs,
+    base,
+    start,
+    end,
+    count: int,
+    method,
+    register_null,
+    dbif,
+    offset: int = 0,
+    *,
+    nprocs: int = 0,
 ):
     """Aggregate a list of raster input maps with r.series
 
@@ -130,6 +140,7 @@ def aggregate_raster_maps(
                          time raster dataset, if false not
     :param dbif: The temporal database interface to use
     :param offset: Offset to be added to the map counter to create the map ids
+    :param nprocs: Number of cores to use for processing (0 means use all available cores)
     """
 
     msgr = get_tgis_message_interface()
@@ -174,6 +185,7 @@ def aggregate_raster_maps(
         if len(inputs) > 1000:
             gs.run_command(
                 "r.series",
+                nprocs=nprocs,
                 flags="z",
                 file=filename,
                 output=output,
@@ -183,6 +195,7 @@ def aggregate_raster_maps(
         else:
             gs.run_command(
                 "r.series",
+                nprocs=nprocs,
                 file=filename,
                 output=output,
                 overwrite=gs.overwrite(),
@@ -271,6 +284,7 @@ def aggregate_by_topology(
     r_series = pymod.Module(
         "r.series",
         output="spam",
+        nprocs=1,
         method=[method],
         overwrite=overwrite,
         quiet=True,

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -60,6 +60,9 @@ def compute_univar_stats(
         if stats_module.name == "r3.univar" or not registered_map_info["semantic_label"]
         else registered_map_info["semantic_label"]
     )
+    # Only r.univar, not r3.univar has nprocs parameter
+    if stats_module.name == "r.univar":
+        stats_module.inputs.nprocs = 1
 
     stats_module.inputs.map = id
     if rast_region and (stats_module.inputs.zones or stats_module.name == "r3.univar"):
@@ -263,7 +266,6 @@ def print_gridded_dataset_univar_statistics(
         percentile=percentile,
         stdout_=PIPE,
         format="json" if format == "json" else "csv",
-        nprocs=1,
         quiet=True,
         run_=False,
     )

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -263,6 +263,7 @@ def print_gridded_dataset_univar_statistics(
         percentile=percentile,
         stdout_=PIPE,
         format="json" if format == "json" else "csv",
+        nprocs=1,
         quiet=True,
         run_=False,
     )


### PR DESCRIPTION
After parallelization of several tools, with OpenMP, some temporal functions can overcommit ressources to parallel execution of such tools. Similar issues have been fixed for r.mapcalc. This PR applies the approach for r.mapcalc to r.univar and r.series.

- set nprocs=1 for functions that execute OpenMP-parallelized tools in parallel
- use 0 (=all available cores) as a default, when parallelized tools are called serial (e.g. in a single for-loop)